### PR TITLE
Removed redundant config map from extensions.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
@@ -10,6 +10,7 @@ import org.jruby.RubyHash;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +37,10 @@ public class Processor {
         return null;
     }
 
+    public Block createBlock(AbstractBlock parent, String context, String content, Map<String, Object> attributes) {
+        return createBlock(parent, context, content, attributes, new HashMap<Object, Object>());
+    }
+
     public Block createBlock(AbstractBlock parent, String context, String content, Map<String, Object> attributes,
             Map<Object, Object> options) {
 
@@ -44,7 +49,11 @@ public class Processor {
         
         return createBlock(parent, context, options);
     }
-    
+
+    public Block createBlock(AbstractBlock parent, String context, List<String> content, Map<String, Object> attributes) {
+        return createBlock(parent, context, content, attributes, new HashMap<Object, Object>());
+    }
+
     public Block createBlock(AbstractBlock parent, String context, List<String> content, Map<String, Object> attributes,
             Map<Object, Object> options) {
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.extension.Processor;
+import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
@@ -8,12 +9,18 @@ import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.Map;
 
 public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
+
+    protected static final String MEMBER_NAME_CONFIG = "@config";
+    protected static final String METHOD_NAME_INITIALIZE = "initialize";
 
     protected T processor;
 
@@ -43,24 +50,6 @@ public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
 
     public void setProcessorClass(Class<? extends T> processorClass) {
         this.processorClass = processorClass;
-    }
-
-    @JRubyMethod(name = "config")
-    public IRubyObject getConfig(ThreadContext context) {
-        return RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(getRuntime(), getProcessor().getConfig());
-    }
-
-    @JRubyMethod(name = "config=", required = 1)
-    public IRubyObject setConfig(ThreadContext context, IRubyObject newConfig) {
-        processor.setConfig(RubyHashUtil.convertRubyHashMapToStringObjectMap((RubyHash) newConfig));
-        return null;
-    }
-
-    @JRubyMethod(name = "update_config", required = 1)
-    public IRubyObject updateConfig(ThreadContext context, IRubyObject additionalConfig) {
-        Map additionalJavaConfig = RubyUtils.rubyToJava(getRuntime(), additionalConfig, Map.class);
-        processor.update_config(additionalJavaConfig);
-        return RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(getRuntime(), processor.getConfig());
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -4,9 +4,12 @@ import org.asciidoctor.ast.AbstractBlock;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.BlockProcessor;
 import org.asciidoctor.extension.Reader;
+import org.asciidoctor.internal.RubyHashMapDecorator;
+import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyHash;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.Block;
@@ -69,26 +72,22 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
                     context,
                     this,
                     getMetaClass(),
-                    "initialize",
+                    METHOD_NAME_INITIALIZE,
                     new IRubyObject[]{
                             JavaEmbedUtils.javaToRuby(getRuntime(), getProcessor().getName()),
-                            JavaEmbedUtils.javaToRuby(getRuntime(), getProcessor().getConfig()) },
+                            RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(getRuntime(), getProcessor().getConfig())},
                     Block.NULL_BLOCK);
+            // The extension config in the Java extension is just a view on the @config member of the Ruby part
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
-            if (args.length == 1) {
-                setProcessor(getProcessorClass().getConstructor(String.class).newInstance(RubyUtils.rubyToJava(getRuntime(), args[0], String.class)));
-            } else {
-                setProcessor(
-                        getProcessorClass()
-                                .getConstructor(String.class, Map.class)
-                                .newInstance(
-                                        RubyUtils.rubyToJava(getRuntime(), args[0], String.class),
-                                        RubyUtils.rubyToJava(getRuntime(), args[1], Map.class)));
-            }
-            Helpers.invokeSuper(context, this, getMetaClass(), "initialize", args, Block.NULL_BLOCK);
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, args, Block.NULL_BLOCK);
+            setProcessor(
+                    getProcessorClass()
+                            .getConstructor(String.class, Map.class)
+                            .newInstance(
+                                    RubyUtils.rubyToJava(getRuntime(), args[0], String.class),
+                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
         }
-
-
         return null;
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
@@ -3,9 +3,12 @@ package org.asciidoctor.extension.processorproxies;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
 import org.asciidoctor.extension.DocinfoProcessor;
+import org.asciidoctor.internal.RubyHashMapDecorator;
+import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyHash;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.Block;
@@ -61,6 +64,7 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
 
     @JRubyMethod(name = "initialize", required = 1)
     public IRubyObject initialize(ThreadContext context, IRubyObject options) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+
         if (getProcessor() != null) {
             // Instance was created in Java and has options set, so we pass these
             // instead of those passed by asciidoctor
@@ -68,17 +72,20 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
                     context,
                     this,
                     getMetaClass(),
-                    "initialize",
-                    new IRubyObject[]{ JavaEmbedUtils.javaToRuby(getRuntime(), getProcessor().getConfig()) },
+                    METHOD_NAME_INITIALIZE,
+                    new IRubyObject[]{
+                            RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(getRuntime(), getProcessor().getConfig())},
                     Block.NULL_BLOCK);
+            // The extension config in the Java extension is just a view on the @config member of the Ruby part
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[0], Block.NULL_BLOCK);
             setProcessor(
                     getProcessorClass()
                             .getConstructor(Map.class)
-                            .newInstance(RubyUtils.rubyToJava(getRuntime(), options, Map.class)));
-            Helpers.invokeSuper(context, this, getMetaClass(), "initialize", new IRubyObject[]{options}, Block.NULL_BLOCK);
+                            .newInstance(
+                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
         }
