### PR TITLE
Add default constructor to CaseInsensitiveMap so JRuby can dup() it.

### DIFF
--- a/src/main/java/org/asciidoctor/internal/CaseInsensitiveMap.java
+++ b/src/main/java/org/asciidoctor/internal/CaseInsensitiveMap.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.internal;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -15,6 +16,10 @@ import java.util.Set;
 public class CaseInsensitiveMap<K extends String,V> implements Map<K, V> {
 
 	private Map<K, V> map;
+
+	public CaseInsensitiveMap() {
+		this(new HashMap<K,V>());
+	}
 
 	public CaseInsensitiveMap(Map<K, V> map) {
 		this.map = map;


### PR DESCRIPTION
I ran into this on 1.5.0.preview.7 when trying to pass an attributes map obtained from `DocumentHeader.getAttributes()` into `readDocumentStructure()`:

``` java
import org.asciidoctor.Asciidoctor;
import org.asciidoctor.OptionsBuilder;
import org.asciidoctor.ast.DocumentHeader;

public class Test {

    public static void main(String[] args) {
        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
        DocumentHeader hdr = asciidoctor.readDocumentHeader("foo");
        asciidoctor.readDocumentStructure("bar", OptionsBuilder.options().attributes(hdr.getAttributes()).asMap());
    }
}
```

JRuby blows up with this error:

```
Exception in thread "main" org.jruby.exceptions.RaiseException: (NotImplementedError) can't dup Map of type org.asciidoctor.internal.CaseInsensitiveMap
    at org.jruby.RubyKernel.dup(org/jruby/RubyKernel.java:2062)
    at RUBY.load(jar:file:/home/ben/.gradle/caches/modules-2/files-2.1/org.asciidoctor/asciidoctorj/1.5.0.preview.7/946801c962a23808795becce2f6a27f44674230c/asciidoctorj-1.5.0.preview.7.jar!/gems/asciidoctor-1.5.0.preview.7/lib/asciidoctor.rb:1217)
    at RUBY.load(<script>:74)
    at org.jruby.gen.InterfaceImpl367913758.load(org/jruby/gen/InterfaceImpl367913758.gen:13)
```

Found the problem in JRuby's [MapJavaProxy](https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java#L615), it wants to call the Map classes' default constructor via reflection, but `CaseInsensitiveMap` does not have a default constructor, so it fails.

Adding the default constructor fixes this issue.
