### PR TITLE
tidy up build scripts

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -4,6 +4,10 @@ dependencies {
   compile project(':asciidoctorj-pdf')
 }
 
+// we're creating a dist, not a jar, silly Gradle
+jar.enabled = false
+configurations.all { artifacts.clear() }
+
 apply plugin: 'application'
 
 tasks.withType(AbstractArchiveTask) {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,30 @@ ext {
   buildDateTime = new Date()
   (buildDateOnly, buildTimeOnly) = new java.text.SimpleDateFormat('yyyy-MM-dd HH:mm:ss.SSSZ').format(buildDateTime).split(' ')
   statusIsRelease = (status == 'release')
+
+  // jar versions
+  guavaVersion = '18.0'
+  hamcrestVersion = '1.3'
+  jcommanderVersion = '1.35'
+  jrubyVersion = '1.7.17'
+  jsoupVersion = '1.8.1'
+  junitVersion = '4.12'
+  saxonVersion = '9.5.1-6'
+  xmlMatchersVersion = '1.0-RC1'
+
+  // gem versions
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.2'
+  asciidoctorEpub3GemVersion = project(':asciidoctorj-epub3').version.replace('-', '.')
+  asciidoctorPdfGemVersion = project(':asciidoctorj-pdf').version.replace('-', '.')
+  coderayGemVersion = '1.1.0'
+  erubisGemVersion = '2.7.0'
+  hamlGemVersion = '4.0.5'
+  openUriCachedGemVersion = '0.0.5'
+  prawnGemVersion = '1.2.1'
+  slimGemVersion = '2.0.3'
+  threadSafeGemVersion = '0.3.4'
+  tiltGemVersion = '2.0.1'
+  ttfunkGemVersion = '1.2.2'
 }
 
 allprojects {
@@ -34,43 +58,12 @@ allprojects {
 }
 
 subprojects {
-  ext {
-    // jar versions
-    guavaVersion = '18.0'
-    hamcrestVersion = '1.3'
-    jcommanderVersion = '1.35'
-    jrubyVersion = '1.7.17'
-    jsoupVersion = '1.8.1'
-    junitVersion = '4.12'
-    saxonVersion = '9.5.1-6'
-    xmlMatchersVersion = '1.0-RC1'
-
-    // gem versions
-    asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.2'
-    asciidoctorEpub3GemVersion = project(':asciidoctorj-epub3').version.replace('-', '.')
-    asciidoctorPdfGemVersion = project(':asciidoctorj-pdf').version.replace('-', '.')
-    coderayGemVersion = '1.1.0'
-    erubisGemVersion = '2.7.0'
-    hamlGemVersion = '4.0.5'
-    openUriCachedGemVersion = '0.0.5'
-    prawnGemVersion = '1.2.1'
-    slimGemVersion = '2.0.3'
-    threadSafeGemVersion = '0.3.4'
-    tiltGemVersion = '2.0.1'
-    ttfunkGemVersion = '1.2.2'
-  }
-
-  //apply plugin: 'project-reports'
-
   // NOTE applying Java plugin changes the status; take steps to preserve value
   def _status = status
   apply plugin: 'java'
   status = _status
 
-  // NOTE ignore the following warning when you are not using jdk6; it's harmless
-  // "warning: [options] bootstrap class path not set in conjunction with -source 1.6"
-  // solution seems to be setting these properties in gradle.properties
-  sourceCompatibility = targetCompatibility = 1.6
+  // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle
 
   repositories {
     if (project.hasProperty('useMavenLocal') && project.useMavenLocal.toBoolean()) {
@@ -87,7 +80,10 @@ subprojects {
       url 'http://rubygems-proxy.torquebox.org/prereleases'
     }
   }
+}
 
+// apply Java and JRuby stuff for all subprojects except the distribution
+configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
   dependencies {
     testCompile "junit:junit:$junitVersion"
     testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
@@ -134,35 +130,29 @@ subprojects {
     classifier 'javadoc'
   }
 
-  if (project.name.endsWith('-distribution')) {
-    // we're creating a dist, not a jar, silly Gradle
-    jar.enabled = false
-    configurations.all { artifacts.clear() }
+  // jcenter & Maven Central requires sources & javadoc jars (even if empty), so give 'em what they want
+  artifacts {
+    archives sourcesJar, javadocJar
   }
-  // skip the Java and JRuby stuff for the distribution build
-  else {
-    // jcenter & Maven Central requires sources & javadoc jars (even if empty), so give 'em what they want
-    artifacts {
-      archives sourcesJar, javadocJar
-    }
 
-    apply plugin: 'com.github.jruby-gradle.base'
+  apply plugin: 'com.github.jruby-gradle.base'
 
-    jruby {
-      defaultRepositories = false
-      defaultVersion = jrubyVersion
-      // TODO I'd like to be able to customize the name of the gemInstallDir
-    }
-
-    // QUESTION is this the right place to insert this task dependency in the lifecycle?
-    processResources.dependsOn jrubyPrepareGems
-
-    apply from: rootProject.file('gradle/eclipse.gradle')
-    if (JavaVersion.current().isJava7Compatible()) {
-      apply from: rootProject.file('gradle/publish.gradle')
-    }
+  jruby {
+    defaultRepositories = false
+    defaultVersion = jrubyVersion
+    // TODO I'd like to be able to customize the name of the gemInstallDir
   }
- 
+
+  // QUESTION is this the right place to insert this task dependency in the lifecycle?
+  processResources.dependsOn jrubyPrepareGems
+
+  apply from: rootProject.file('gradle/eclipse.gradle')
+  if (JavaVersion.current().isJava7Compatible()) {
+    apply from: rootProject.file('gradle/publish.gradle')
+  }
+}
+
+subprojects {
   if (JavaVersion.current().isJava7Compatible()) {
     apply from: rootProject.file('gradle/sign.gradle')
     apply from: rootProject.file('gradle/deploy.gradle')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 version=1.5.3-SNAPSHOT
+sourceCompatibility=1.6
+targetCompatibility=1.6

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -14,6 +14,7 @@ bintray {
       // FIXME WTF??? <flips table>
       // NOTE we have to plant a placeholder so filesSpec resolves the location of the signature file during the initialization phase
       file(distsDir).mkdirs()
+      // QUESTION can we use the archivePath property of the distPath to get this location?
       file("$distsDir/${project(':asciidoctorj').name}-${project.version}-bin.zip.asc").createNewFile()
       from(distsDir) { include '*.asc' }
       into "${project.group.replace('.', '/')}/${project(':asciidoctorj').name}/${project.version}"


### PR DESCRIPTION
- separate out common logic for distribution and non-distribution builds
- move library versions to top-level ext block
- enable sources & javadoc for all jar archives