-
 
         return null;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
@@ -4,9 +4,12 @@ import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
 import org.asciidoctor.extension.IncludeProcessor;
 import org.asciidoctor.extension.PreprocessorReader;
+import org.asciidoctor.internal.RubyHashMapDecorator;
+import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyHash;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.Block;
@@ -62,6 +65,7 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
 
     @JRubyMethod(name = "initialize", required = 1)
     public IRubyObject initialize(ThreadContext context, IRubyObject options) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+
         if (getProcessor() != null) {
             // Instance was created in Java and has options set, so we pass these
             // instead of those passed by asciidoctor
@@ -69,17 +73,20 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
                     context,
                     this,
                     getMetaClass(),
-                    "initialize",
-                    new IRubyObject[]{ JavaEmbedUtils.javaToRuby(getRuntime(), getProcessor().getConfig()) },
+                    METHOD_NAME_INITIALIZE,
+                    new IRubyObject[]{
+                            RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(getRuntime(), getProcessor().getConfig())},
                     Block.NULL_BLOCK);
+            // The extension config in the Java extension is just a view on the @config member of the Ruby part
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[0], Block.NULL_BLOCK);
             setProcessor(
                     getProcessorClass()
                             .getConstructor(Map.class)
-                            .newInstance(RubyUtils.rubyToJava(getRuntime(), options, Map.class)));
-            Helpers.invokeSuper(context, this, getMetaClass(), "initialize", new IRubyObject[]{options}, Block.NULL_BLOCK);
+                            .newInstance(
+                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
         }
-
 
         return null;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
@@ -3,9 +3,12 @@ package org.asciidoctor.extension.processorproxies;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
 import org.asciidoctor.extension.Postprocessor;
+import org.asciidoctor.internal.RubyHashMapDecorator;
+import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyHash;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.Block;
@@ -68,18 +71,20 @@ public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
                     context,
                     this,
                     getMetaClass(),
-                    "initialize",
-                    new IRubyObject[]{ JavaEmbedUtils.javaToRuby(getRuntime(), getProcessor().getConfig()) },
+                    METHOD_NAME_INITIALIZE,
+                    new IRubyObject[]{
+                            RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(getRuntime(), getProcessor().getConfig())},
                     Block.NULL_BLOCK);
+            // The extension config in the Java extension is just a view on the @config member of the Ruby part
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[0], Block.NULL_BLOCK);
             setProcessor(
                     getProcessorClass()
                             .getConstructor(Map.class)
-                            .newInstance(RubyUtils.rubyToJava(getRuntime(), options, Map.class)));
-            Helpers.invokeSuper(context, this, getMetaClass(), "initialize", new IRubyObject[]{options}, Block.NULL_BLOCK);
+                            .newInstance(
+                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
         }
