### PR TITLE
Test that TreeProcessor and BlockMacroProcessor can be used together

### DIFF
--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
@@ -19,27 +19,30 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {
 
     @Override
     public DocumentRuby process(DocumentRuby document) {
-
-    	this.document = document;
-    	
-        final List<AbstractBlock> blocks = this.document.blocks();
-
-        for (int i = 0; i < blocks.size(); i++) {
-            final AbstractBlock currentBlock = blocks.get(i);
-            if(currentBlock instanceof Block) {
-                Block block = (Block)currentBlock;
-                List<String> lines = block.lines();
-                if (lines.size() > 0 && lines.get(0).startsWith("$")) {
-                    blocks.set(
-                            i, convertToTerminalListing(block));
-                            
-                }
-            }
-        }
-        
+        this.document = document;
+        processBlock((AbstractBlock) this.document);
         return this.document;
     }
 
+    private void processBlock(AbstractBlock block) {
+
+        List<AbstractBlock> blocks = block.getBlocks();
+
+        for (int i = 0; i < blocks.size(); i++) {
+            final AbstractBlock currentBlock = blocks.get(i);
+            if(currentBlock instanceof AbstractBlock) {
+                if ("paragraph".equals(currentBlock.getContext())) {
+                    List<String> lines = ((Block) currentBlock).lines();
+                    if (lines.size() > 0 && lines.get(0).startsWith("$")) {
+                        blocks.set(i, convertToTerminalListing((Block) currentBlock));
+                    }
+                } else {
+                    // It's not a paragraph, so recursively descent into the child node
+                    processBlock(currentBlock);
+                }
+            }
+        }
+    }
     public Block convertToTerminalListing(Block block) {
 
         Map<String, Object> attributes = block.getAttributes();

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
@@ -55,7 +55,7 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {
             if (line.startsWith("$")) {
                 resultLines.append("<span class=\"command\">")
                         .append(line.substring(2, line.length()))
-                        .append("</command");
+                        .append("</span>");
             } else {
                 resultLines.append(line);
             }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -392,6 +392,32 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
+    public void a_treeprocessor_and_blockmacroprocessor_should_be_executed_in_document() {
+
+        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+
+        javaExtensionRegistry.treeprocessor(TerminalCommandTreeprocessor.class);
+        javaExtensionRegistry.blockMacro("gist", GistMacro.class);
+
+        String content = asciidoctor.renderFile(
+                classpath.getResource("sample-with-terminal-command-and-gist-macro.ad"),
+                options().toFile(false).get());
+
+        Document doc = Jsoup.parse(content, "UTF-8");
+
+        Element contentElement = doc.getElementsByAttributeValue("class", "command").first();
+        assertThat(contentElement.text(), is("echo \"Hello, World!\""));
+
+        contentElement = doc.getElementsByAttributeValue("class", "command").last();
+        assertThat(contentElement.text(), is("gem install asciidoctor"));
+
+        Element script = doc.getElementsByTag("script").first();
+
+        assertThat(script.attr("src"), is("https://gist.github.com/42.js"));
+
+    }
+
+    @Test
     public void a_treeprocessor_as_string_should_be_executed_in_document() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();

--- a/asciidoctorj-core/src/test/resources/sample-with-terminal-command-and-gist-macro.ad
+++ b/asciidoctorj-core/src/test/resources/sample-with-terminal-command-and-gist-macro.ad
@@ -1,0 +1,15 @@
+= Hello World
+
+
+== First
+
+$ echo "Hello, World!"
+
+== Section
+
+$ gem install asciidoctor
+
+== Third
+
+.My Gist
+gist::42[]


### PR DESCRIPTION
In the discussion around #267 @pmagon mentioned that he was not able to get a TreeProcessor running together with a BlockMacroProcessor.
This PR adds a test that proves that this configuration works.

Additionally the existing TerminalCommandTreeprocessor was changed to also convert terminal commands that are nested in sections.