### PR TITLE
Add case insensitivity for document attributes. fixes #106

### DIFF
--- a/src/main/java/org/asciidoctor/DocumentHeader.java
+++ b/src/main/java/org/asciidoctor/DocumentHeader.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.asciidoctor.internal.CaseInsensitiveMap;
+
 public class DocumentHeader {
 
 	private String documentTitle;
@@ -49,7 +51,7 @@ public class DocumentHeader {
 		
 		documentHeader.documentTitle = documentTitle;
 		documentHeader.pageTitle = pageTitle;
-		documentHeader.attributes = attributes;
+		documentHeader.attributes = new CaseInsensitiveMap<String, Object>(attributes);
 		
 		documentHeader.author = getAuthor(attributes);
 		documentHeader.revisionInfo = geRevisionInfo(attributes);

--- a/src/main/java/org/asciidoctor/internal/CaseInsensitiveMap.java
+++ b/src/main/java/org/asciidoctor/internal/CaseInsensitiveMap.java
@@ -1,0 +1,97 @@
+package org.asciidoctor.internal;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Create case insensitive wrapper map for attributes handling.
+ * 
+ * @author marek
+ * 
+ * @param <K>
+ * @param <V>
+ */
+public class CaseInsensitiveMap<K extends String,V> implements Map<K, V> {
+
+	private Map<K, V> map;
+
+	public CaseInsensitiveMap(Map<K, V> map) {
+		this.map = map;
+	}
+
+	@Override
+	public void clear() {
+		map.clear();
+	}
+
+	@Override
+	public boolean containsKey(Object key) {
+		if (key instanceof String) {
+			return map.containsKey(((String) key).toLowerCase());
+		} else {
+			return map.containsKey(key);
+		}
+	}
+
+	@Override
+	public boolean containsValue(Object value) {
+		return map.containsValue(value);
+	}
+
+	@Override
+	public Set<java.util.Map.Entry<K, V>> entrySet() {
+		return map.entrySet();
+	}
+
+	@Override
+	public V get(Object key) {
+		if (key instanceof String) {
+			return map.get(((String) key).toLowerCase());
+		} else {
+			return map.get(key);
+		}
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+
+	@Override
+	public Set<K> keySet() {
+		return map.keySet();
+	}
+
+	@Override
+	public V put(K key, V value) {
+		return map.put((K)key.toLowerCase(), value);
+	}
+
+	@Override
+	public void putAll(Map<? extends K, ? extends V> m) {
+		for (Entry<? extends String, ? extends V> entry : m.entrySet()) {
+			map.put((K)entry.getKey().toLowerCase(), entry.getValue());
+		}
+	}
+
+	@Override
+	public V remove(Object key) {
+		if (key instanceof String) {
+			return map.remove(((String) key).toLowerCase());
+		} else {
+			return map.remove(key);
+		}
+	}
+
+	@Override
+	public int size() {
+		return map.size();
+	}
+
+	@Override
+	public Collection<V> values() {
+		return map.values();
+	}
+
+}

--- a/src/test/java/org/asciidoctor/WhenDocumentHeaderIsRequired.java
+++ b/src/test/java/org/asciidoctor/WhenDocumentHeaderIsRequired.java
@@ -33,7 +33,9 @@ public class WhenDocumentHeaderIsRequired {
 		assertThat((String)attributes.get("revdate"), is("2013-05-20"));
 		assertThat((String)attributes.get("revnumber"), is("1.0"));
 		assertThat((String)attributes.get("revremark"), is("First draft"));
+		//attributes should be incasesensitive
 		assertThat((String)attributes.get("tags"), is("[document, example]"));
+		assertThat((String)attributes.get("Tags"), is("[document, example]"));
 		assertThat((String)attributes.get("author"), is("Doc Writer"));
 		assertThat((String)attributes.get("email"), is("doc.writer@asciidoc.org"));
 		

--- a/src/test/java/org/asciidoctor/WhenStructuredDocumentIsRequired.java
+++ b/src/test/java/org/asciidoctor/WhenStructuredDocumentIsRequired.java
@@ -41,7 +41,9 @@ public class WhenStructuredDocumentIsRequired {
 		assertThat((String) attributes.get("revdate"), is("2013-05-20"));
 		assertThat((String) attributes.get("revnumber"), is("1.0"));
 		assertThat((String) attributes.get("revremark"), is("First draft"));
+		//attributes should be incasesensitive
 		assertThat((String) attributes.get("tags"), is("[document, example]"));
+		assertThat((String) attributes.get("Tags"), is("[document, example]"));
 		assertThat((String) attributes.get("author"), is("Doc Writer"));
 		assertThat((String) attributes.get("email"),
 				is("doc.writer@asciidoc.org"));
@@ -67,6 +69,7 @@ public class WhenStructuredDocumentIsRequired {
 		assertThat(parts.get(1).getParts().get(1).getId(), is("blockid"));
 		assertThat(parts.get(1).getParts().get(1).getStyle(), is("quote"));
 		assertThat((String)parts.get(1).getParts().get(1).getAttributes().get("attribution"), is("Abraham Lincoln"));
+
 
 		assertThat(parts.get(1).getParts().get(2).getRole(), is("feature-list"));
 

--- a/src/test/resources/documentblocks.asciidoc
+++ b/src/test/resources/documentblocks.asciidoc
@@ -2,7 +2,7 @@
 Doc Writer <doc.writer@asciidoc.org>; John Smith <john.smith@asciidoc.org>
 v1.0, 2013-05-20: First draft
 :title: Sample Document
-:tags: [document, example]
+:Tags: [document, example]
 
 == Abstract
 [abstract]


### PR DESCRIPTION
Fix for case insensitivity. Btw I think behaviour of attributes is inconsistent between document and block attributes. Block attributes are in fact case sensitive.

Is this a feature of asciidoc or do you want me to rise bug for it?