-
-
         return null;
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyHashMapDecorator.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyHashMapDecorator.java
@@ -1,0 +1,139 @@
+package org.asciidoctor.internal;
+import org.jruby.RubyHash;
+import org.jruby.RubyString;
+import org.jruby.RubySymbol;
+import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.builtin.IRubyObject;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+public class RubyHashMapDecorator implements Map<String, Object> {
+
+    private final RubyHash rubyHash;
+
+    public RubyHashMapDecorator(RubyHash rubyHash) {
+        this.rubyHash = rubyHash;
+    }
+
+    @Override
+    public int size() {
+        return rubyHash.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return rubyHash.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (!(key instanceof String)) {
+            return false;
+        }
+        RubySymbol symbol = rubyHash.getRuntime().getSymbolTable().getSymbol((String) key);
+        return rubyHash.containsKey(symbol);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return rubyHash.containsValue(value);
+    }
+
+    @Override
+    public Object get(Object key) {
+        if (!(key instanceof String)) {
+            return false;
+        }
+        RubySymbol symbol = rubyHash.getRuntime().getSymbolTable().getSymbol((String) key);
+        Object value = rubyHash.get(symbol);
+        return convertRubyValue(value);
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        Object oldValue = get(key);
+        RubySymbol symbol = rubyHash.getRuntime().getSymbolTable().getSymbol(key);
+        rubyHash.put(symbol, convertJavaValue(value));
+        return oldValue;
+    }
+
+    @Override
+    public Object remove(Object key) {
+        if (!(key instanceof String)) {
+            return null;
+        }
+        Object oldValue = get(key);
+        RubySymbol symbol = rubyHash.getRuntime().getSymbolTable().getSymbol((String) key);
+        rubyHash.remove(symbol);
+        return convertRubyValue(oldValue);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ?> m) {
+        for (Map.Entry<? extends String, ?> entry: m.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public void clear() {
+        rubyHash.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return createJavaMap().keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return createJavaMap().values();
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        return createJavaMap().entrySet();
+    }
+
+    private Map<String, Object> createJavaMap() {
+        Map<String, Object> copy = new HashMap<String, Object>();
+        Set<Entry<Object, Object>> rubyEntrySet = rubyHash.entrySet();
+        for (Map.Entry<Object, Object> o: rubyEntrySet) {
+            String key;
+            Object value;
+            Object rubyKey = o.getKey();
+            Object rubyValue = o.getValue();
+            if (rubyKey instanceof RubySymbol) {
+                key = ((RubySymbol) rubyKey).asJavaString();
+            } else if (rubyKey instanceof RubyString) {
+                key = ((RubyString) rubyKey).asJavaString();
+            } else {
+                throw new IllegalStateException("Did not expect key " + rubyKey + " of type " + rubyKey.getClass());
+            }
+            value = convertRubyValue(rubyValue);
+            copy.put(key, value);
+        }
+        return copy;
+    }
+
+    private Object convertRubyValue(Object rubyValue) {
+        if (rubyValue == null) {
+            return null;
+        } else if (rubyValue instanceof IRubyObject) {
+            return JavaEmbedUtils.rubyToJava((IRubyObject) rubyValue);
+        } else {
+            return rubyValue;
+        }
+    }
+
+    private IRubyObject convertJavaValue(Object value) {
+        if (value == null) {
+            return null;
+        } else if (value instanceof String && ((String) value).startsWith(":")) {
+            return rubyHash.getRuntime().getSymbolTable().getSymbol(((String) value).substring(1));
+        } else {
+            return JavaEmbedUtils.javaToRuby(rubyHash.getRuntime(), value);
+        }
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/internal/RubyHashMapDecoratorSpecification.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/internal/RubyHashMapDecoratorSpecification.groovy
@@ -1,0 +1,119 @@
+package org.asciidoctor.internal
+
+import org.jruby.Ruby
+import org.jruby.RubyHash
+import org.jruby.RubyString
+import org.jruby.embed.ScriptingContainer
+import spock.lang.Specification
+
+class RubyHashMapDecoratorSpecification extends Specification {
+
+    public static final String KEY = 'key'
+    public static final String VALUE = 'value'
+    public static final String KEY_VALUE_MAPPING = '{:key => "value"}'
+    public static final String A = 'A'
+    public static final String VALUE_B = 'B'
+    public static final String VALUE_D = 'D'
+    public static final String CREATE_EMPTY_RUBY_HASH = '$ruby_hash = Hash.new'
+    Ruby ruby = new ScriptingContainer().getProvider().getRuntime()
+
+    def cleanup() {
+        ruby.tearDown()
+    }
+
+    def 'when a RubyHash is empty the Map should be empty too'() {
+        given: 'An empty RubyHash'
+        RubyHash rubyHash = RubyHash.newHash(ruby)
+
+        when: 'A RubyHashMapDecorator wraps it'
+        RubyHashMapDecorator map = new RubyHashMapDecorator(rubyHash)
+
+        then: 'The decorator is empty too'
+        map.isEmpty()
+        map.size() == 0
+        map.keySet().empty
+        map.keySet().size() == 0
+        map.values().empty
+        map.values().size() == 0
+        map.entrySet().size() == 0
+        map.entrySet().empty
+    }
+
+    def 'when a RubyHash is not empty with a symbol key the Map should show the same key as a string and value'() {
+        given: 'An RubyHash with a value'
+        RubyHash rubyHash = ruby.evalScriptlet(KEY_VALUE_MAPPING)
+
+        when: 'A RubyHashMapDecorator wraps it'
+        RubyHashMapDecorator map = new RubyHashMapDecorator(rubyHash)
+
+        then: 'The decorator shows the key as a string'
+        !map.isEmpty()
+        map.size() == 1
+        !map.keySet().empty
+        map.keySet().size() == 1
+        map.containsKey(KEY)
+        map.keySet().contains(KEY)
+        map.values().size() == 1
+        !map.values().empty
+        map.values().contains(VALUE)
+        map.containsValue(VALUE)
+        map.entrySet().size() == 1
+        !map.entrySet().empty
+        map.get(KEY) == VALUE
+        map.keySet().iterator().next() == KEY
+        map.values().iterator().next() == VALUE
+    }
+
+    def 'when an entry is added to a RubyHashMapDecorator the RubyHash should contain the value afterwards'() {
+        given: 'An empty RubyHash'
+        RubyHash rubyHash = ruby.evalScriptlet(CREATE_EMPTY_RUBY_HASH)
+        RubyHashMapDecorator map = new RubyHashMapDecorator(rubyHash)
+
+        when: 'a single key value pair is added to the RubyHashMapDecorator'
+        map.put(KEY, VALUE)
+
+        then: 'The key is visible in both the RubyHashMapDecorator as well as the RubyHash'
+        map.get(KEY) == VALUE
+        ruby.evalScriptlet('$ruby_hash[:key]') == RubyString.newString(ruby, VALUE)
+    }
+
+    def 'when an entry is removed from a RubyHashMapDecorator it should be removed from the RubyHash as well'() {
+        given: 'An RubyHash with a single key value pair'
+        RubyHash rubyHash = ruby.evalScriptlet(KEY_VALUE_MAPPING)
+        RubyHashMapDecorator map = new RubyHashMapDecorator(rubyHash)
+
+        when: 'The key is removed'
+        map.remove(KEY)
+
+        then: 'The RubyHash and the RubyHashMapDecorator are empty'
+        map.isEmpty()
+        rubyHash.isEmpty()
+    }
+
+    def 'when multiple values are added via putAll they are all visible in the RubyHashMapDecorator'() {
+        given: 'An empty RubyHash and a RubyHashMapDecorator that wraps it'
+        RubyHash rubyHash = ruby.evalScriptlet(CREATE_EMPTY_RUBY_HASH)
+        RubyHashMapDecorator map = new RubyHashMapDecorator(rubyHash)
+
+        when: 'a collection of key value pairs is added to the RubyHashMapDecorator'
+        map.putAll(['A': VALUE_B, 'C': VALUE_D])
+
+        then: 'the RubyHash and the RubyHashMapDecorator both contain all key pair value pairs'
+        map.get(A) == VALUE_B
+        map.get('C') == VALUE_D
+        ruby.evalScriptlet('$ruby_hash[:A]') == RubyString.newString(ruby, VALUE_B)
+        ruby.evalScriptlet('$ruby_hash[:C]') == RubyString.newString(ruby, VALUE_D)
+    }
+
+    def 'when a string value beginning with a colon is added to a RubyHashMapDecorator a symbol value is added to the RubyHash'() {
+        given: 'An empty RubyHash and a RubyHashMapDecorator that wraps it'
+        RubyHash rubyHash = ruby.evalScriptlet(CREATE_EMPTY_RUBY_HASH)
+        RubyHashMapDecorator map = new RubyHashMapDecorator(rubyHash)
+
+        when: 'a string beginning with a colon is added as value to the RubyHashMapDecorator'
+        map.put('format', ':short')
+
+        then: 'The RubyHash contains a symbol as value'
+        ruby.evalScriptlet('$ruby_hash[:format]') == ruby.getSymbolTable().getSymbol('short')
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/GistMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/GistMacro.java
@@ -19,7 +19,7 @@ public class GistMacro extends BlockMacroProcessor {
        		"<script src=\"https://gist.github.com/"+target+".js\"></script>\n" + 
        		"</div>"; 
        
-       return createBlock(parent, "pass", Arrays.asList(content), attributes, this.getConfig());
+       return createBlock(parent, "pass", Arrays.asList(content), attributes);
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -7,6 +7,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import java.io.BufferedReader;
@@ -583,6 +584,26 @@ public class WhenJavaExtensionIsRegistered {
         assertNotNull(link);
         assertThat(link.attr("href"), is("gittutorial.html"));
 
+    }
+
+    @Test
+    public void an_inline_macro_as_instance_extension_should_not_be_executed_when_regexp_is_set_and_does_not_match() {
+
+        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put("regexp", "man(?:page)?:(ThisDoesNotMatch)\\[(.*?)\\]");
+
+        ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
+        javaExtensionRegistry.inlineMacro(inlineMacroProcessor);
+
+        String content = asciidoctor.renderFile(
+                classpath.getResource("sample-with-man-link.ad"),
+                options().toFile(false).get());
+
+        Document doc = Jsoup.parse(content, "UTF-8");
+        Element link = doc.getElementsByTag("a").first();
+        assertNull(link);
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -43,11 +43,13 @@ ext {
   asciidoctorPdfGemVersion = project(':asciidoctorj-pdf').version.replace('-', '.')
   asciidoctorDiagramGemVersion = project(':asciidoctorj-diagram').version.replace('-', '.')
   coderayGemVersion = '1.1.0'
+  groovyVersion = '2.1.8'
   erubisGemVersion = '2.7.0'
   hamlGemVersion = '4.0.5'
   openUriCachedGemVersion = '0.0.5'
   prawnGemVersion = '1.2.1'
   slimGemVersion = '2.0.3'
+  spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.4'
   tiltGemVersion = '2.0.1'
   ttfunkGemVersion = '1.2.2'
@@ -62,6 +64,7 @@ subprojects {
   // NOTE applying Java plugin changes the status; take steps to preserve value
   def _status = status
   apply plugin: 'java'
+  apply plugin: 'groovy'
   status = _status
 
   // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle
@@ -90,6 +93,14 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
   dependencies {
     testCompile "junit:junit:$junitVersion"
     testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
+    testCompile("org.spockframework:spock-core:$spockVersion") {
+      exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+    testCompile "org.codehaus.groovy:groovy-all:$groovyVersion"
+  }
+  apply plugin: 'codenarc'
+  codenarc {
+    configFile = rootProject.file('config/codenarc/codenarc.groovy')
   }
 
   test {

--- a/config/codenarc/codenarc.groovy
+++ b/config/codenarc/codenarc.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ruleset {
+    ruleset('rulesets/basic.xml') {
+        exclude 'EmptyCatchBlock'
+        exclude 'EmptyMethod'
+    }
+    ruleset('rulesets/imports.xml') {
+        exclude 'MisorderedStaticImports'
+    }
+    ruleset('rulesets/naming.xml') {
+        exclude 'PropertyName'
+        'ClassName' {
+            regex = '^[A-Z][a-zA-Z0-9]*$'
+        }
+        'FieldName' {
+            finalRegex = '^_?[a-z][a-zA-Z0-9]*$'
+            staticFinalRegex = '^[A-Z][A-Z_0-9]*$'
+        }
+        'MethodName' {
+            regex = '^[a-z][a-zA-Z0-9_ ]*$'
+        }
+        'VariableName' {
+            finalRegex = '^_?[a-z][a-zA-Z0-9]*$'
+        }
+    }
+    ruleset('rulesets/unused.xml')
+    ruleset('rulesets/exceptions.xml')
+    ruleset('rulesets/logging.xml')
+    ruleset('rulesets/braces.xml') {
+        exclude 'IfStatementBraces'
+    }
+    ruleset('rulesets/size.xml')
+    ruleset('rulesets/junit.xml')
+    ruleset('rulesets/unnecessary.xml') {
+        // UnnecessaryGetter rule does not work correct if there are methods like getRole() and isRole()
+        exclude 'UnnecessaryGetter'
+    }
+    ruleset('rulesets/dry.xml')
+    ruleset('rulesets/design.xml')
+}


### PR DESCRIPTION
Currently the extension config is held redundantly in the Ruby part and in the Java part of an extension.
This leads to problems that config properties set in the Ruby part do not appear in the Java part and vice versa.
You can see the problem if you change the regular expression in the current test for an inline macro processor so that the extension should _not_ be applied. 
But it applies nevertheless because the regular expression does not translate into the Ruby part and therefore only the name is used.

This PR invents a RubyHashMapDecorator that wraps a RubyHash and decorates a `Map<String, Object>` around it, so that the `@config` member of the Ruby extension is also used in the Java part only with another view on it.