### PR TITLE
add method for defining a flag-only attribute

### DIFF
--- a/src/main/java/org/asciidoctor/AttributesBuilder.java
+++ b/src/main/java/org/asciidoctor/AttributesBuilder.java
@@ -136,6 +136,16 @@ public class AttributesBuilder {
 		this.attributes.put(attributeName, attributeValue);
 		return this;
 	}
+
+	/**
+	 * Sets custom or unlisted attribute to the default value, empty string.
+	 * @param attributeName A flag-only attribute, such as "icons"
+	 * @return this instance.
+	 */
+	public AttributesBuilder attribute(String attributeName) {
+		this.attributes.put(attributeName, "");
+		return this;
+	}
 	
 	/**
 	 * Gets a map with configured options.

--- a/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiated.java
+++ b/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiated.java
@@ -106,6 +106,22 @@ public class WhenAnAsciidoctorClassIsInstantiated {
 		assertThat(expectedFile.exists(), is(true));
 		assertThat(renderContent, is(nullValue()));
 	}
+
+	@Test
+	public void string_content_with_icons_enabled_should_be_rendered() throws IOException, SAXException, ParserConfigurationException {
+		
+		InputStream content = new FileInputStream("target/test-classes/documentwithnote.asciidoc");
+		
+		Map<String, Object> attributes = attributes().attribute("icons").asMap();
+		Map<String, Object> options = options()
+										.attributes(attributes)
+									  .asMap();
+		
+		String result = asciidoctor.render(toString(content), options);
+        result = result.replaceAll("<img(.*?)>", "<img$1/>");
+		assertRenderedAdmonitionIcon(result);
+		
+	}
 	
 	@Test
 	public void string_content_with_custom_date_should_be_rendered() throws IOException, SAXException, ParserConfigurationException {
@@ -195,6 +211,12 @@ public class WhenAnAsciidoctorClassIsInstantiated {
 		assertThat(renderFileSource, hasXPath("/div/h2[@id='_section_a']"));
 		assertThat(renderFileSource, hasXPath("/div/h2", is("Section A")));
 		assertThat(renderFileSource, hasXPath("/div/div[@class='sectionbody']"));
+	}
+
+	private void assertRenderedAdmonitionIcon(String render_content) throws IOException, SAXException, ParserConfigurationException {
+		Source renderFileSource = new DOMSource(inputStream2Document(new ByteArrayInputStream(render_content.getBytes())));
+		
+		assertThat(renderFileSource, hasXPath("//img[@alt='Note']"));
 	}
 	
 	private static String toString(InputStream inputStream) throws IOException {

--- a/src/test/resources/documentwithnote.asciidoc
+++ b/src/test/resources/documentwithnote.asciidoc
@@ -1,0 +1,1 @@
+NOTE: This is an admonition note.


### PR DESCRIPTION
To emulate the following assignment:

```
-a icons
```

The AttributesBuilder now supports:

```
AttributesBuilder.attributes().attribute("icons")
```
