### PR TITLE
Documents how safe mode works.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -303,8 +303,7 @@ StringBuffer htmlBuffer = writer.getBuffer();
 System.out.println(htmlBuffer.toString());
 ----
 
-[IMPORTANT]
-====
+==== Safe mode and file system access
 Asciidoctor provides security levels that control the read and write access of attributes, the include directive, macros, and scripts while a document is processing. Each level includes the restrictions enabled in the prior security level.
 
 When Asciidoctor (and AsciidoctorJ) is used as _API_, it uses `SECURE` safe mode by default.
@@ -329,7 +328,6 @@ We are going to explain in more detail options in <<conversion-options, next sec
 
 
 You can read more about safe modes in http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely
-====
 
 === Conversion options
 


### PR DESCRIPTION
Documents how safe mode works. Resolves issue #260. Basically we have added the info about what is the default mode in API mode, why you should consider using `SAFE` safe mode and we add a link to Asciidoctor document where safe modes are explained.
