### PR TITLE
upgrade Asciidoctor EPUB3 to fix multibyte char issue; upgrade Saxon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <coderay.version>1.1.0</coderay.version>
         <cacheUri.version>0.0.5</cacheUri.version>
         <threadsafe.version>0.3.4</threadsafe.version>
-        <asciidoctor.epub3.version>1.0.0.alpha.1</asciidoctor.epub3.version>
+        <asciidoctor.epub3.version>1.0.0.alpha.2</asciidoctor.epub3.version>
         <asciidoctor.version>1.5.0</asciidoctor.version>
         <erubis.version>2.7.0</erubis.version>
         <slim.version>2.0.2</slim.version>
@@ -84,6 +84,20 @@
             <groupId>org.xmlmatchers</groupId>
             <artifactId>xml-matchers</artifactId>
             <version>${xmlmatchers.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sf.saxon</groupId>
+                    <artifactId>Saxon-HE</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Use newer version of Saxon than provided by xmlunit
+             The older version causes problems when using Xpath in Nokogiri -->
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>9.5.1-6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -225,6 +239,9 @@
                         <configuration>
                             <!-- <skip>false</skip> -->
                             <includes>
+                                <!--
+                                <include>**/NameOfTestClass.java</include>
+                                -->
                                 <include>**/*Test.java</include>
                                 <include>**/Test*.java</include>
                                 <include>**/When*.java</include>

--- a/src/test/java/org/asciidoctor/WhenANoneStandardBackendIsSet.java
+++ b/src/test/java/org/asciidoctor/WhenANoneStandardBackendIsSet.java
@@ -13,11 +13,10 @@ public class WhenANoneStandardBackendIsSet {
     
     @Test
     public void epub3_should_be_rendered_for_epub3_backend() {
-        
-        System.setProperty("file.encoding", "UTF-8");
+        //System.setProperty("file.encoding", "UTF-8");
         
         asciidoctor.renderFile(new File("target/test-classes/epub-index.adoc"),
-                options().backend("epub3").get());
+                options().safe(SafeMode.SAFE).backend("epub3").get());
     }
     
 }

--- a/src/test/resources/epub-index.adoc
+++ b/src/test/resources/epub-index.adoc
@@ -1,4 +1,5 @@
 = Book Title
 Author Name
+:imagesdir: images
 
 include::content-document.adoc[]


### PR DESCRIPTION
- Asciidoctor EPUB3 uses /\uFEFF/ to match BOM in gsub
- upgrade Saxon to workaround conflict with Nokogiri xpath
- set safe mode to safe in epub3 backend test (required atm)
- set imagesdir to images in epub3 sample document (required atm)
