### PR TITLE
Fix ConverterRegistry.converters()

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/converter/Converter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/converter/Converter.java
@@ -5,5 +5,26 @@ import org.asciidoctor.ast.AbstractNode;
 import java.util.Map;
 
 public interface Converter {
-    Object convert(AbstractNode abstractBlock, String s, Map<Object, Object> o);
+
+    /**
+     * Converts an {@link org.asciidoctor.ast.AbstractNode} using the specified transform along
+     * with additional options. If a transform is not specified, implementations
+     * typically derive one from the {@link org.asciidoctor.ast.AbstractNode#getNodeName()} property.
+     *
+     * <p>Implementations are free to decide how to carry out the conversion. In
+     * the case of the built-in converters, the tranform value is used to
+     * dispatch to a handler method. The TemplateConverter uses the value of
+     * the transform to select a template to render.
+     *
+     * @param node The concrete instance of AbstractNode to convert
+     * @param transform An optional String transform that hints at which transformation
+     *             should be applied to this node. If a transform is not specified,
+     *             the transform is typically derived from the value of the
+     *             node's node_name property. (optional, default: null)
+     * @param opts An optional map of options that provide additional hints about
+     *             how to convert the node. (optional, default: empty map)
+     * @return the converted result
+     */
+    Object convert(AbstractNode node, String transform, Map<Object, Object> opts);
+
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
@@ -6,9 +6,10 @@ import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.junit.After;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class WhenConverterIsRegistered {
 
@@ -33,6 +34,14 @@ public class WhenConverterIsRegistered {
         String result = asciidoctor.render("== Hello\n\nWorld!", OptionsBuilder.options().backend("test"));
 
         assertThat(result, is("== Hello ==\n\nWorld!\n"));
+    }
+
+    @Test
+    public void shouldReturnRegisteredConverter() {
+        asciidoctor.converterRegistry().register(TextConverter.class, "test2");
+
+        System.out.println(asciidoctor.converterRegistry().converters());
+        assertEquals(TextConverter.class, asciidoctor.converterRegistry().converters().get("test2"));
     }
 
 }


### PR DESCRIPTION
With my last additions ConverterRegistry.converters() did not work correctly anymore because getReifiedClass() always returns null due to the way the converter is created.
Therefore the converters method now checks if the RubyClass has an ObjectAllocator and if so it returns the associated Converter class.

It's not nice, but I also added some Javadocs to this PR for the Converter interface.
Additionally the initialize() method provided by the ConverterProxy now reflects correctly that Asciidoctor ruby may call the constructor only with one parameter, using an empty hash as the second parameter.
