### PR TITLE
Added new Java counterparts for List and ListItem nodes.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
@@ -5,10 +5,26 @@ import java.util.Map;
 
 public interface AbstractBlock extends AbstractNode {
 
+    /**
+     * @deprecated Please use {@linkplain #getTitle()} instead
+     */
     String title();
+    String getTitle();
+    /**
+     * @deprecated Please use {@linkplain #getStyle()} instead
+     */
     String style();
+    String getStyle();
+    /**
+     * @deprecated Please use {@linkplain #getBlocks()} instead
+     */
     List<AbstractBlock> blocks();
+    List<AbstractBlock> getBlocks();
+    /**
+     * @deprecated Please use {@linkplain #getContent()} instead
+     */
     Object content();
+    Object getContent();
     String convert();
     AbstractBlock delegate();
     List<AbstractBlock> findBy(Map<Object, Object> selector);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -3,11 +3,13 @@ package org.asciidoctor.ast;
 import java.util.List;
 import java.util.Map;
 
+import org.asciidoctor.converter.ConverterProxy;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyObject;
+import org.jruby.javasupport.JavaEmbedUtils;
 
 public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock {
 
@@ -24,23 +26,38 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
     @Override
     public String title() {
-        return delegate.title();
+        return getTitle();
+    }
+
+    @Override
+    public String getTitle() {
+        return delegate.getTitle();
     }
 
     @Override
     public String style() {
-        return delegate.style();
+        return getStyle();
+    }
+
+    @Override
+    public String getStyle() {
+        return delegate.getStyle();
     }
 
     @Override
     public List<AbstractBlock> blocks() {
-        List<AbstractBlock> rubyBlocks = delegate.blocks();
+        return getBlocks();
+    }
+
+    @Override
+    public List<AbstractBlock> getBlocks() {
+        List<AbstractBlock> rubyBlocks = delegate.getBlocks();
 
         for (int i = 0; i < rubyBlocks.size(); i++) {
             Object abstractBlock = rubyBlocks.get(i);
-            if (!(abstractBlock instanceof RubyArray) && !(abstractBlock instanceof Block)) {
+            if (!(abstractBlock instanceof RubyArray) && !(abstractBlock instanceof AbstractNode)) {
                 RubyObject rubyObject = (RubyObject) abstractBlock;
-                rubyBlocks.set(i, overrideRubyObjectToJavaObject(rubyObject));
+                rubyBlocks.set(i, (AbstractBlock) NodeConverter.createASTNode(rubyObject));
             }
         }
 
@@ -49,6 +66,11 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
     @Override
     public Object content() {
+        return getContent();
+    }
+
+    @Override
+    public Object getContent() {
         return delegate.content();
     }
 
@@ -83,26 +105,11 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
             Object abstractBlock = findBy.get(i);
             if (!(abstractBlock instanceof RubyArray) && !(abstractBlock instanceof AbstractBlock)) {
                 RubyObject rubyObject = (RubyObject)abstractBlock;
-                findBy.set(i, overrideRubyObjectToJavaObject(rubyObject));
+                findBy.set(i, (AbstractBlock) NodeConverter.createASTNode(rubyObject));
             }
 
         }
         return findBy;
     }
 
-    private AbstractBlock overrideRubyObjectToJavaObject(RubyObject rubyObject) {
-        if (BLOCK_CLASS.equals(rubyObject.getMetaClass().getBaseName())) {
-            Block blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, Block.class);
-            return new BlockImpl(blockRuby, runtime);
-        }
-        else if (SECTION_CLASS.equals(rubyObject.getMetaClass().getBaseName())) {
-            Section blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, Section.class);
-            return new SectionImpl(blockRuby, runtime);
-        }
-        else {
-            AbstractBlock blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, AbstractBlock.class);
-            return new AbstractBlockImpl(blockRuby, runtime);
-        }
-    }
-    
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
@@ -50,4 +50,8 @@ public interface AbstractNode {
     String readAsset(String path, Map<Object, Object> opts);
     String normalizeWebPath(String path, String start, boolean preserveUriTarget);
 
+    String getStyle();
+
+    String listMarkerKeyword();
+    String listMarkerKeyword(String listType);
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
@@ -4,7 +4,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.asciidoctor.internal.RubyHashUtil;
+import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
+import org.jruby.java.proxies.RubyObjectHolderProxy;
+import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.builtin.InstanceVariables;
+import org.jruby.runtime.builtin.Variable;
 
 public abstract class AbstractNodeImpl implements AbstractNode {
 
@@ -169,5 +176,29 @@ public abstract class AbstractNodeImpl implements AbstractNode {
     @Override
     public String normalizeWebPath(String path, String start, boolean preserveUriTarget) {
         return this.abstractNode.normalizeWebPath(path, start, preserveUriTarget);
+    }
+
+    @Override
+    public String getStyle() {
+
+        IRubyObject style = ((RubyObjectHolderProxy) this.abstractNode).__ruby_object()
+                .getInstanceVariables()
+                .getInstanceVariable("@style");
+
+        if (style == null) {
+            return null;
+        } else {
+            return RubyUtils.rubyToJava(runtime, style, String.class);
+        }
+    }
+
+    @Override
+    public String listMarkerKeyword() {
+        return abstractNode.listMarkerKeyword();
+    }
+
+    @Override
+    public String listMarkerKeyword(String listType) {
+        return abstractNode.listMarkerKeyword(listType);
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/InlineImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/InlineImpl.java
@@ -1,0 +1,33 @@
+package org.asciidoctor.ast;
+
+import org.jruby.Ruby;
+
+public class InlineImpl extends AbstractNodeImpl implements Inline  {
+
+    protected Inline delegate;
+
+    public InlineImpl(Inline delegate, Ruby ruby) {
+        super(delegate, ruby);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String render() {
+        return delegate.render();
+    }
+
+    @Override
+    public String convert() {
+        return delegate.convert();
+    }
+
+    @Override
+    public String getType() {
+        return delegate.getType();
+    }
+
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListImpl.java
@@ -1,0 +1,35 @@
+package org.asciidoctor.ast;
+
+import org.jruby.Ruby;
+
+import java.util.List;
+
+public class ListImpl extends AbstractBlockImpl implements ListNode {
+
+    private final ListNode listDelegate;
+
+    public ListImpl(ListNode delegate, Ruby rubyRuntime) {
+        super(delegate, rubyRuntime);
+        this.listDelegate = delegate;
+    }
+
+    @Override
+    public List<AbstractBlock> getItems() {
+        return blocks();
+    }
+
+    @Override
+    public boolean isItem() {
+        return isBlock();
+    }
+
+    @Override
+    public String render() {
+        return listDelegate.render();
+    }
+
+    @Override
+    public String convert() {
+        return listDelegate.convert();
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItem.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItem.java
@@ -1,0 +1,10 @@
+package org.asciidoctor.ast;
+
+public interface ListItem extends AbstractBlock {
+
+    public String getMarker();
+
+    public String getText();
+
+    public boolean hasText();
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItemImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItemImpl.java
@@ -1,0 +1,28 @@
+package org.asciidoctor.ast;
+
+import org.jruby.Ruby;
+
+public class ListItemImpl extends AbstractBlockImpl implements ListItem {
+
+    private final ListItem listDelegate;
+
+    public ListItemImpl(ListItem listDelegate, Ruby runtime) {
+        super(listDelegate, runtime);
+        this.listDelegate = listDelegate;
+    }
+
+    @Override
+    public String getMarker() {
+        return listDelegate.getMarker();
+    }
+
+    @Override
+    public String getText() {
+        return listDelegate.getText();
+    }
+
+    @Override
+    public boolean hasText() {
+        return listDelegate.hasText();
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListNode.java
@@ -1,0 +1,14 @@
+package org.asciidoctor.ast;
+
+public interface ListNode extends AbstractBlock {
+
+    java.util.List<AbstractBlock> getItems();
+
+    boolean isItem();
+
+    @Deprecated
+    public String render();
+
+    public String convert();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
@@ -1,0 +1,57 @@
+package org.asciidoctor.ast;
+
+import org.asciidoctor.internal.RubyUtils;
+import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * A library class that allows to convert nodes from Asciidoctor Ruby
+ * to its AsciidoctorJ counterparts.
+ */
+public final class NodeConverter {
+
+    private static final String BLOCK_CLASS = "Asciidoctor::Block";
+
+    private static final String SECTION_CLASS = "Asciidoctor::Section";
+
+    private static final String DOCUMENT_CLASS = "Asciidoctor::Document";
+
+    private static final String INLINE_CLASS = "Asciidoctor::Inline";
+
+    private static final String LIST_CLASS = "Asciidoctor::List";
+
+    private static final String LIST_ITEM_CLASS = "Asciidoctor::ListItem";
+
+    private NodeConverter() {}
+
+    public static AbstractNode createASTNode(IRubyObject rubyObject) {
+        String rubyClassName = rubyObject.getMetaClass().getRealClass().getName();
+        Ruby runtime = rubyObject.getRuntime();
+        if (BLOCK_CLASS.equals(rubyClassName)) {
+            Block blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, Block.class);
+            return new BlockImpl(blockRuby, runtime);
+        }
+        else if (SECTION_CLASS.equals(rubyClassName)) {
+            Section blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, Section.class);
+            return new SectionImpl(blockRuby, runtime);
+        }
+        else if (DOCUMENT_CLASS.equals(rubyClassName)) {
+            DocumentRuby blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, DocumentRuby.class);
+            return new Document(blockRuby, runtime);
+        }
+        else if (INLINE_CLASS.equals(rubyClassName)) {
+            Inline inline = RubyUtils.rubyToJava(runtime, rubyObject, Inline.class);
+            return new InlineImpl(inline, runtime);
+        }
+        else if (LIST_CLASS.equals(rubyClassName)) {
+            ListNode list = RubyUtils.rubyToJava(runtime, rubyObject, ListNode.class);
+            return new ListImpl(list, runtime);
+        }
+        else if (LIST_ITEM_CLASS.equals(rubyClassName)) {
+            ListItem list = RubyUtils.rubyToJava(runtime, rubyObject, ListItem.class);
+            return new ListItemImpl(list, runtime);
+        }
+        throw new IllegalArgumentException("Don't know what to do with a " + rubyObject);
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
@@ -3,6 +3,8 @@ package org.asciidoctor.converter;
 import org.asciidoctor.ast.AbstractBlock;
 import org.asciidoctor.ast.AbstractNode;
 import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.ast.ListItem;
+import org.asciidoctor.ast.ListNode;
 import org.asciidoctor.ast.Section;
 
 import java.util.Map;
@@ -24,20 +26,28 @@ public class TextConverter extends AbstractConverter {
  
         if (node instanceof DocumentRuby) {
             DocumentRuby document = (DocumentRuby) node;
-            return document.content();
+            return document.getContent();
         } else if (node instanceof Section) {
             Section section = (Section) node;
             return new StringBuilder()
-                    .append("== ").append(section.title()).append(" ==")
+                    .append("== ").append(section.getTitle()).append(" ==")
                     .append(LINE_SEPARATOR).append(LINE_SEPARATOR)
-                    .append(section.content()).toString();
+                    .append(section.getContent()).toString();
         } else if (transform.equals("paragraph")) {
             AbstractBlock block = (AbstractBlock) node;
             String content = (String) block.content();
-            return new StringBuilder(content.replaceAll(LINE_SEPARATOR, " ")).append('\n');
+            return new StringBuilder(content.replaceAll(LINE_SEPARATOR, " ")).append(LINE_SEPARATOR);
+        } else if (node instanceof ListNode) {
+            StringBuilder sb = new StringBuilder();
+            for (AbstractBlock listItem: ((ListNode) node).getItems()) {
+                sb.append(listItem.convert()).append(LINE_SEPARATOR);
+            }
+            return sb.toString();
+        } else if (node instanceof ListItem) {
+            return "-> " + ((ListItem) node).getText();
         } else if (node instanceof AbstractBlock) {
             AbstractBlock block = (AbstractBlock) node;
-            return block.content();
+            return block.getContent();
         }
         return null;
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
@@ -31,9 +31,9 @@ public class WhenConverterIsRegistered {
     public void shouldRegisterAndExecuteGivenConverter() {
         asciidoctor.converterRegistry().register(TextConverter.class, "test");
 
-        String result = asciidoctor.render("== Hello\n\nWorld!", OptionsBuilder.options().backend("test"));
+        String result = asciidoctor.render("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options().backend("test"));
 
-        assertThat(result, is("== Hello ==\n\nWorld!\n"));
+        assertThat(result, is("== Hello ==\n\nWorld!\n\n-> a\n-> b\n"));
     }
 
     @Test


### PR DESCRIPTION
Also provided an implementation for the Inline interface.
Additionally moved Ruby to Java node conversion to separate class org.asciidoctor.ast.NodeFactory.

I tried hard for a DynamicProxy based approach and it worked fine for converters.
But the whole approach got mixed up when TreeConverters are added.
It seems to be impossible or at least very hard to mix and match JRuby type conversion and own DynamicProxies.