### PR TITLE
Added javadoc for extension config options

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockProcessor.java
@@ -7,6 +7,124 @@ import org.asciidoctor.ast.AbstractBlock;
 
 public abstract class BlockProcessor extends Processor {
 
+    /**
+     * This value is used as the config option key when defining the block type
+     * a Processor should process.
+     * Its value must be a list of String constants:
+     *
+     * <p>Example to make a BlockProcessor work on listings and examples named foo:
+     * <pre>
+     * <verbatim>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put(CONTEXTS, Arrays.asList(CONTEXT_EXAMPLE, CONTEXT_LISTING));
+     * BlockProcessor blockProcessor = new BlockProcessor("foo", config);
+     * asciidoctor.javaExtensionRegistry().block(blockProcessor);
+     * </verbatim>
+     * </pre>
+     * </p>
+     */
+    public static final String CONTEXTS = "contexts";
+
+    /**
+     * Predefined constant for making a BlockProcessor work on open blocks.
+     * When passed with the {@link #CONTEXTS} config option this BlockProcessor works on open blocks:
+     * <pre>
+     * [foo]
+     * --
+     * An open block can be an anonymous container,
+     * or it can masquerade as any other block.
+     * --
+     * </pre>
+     */
+    public static final String CONTEXT_OPEN = ":open";
+
+    /**
+     * Predefined constant for making a BlockProcessor work on example blocks.
+     * When passed with the {@link #CONTEXTS} config option this BlockProcessor works on example blocks:
+     * <pre>
+     * [foo]
+     * ====
+     * This is just a neat example.
+     * ====
+     * </pre>
+     */
+    public static final String CONTEXT_EXAMPLE = ":example";
+
+    /**
+     * Predefined constant for making a BlockProcessor work on sidebar blocks.
+     * When passed with the {@link #CONTEXTS} config option this BlockProcessor works on sidebar blocks:
+     * <pre>
+     * [foo]
+     * ****
+     * This is just a sidebar.
+     * ****
+     * </pre>
+     */
+    public static final String CONTEXT_SIDEBAR = ":sidebar";
+
+    /**
+     * Predefined constant for making a BlockProcessor work on literal blocks.
+     * When passed with the {@link #CONTEXTS} config option this BlockProcessor works on literal blocks:
+     * <pre>
+     * [foo]
+     * ....
+     * This is just a literal block.
+     * ....
+     * </pre>
+     */
+    public static final String CONTEXT_LITERAL = ":literal";
+
+    /**
+     * Predefined constant for making a BlockProcessor work on source blocks.
+     * When passed with the {@link #CONTEXTS} config option this BlockProcessor works on source blocks:
+     * <pre>
+     * [foo]
+     * ....
+     * This is just a literal block.
+     * ....
+     * </pre>
+     */
+    public static final String CONTEXT_LISTING = ":listing";
+
+    /**
+     * Predefined constant for making a BlockProcessor work on quote blocks.
+     * When passed with the {@link #CONTEXTS} config option this BlockProcessor works on quote blocks:
+     * <pre>
+     * [foo]
+     * ____
+     * To be or not to be...
+     * ____
+     * </pre>
+     */
+    public static final String CONTEXT_QUOTE = ":quote";
+
+    /**
+     * Predefined constant for making a BlockProcessor work on passthrough blocks.
+     * When passed with the {@link #CONTEXTS} config option this BlockProcessor works on passthrough blocks:
+     *
+     * <pre>
+     * [foo]
+     * ++++
+     * &lt;h1&gt;Big text&lt;/h1&gt;
+     * ++++
+     * </pre>
+     */
+    public static final String CONTEXT_PASS = ":pass";
+
+    /**
+     * Predefined constant for making a BlockProcessor work on paragraph blocks.
+     * This is also the default for the {@link #CONTEXTS} config option if no other context is given.
+     * When passed with the {@link #CONTEXTS} config option this BlockProcessor works on paragraph blocks:
+     *
+     * <pre>
+     * [foo]
+     * Please process this paragraph.
+     *
+     * And don't process this.
+     * </pre>
+     */
+    public static final String CONTEXT_PARAGRAPH = ":paragraph";
+
     protected String name;
     
     public BlockProcessor(String name) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
@@ -16,7 +16,61 @@ import java.util.Map;
 
 public class Processor {
 
-	protected RubyHash config;
+    /**
+     * This value is used as the config option key to configure how Asciidoctor should treat blocks created by
+     * this Processor.
+     * Its value must be a String constant.
+     *
+     * <p>Example to Asciidoctor know that a BlockProcessor creates zero or more child blocks:
+     * <pre>
+     * <verbatim>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put(CONTENT_MODEL, CONTENT_MODEL_COMPOUND);
+     * BlockProcessor blockProcessor = new BlockProcessor("foo", config);
+     * asciidoctor.javaExtensionRegistry().block(blockProcessor);
+     * </verbatim>
+     * </pre>
+     * </p>
+     */
+    public static final String CONTENT_MODEL = "content_model";
+
+    /**
+     * Predefined constant to let Asciidoctor know that this BlockProcessor creates zero or more child blocks.
+     */
+    public static final String CONTENT_MODEL_COMPOUND = ":compound";
+
+    /**
+     * Predefined constant to let Asciidoctor know that this BlockProcessor creates simple paragraph content.
+     */
+    public static final String CONTENT_MODEL_SIMPLE =":simple";
+
+    /**
+     * Predefined constant to let Asciidoctor know that this BlockProcessor creates literal content.
+     */
+    public static final String CONTENT_MODEL_VERBATIM =":verbatim";
+
+    /**
+     * Predefined constant to make Asciidoctor pass through the content unprocessed.
+     */
+    public static final String CONTENT_MODEL_RAW =":raw";
+
+    /**
+     * Predefined constant to make Asciidoctor drop the content.
+     */
+    public static final String CONTENT_MODEL_SKIP =":skip";
+
+    /**
+     * Predefined constant to make Asciidoctor not expect any content.
+     */
+    public static final String CONTENT_MODEL_EMPTY =":empty";
+
+    /**
+     * Predefined constant to make Asciidoctor parse content as attributes.
+     */
+    public static final String CONTENT_MODEL_ATTRIBUTES =":attributes";
+
+
+    protected RubyHash config;
     protected Ruby rubyRuntime;
 
     public Processor(Map<String, Object> config) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -715,8 +715,8 @@ public class WhenJavaExtensionIsRegistered {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> config = new HashMap<String, Object>();
-        config.put("contexts", Arrays.asList(":paragraph"));
-        config.put("content_model", ":simple");
+        config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_PARAGRAPH));
+        config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
         javaExtensionRegistry.block(yellBlock);
         String content = asciidoctor.renderFile(
@@ -739,6 +739,27 @@ public class WhenJavaExtensionIsRegistered {
                 classpath.getResource("sample-with-yell-listing-block.ad"),
                 options().toFile(false).get());
 
+        Document doc = Jsoup.parse(content, "UTF-8");
+        Elements elements = doc.getElementsByClass("paragraph");
+        assertThat(elements.size(), is(1));
+        assertThat(elements.get(0).text(), is("THE TIME IS NOW. GET A MOVE ON."));
+
+    }
+
+    @Test
+    public void a_block_processor_instance_should_be_executed_when_registered_listing_block_is_found_in_document()
+            throws IOException {
+
+        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_LISTING));
+        config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
+        YellBlock yellBlock = new YellBlock("yell", config);
+        javaExtensionRegistry.block(yellBlock);
+        String content = asciidoctor.renderFile(
+                classpath.getResource("sample-with-yell-listing-block.ad"),
+                options().toFile(false).get());
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
         assertThat(elements.size(), is(1));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticBlock.java
