### PR TITLE
Aligned AST interfaces with Ruby definitions

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
@@ -5,15 +5,13 @@ import java.util.Map;
 
 public interface AbstractBlock extends AbstractNode {
 
-    String id();
     String title();
-    String role();
     String style();
     List<AbstractBlock> blocks();
     Object content();
     String convert();
     DocumentRuby document();
-    String context();
     AbstractBlock delegate();
     List<AbstractBlock> findBy(Map<Object, Object> selector);
+    int level();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
@@ -12,5 +12,5 @@ public interface AbstractBlock extends AbstractNode {
     String convert();
     AbstractBlock delegate();
     List<AbstractBlock> findBy(Map<Object, Object> selector);
-    int level();
+    int getLevel();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
@@ -10,7 +10,6 @@ public interface AbstractBlock extends AbstractNode {
     List<AbstractBlock> blocks();
     Object content();
     String convert();
-    DocumentRuby document();
     AbstractBlock delegate();
     List<AbstractBlock> findBy(Map<Object, Object> selector);
     int level();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -63,8 +63,8 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     }
 
     @Override
-    public int level() {
-        return delegate.level();
+    public int getLevel() {
+        return delegate.getLevel();
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -73,11 +73,6 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     }
 
     @Override
-    public DocumentRuby document() {
-        return delegate.document();
-    }
-
-    @Override
     public List<AbstractBlock> findBy(Map<Object, Object> selector) {
 
         @SuppressWarnings("unchecked")

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -23,18 +23,8 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     }
 
     @Override
-    public String id() {
-        return delegate.id();
-    }
-
-    @Override
     public String title() {
         return delegate.title();
-    }
-
-    @Override
-    public String role() {
-        return delegate.role();
     }
 
     @Override
@@ -73,8 +63,8 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     }
 
     @Override
-    public String context() {
-        return delegate.context();
+    public int level() {
+        return delegate.level();
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
@@ -7,9 +7,21 @@ public interface AbstractNode {
 
     String id();
     String getNodeName();
+    /**
+     * @deprecated Use {@linkplain #getParent()}  instead.
+     */
     AbstractNode parent();
+    AbstractNode getParent();
+    /**
+     * @deprecated Use {@linkplain #getContext()}  instead.
+     */
     String context();
+    String getContext();
+    /**
+     * @deprecated Use {@linkplain #getDocument()}  instead.
+     */
     DocumentRuby document();
+    DocumentRuby getDocument();
     boolean isInline();
     boolean isBlock();
     Map<String, Object> getAttributes();
@@ -24,6 +36,9 @@ public interface AbstractNode {
     boolean isRole();
     boolean hasRole(String role);
     String getRole();
+    /**
+     * @deprecated Use {@linkplain #getRole()}  instead.
+     */
     String role();
     List<String> getRoles();
     boolean isReftext();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
@@ -5,11 +5,18 @@ import java.util.Map;
 
 public interface AbstractNode {
 
+    String id();
     String getNodeName();
+    AbstractNode parent();
+    String context();
+    DocumentRuby document();
     boolean isInline();
     boolean isBlock();
     Map<String, Object> getAttributes();
     Object getAttr(Object name, Object defaultValue, boolean inherit);
+    Object getAttr(Object name, Object defaultValue);
+    Object getAttr(Object name);
+    boolean isAttr(Object name, Object expected);
     boolean isAttr(Object name, Object expected, boolean inherit);
     boolean setAttr(Object name, Object value, boolean overwrite);
     boolean isOption(Object name);
@@ -17,6 +24,7 @@ public interface AbstractNode {
     boolean isRole();
     boolean hasRole(String role);
     String getRole();
+    String role();
     List<String> getRoles();
     boolean isReftext();
     String getReftext();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
@@ -23,12 +23,32 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public String context() {
-        return this.abstractNode.context();
+        return getContext();
+    }
+
+    @Override
+    public String getContext() {
+        return this.abstractNode.getContext();
     }
 
     @Override
     public AbstractNode parent() {
-        return this.abstractNode.parent();
+        return getParent();
+    }
+
+    @Override
+    public AbstractNode getParent() {
+        return this.abstractNode.getParent();
+    }
+
+    @Override
+    public DocumentRuby document() {
+        return getDocument();
+    }
+
+    @Override
+    public DocumentRuby getDocument() {
+        return this.abstractNode.getDocument();
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
@@ -17,6 +17,21 @@ public abstract class AbstractNodeImpl implements AbstractNode {
     }
 
     @Override
+    public String id() {
+        return this.abstractNode.id();
+    }
+
+    @Override
+    public String context() {
+        return this.abstractNode.context();
+    }
+
+    @Override
+    public AbstractNode parent() {
+        return this.abstractNode.parent();
+    }
+
+    @Override
     public String getNodeName() {
         return this.abstractNode.getNodeName();
     }
@@ -42,8 +57,23 @@ public abstract class AbstractNodeImpl implements AbstractNode {
     }
 
     @Override
+    public Object getAttr(Object name, Object defaultValue) {
+        return this.abstractNode.getAttr(name, defaultValue, true);
+    }
+
+    @Override
+    public Object getAttr(Object name) {
+        return this.abstractNode.getAttr(name, null, true);
+    }
+
+    @Override
     public boolean isAttr(Object name, Object expected, boolean inherit) {
         return this.abstractNode.isAttr(name, expected, inherit);
+    }
+
+    @Override
+    public boolean isAttr(Object name, Object expected) {
+        return this.abstractNode.isAttr(name, expected, true);
     }
 
     @Override
@@ -64,6 +94,11 @@ public abstract class AbstractNodeImpl implements AbstractNode {
     @Override
     public String getRole() {
         return this.abstractNode.getRole();
+    }
+
+    @Override
+    public String role() {
+        return this.abstractNode.role();
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DocumentRuby.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DocumentRuby.java
@@ -18,6 +18,14 @@ public interface DocumentRuby extends AbstractBlock {
     Object doctitle(Map<Object, Object> opts);
 
     /**
+     * Get doc title
+     *
+     * @return String if partition flag is not set to false or not present, Title if partition is set to true.
+     * @see Title
+     */
+    Object doctitle();
+
+    /**
      * 
      * @return page title
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Inline.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Inline.java
@@ -7,7 +7,7 @@ public interface Inline extends AbstractNode {
     
     public String convert();
 
-    public String type();
+    public String getType();
 
-    public String text();
+    public String getText();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Inline.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Inline.java
@@ -1,10 +1,13 @@
 package org.asciidoctor.ast;
 
-public interface Inline {
+public interface Inline extends AbstractNode {
 
     @Deprecated
     public String render();
     
     public String convert();
-    
+
+    public String type();
+
+    public String text();
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
@@ -1,14 +1,11 @@
 package org.asciidoctor.converter;
 
+import org.asciidoctor.ast.AbstractBlock;
 import org.asciidoctor.ast.AbstractNode;
-import org.asciidoctor.ast.Block;
-import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.DocumentRuby;
 import org.asciidoctor.ast.Section;
 
 import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 
 public class TextConverter extends AbstractConverter {
 
@@ -21,14 +18,12 @@ public class TextConverter extends AbstractConverter {
     @Override
     public Object convert(AbstractNode node, String transform, Map<Object, Object> o) {
 
-        assertThat(node.getClass().getPackage().getName(), is("org.asciidoctor.ast"));
-
         if (transform == null) {
             transform = node.getNodeName();
         }
  
-        if (node instanceof Document) {
-            Document document = (Document) node;
+        if (node instanceof DocumentRuby) {
+            DocumentRuby document = (DocumentRuby) node;
             return document.content();
         } else if (node instanceof Section) {
             Section section = (Section) node;
@@ -37,11 +32,11 @@ public class TextConverter extends AbstractConverter {
                     .append(LINE_SEPARATOR).append(LINE_SEPARATOR)
                     .append(section.content()).toString();
         } else if (transform.equals("paragraph")) {
-            Block block = (Block) node;
+            AbstractBlock block = (AbstractBlock) node;
             String content = (String) block.content();
             return new StringBuilder(content.replaceAll(LINE_SEPARATOR, " ")).append('\n');
-        } else if (node instanceof Block) {
-            Block block = (Block) node;
+        } else if (node instanceof AbstractBlock) {
+            AbstractBlock block = (AbstractBlock) node;
             return block.content();
         }
         return null;


### PR DESCRIPTION
Wile trying to move the reveal.js slim backend to a Groovy MarkupTemplateEngine based approach I needed to make these changes.
The members that are moved from AbstractBlock to AbstractNode are are also defined on AbstractNode in the Ruby implementation.

Some methods like DocumentRuby.doctitle() or AbstractNode.getAttr() were overloaded to mirror the defaults defined in the Ruby implementation.