### PR TITLE
Fixes #302: Pass config options defined in a Java BlockProcessor cons…

### DIFF
--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -664,7 +664,7 @@ public class WhenJavaExtensionIsRegistered {
                 .safe(SafeMode.UNSAFE).get();
 
         asciidoctor.unregisterAllExtensions();
-        asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"),options);
+        asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options);
 
         File renderedFile = new File(testFolder.getRoot(), "rendersample.html");
         Document doc = Jsoup.parse(renderedFile, "UTF-8");
@@ -722,6 +722,23 @@ public class WhenJavaExtensionIsRegistered {
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-yell-block.ad"),
                 options().toFile(false).get());
+        Document doc = Jsoup.parse(content, "UTF-8");
+        Elements elements = doc.getElementsByClass("paragraph");
+        assertThat(elements.size(), is(1));
+        assertThat(elements.get(0).text(), is("THE TIME IS NOW. GET A MOVE ON."));
+
+    }
+
+    @Test
+    public void a_block_processor_should_be_executed_when_registered_listing_block_is_found_in_document() throws IOException {
+
+        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+
+        javaExtensionRegistry.block("yell", YellStaticListingBlock.class);
+        String content = asciidoctor.renderFile(
+                classpath.getResource("sample-with-yell-listing-block.ad"),
+                options().toFile(false).get());
+
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
         assertThat(elements.size(), is(1));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticListingBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticListingBlock.java
@@ -1,24 +1,24 @@
 package org.asciidoctor.extension;
 
+import org.asciidoctor.ast.AbstractBlock;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
-
-public class YellStaticBlock extends BlockProcessor {
+public class YellStaticListingBlock extends BlockProcessor {
 
 	private static Map<String, Object> configs = new HashMap<String, Object>() {{
-		put("contexts", Arrays.asList(":paragraph"));
+		put("contexts", Arrays.asList(":listing"));
         put("content_model", ":simple");
 	}};
 
-    public YellStaticBlock(String name) {
+    public YellStaticListingBlock(String name) {
         super(name, configs);
     }
 
-    public YellStaticBlock(String name, Map<String, Object> config) {
+    public YellStaticListingBlock(String name, Map<String, Object> config) {
         super(name, configs);
     }
 

--- a/asciidoctorj-core/src/test/resources/sample-with-yell-listing-block.ad
+++ b/asciidoctorj-core/src/test/resources/sample-with-yell-listing-block.ad
@@ -1,0 +1,4 @@
+[yell]
+----
+The time is now. Get a move on.
+----


### PR DESCRIPTION
…tructor to the Ruby part when registered as a class.

See #302 for details.

Changed also the API a bit by requiring that a BlockProcessor registered as a class contains a constructor with only one String parameter.