@@ -10,8 +10,8 @@ import org.asciidoctor.ast.AbstractBlock;
 public class YellStaticBlock extends BlockProcessor {
 
 	private static Map<String, Object> configs = new HashMap<String, Object>() {{
-		put("contexts", Arrays.asList(":paragraph"));
-        put("content_model", ":simple");
+		put(CONTEXTS, Arrays.asList(CONTEXT_PARAGRAPH));
+        put(CONTENT_MODEL, CONTENT_MODEL_SIMPLE);
 	}};
 
     public YellStaticBlock(String name) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticListingBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticListingBlock.java
@@ -10,8 +10,8 @@ import java.util.Map;
 public class YellStaticListingBlock extends BlockProcessor {
 
 	private static Map<String, Object> configs = new HashMap<String, Object>() {{
-		put("contexts", Arrays.asList(":listing"));
-        put("content_model", ":simple");
+        put(CONTEXTS, Arrays.asList(CONTEXT_LISTING));
+        put(CONTENT_MODEL, CONTENT_MODEL_SIMPLE);
 	}};
 
     public YellStaticListingBlock(String name) {


### PR DESCRIPTION
This PR is at the moment WIP!

It adds Javadoc for some config options for processors.

I added constants for `:contexts` config key and the values mentioned in (1).
I guess that this config parameter only makes sense with BlockProcessors.
If the location of the constants is correct I think I got it not too bad.

I added constants for `:content_model` and the values mentioned also mentioned in (1) to Processor.
I think this option makes also sense at least for a BlockMacro.
But I am very unsure about my comments and would like to get some feedback about the descriptions because I did not fully understand them yet.

(1) https://github.com/asciidoctor/asciidoctor-documentation/issues/30 to BlockProcessor.

(While typing this I always got the constant names incorrectly, so IMO it absolutely makes sense to add constants for them :wink:)