### PR TITLE
Fixes #275.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
@@ -171,8 +171,7 @@ public class AsciidoctorInvoker {
         List<File> filesToBeRendered = new ArrayList<File>();
 
         for (String globExpression : parameters) {
-            DirectoryWalker globDirectoryWalker = new GlobDirectoryWalker(".",
-                    globExpression);
+            DirectoryWalker globDirectoryWalker = new GlobDirectoryWalker(globExpression);
             filesToBeRendered.addAll(globDirectoryWalker.scan());
         }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
@@ -21,7 +21,7 @@ public class WhenGlobExpressionIsUsedForScanning {
     public void all_files_with_given_extension_of_current_directory_should_be_returned() {
         
         File pathToWalk = classpath.getResource("src");
-        DirectoryWalker globDirectoryWalker = new GlobDirectoryWalker(pathToWalk.getPath(), "documents/*.adoc");
+        DirectoryWalker globDirectoryWalker = new GlobDirectoryWalker(pathToWalk.getPath() + File.separator + "documents/*.adoc");
         List<File> asciidocFiles = globDirectoryWalker.scan();
         
         assertThat(
@@ -35,7 +35,7 @@ public class WhenGlobExpressionIsUsedForScanning {
     public void all_files_with_given_extension_should_be_returned_recursively() {
         
         File pathToWalk = classpath.getResource("src");
-        DirectoryWalker globDirectoryWalker = new GlobDirectoryWalker(pathToWalk.getPath(), "**/*.adoc");
+        DirectoryWalker globDirectoryWalker = new GlobDirectoryWalker(pathToWalk.getPath() + File.separator + "**/*.adoc");
         List<File> asciidocFiles = globDirectoryWalker.scan();
         
         assertThat(
@@ -49,7 +49,7 @@ public class WhenGlobExpressionIsUsedForScanning {
     public void no_should_be_returned_if_glob_expression_does_not_match() {
         
         File pathToWalk = classpath.getResource("src");
-        DirectoryWalker globDirectoryWalker = new GlobDirectoryWalker(pathToWalk.getPath(), "**/*.a");
+        DirectoryWalker globDirectoryWalker = new GlobDirectoryWalker(pathToWalk.getPath() + File.separator + "**/*.a");
         List<File> asciidocFiles = globDirectoryWalker.scan();
         
         assertThat(asciidocFiles, is(empty()));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -231,7 +231,19 @@ public class WhenAsciidoctorIsCalledUsingCli {
 	    
 	}
 
-	private ByteArrayOutputStream redirectStdout() {
+    @Test
+    public void with_absolute_path_file_should_be_rendered() {
+
+        File inputFile = classpath.getResource("rendersample.asciidoc");
+        String inputPath = inputFile.getAbsolutePath();
+        new AsciidoctorInvoker().invoke(inputPath);
+        File expectedFile = new File(inputPath.replaceFirst("\\.asciidoc$", ".html"));
+
+        assertThat(expectedFile.exists(), is(true));
+        expectedFile.delete();
+    }
+
+    private ByteArrayOutputStream redirectStdout() {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		System.setOut(new PrintStream(output));
 		return output;


### PR DESCRIPTION
Absolute paths are split into an absolute part without wildcards that serves as the root directory and a relative part containing wildcards or at least the file name.
Relative paths are still handled as being reachable from current working dir.