### PR TITLE
Fixes #299: Removed rerouting of System.out and System.err to JUL

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -33,27 +33,6 @@ import java.util.logging.Logger;
 
 public class JRubyAsciidoctor implements Asciidoctor {
 
-    static {
-
-        final Logger logger = Logger.getLogger("Asciidoctor");
-        final LoggerOutputStream out = new LoggerOutputStream(logger);
-        System.setOut(new PrintStream(out));
-        System.setErr(new PrintStream(out));
-
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                try { // can log or not something depending logger is already closed or not, best is to call it manually at the end of main if possible
-                    out.flush();
-                } catch (final IOException e) {
-                    // no-op
-                }
-            }
-        });
-
-    }
-
-
     private static final Logger logger = Logger.getLogger(JRubyAsciidoctor.class.getName());
 
     private static final String GEM_PATH = "GEM_PATH";
@@ -622,56 +601,4 @@ public class JRubyAsciidoctor implements Asciidoctor {
         return new Document(this.asciidoctorModule.load(file.getAbsolutePath(), rubyHash), this.rubyRuntime);
 
     }
-
-    static class LoggerOutputStream extends OutputStream {
-        private final StringBuilder builder = new StringBuilder();
-        private Logger logger;
-
-        public LoggerOutputStream(Logger logger) {
-            this.logger = logger;
-        }
-
-        private boolean doLog() {
-            synchronized(this) {
-                if (builder.length() > 0) {
-                    String msg = builder.toString();
-                    logger.info("My message: "+msg);
-                    if(msg.contains("WARNING")) {
-                        logger.logp(Level.WARNING, "", "", msg);
-                    } else {
-                        if(msg.contains("FAILED")) {
-                            logger.logp(Level.SEVERE, "", "", msg);
-                        } else {
-                            logger.logp(Level.FINE, "", "", msg);
-                        }
-                    }
-                    builder.setLength(0);
-                    return true;
-                }
-                return false;
-            }
-        }
-
-        @Override
-        public void write(int b) throws IOException {
-            if (b == '\n') {
-                if (!doLog()) {
-                    logger.info("");
-                }
-            } else {
-                builder.append((char) b);
-            }
-        }
-
-        @Override
-        public void flush() throws IOException {
-            doLog();
-        }
-
-        @Override
-        public void close() throws IOException {
-            doLog();
-        }
-    };
-
 }


### PR DESCRIPTION
The current solution to capture output from Asciidoctor and route it to a Java logger leads to infinite recursions and therefore StackOverflows when a ConsoleHandler is configured, which is the default in most configurations.
This problem is not reproducable with gradle as it replaces the normal System.out and System.err fields with own streams.
As Dan pointed out in #299 Asciidoctor will provide another solution that allows for capturing the output without having to read from System.out.
Therefore this PR completely removes capturing System.out and .err without replacement.