### PR TITLE
Adapted processor instantiation to same way as a BlockProcessor is in…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
@@ -79,13 +79,21 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
             // The extension config in the Java extension is just a view on the @config member of the Ruby part
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash)getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
-            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, args, Block.NULL_BLOCK);
+            // First create only the instance passing in the name
             setProcessor(
                     getProcessorClass()
-                            .getConstructor(String.class, Map.class)
+                            .getConstructor(String.class)
                             .newInstance(
-                                    RubyUtils.rubyToJava(getRuntime(), args[0], String.class),
-                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
+                                    RubyUtils.rubyToJava(getRuntime(), args[0], String.class)));
+
+            // Then create the config hash that may contain config options defined in the Java constructor
+            RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(context.getRuntime(), getProcessor().getConfig());
+
+            // Initialize the Ruby part and pass in the config options
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[] {args[0], config}, Block.NULL_BLOCK);
+
+            // Reset the Java config options to the decorated Ruby hash, so that Java and Ruby work on the same config map
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         }
 
         return null;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
@@ -79,12 +79,21 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
             // The extension config in the Java extension is just a view on the @config member of the Ruby part
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
-            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[0], Block.NULL_BLOCK);
+            // First create only the instance passing in the block name
             setProcessor(
                     getProcessorClass()
-                            .getConstructor(Map.class)
-                            .newInstance(
-                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
+                            .getConstructor()
+                            .newInstance());
+
+            // Then create the config hash that may contain config options defined in the Java constructor
+            RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(context.getRuntime(), getProcessor().getConfig());
+
+            // Initialize the Ruby part and pass in the config options
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[] {config}, Block.NULL_BLOCK);
+
+            // Reset the Java config options to the decorated Ruby hash, so that Java and Ruby work on the same config map
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
+
         }
 
         return null;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
@@ -80,12 +80,20 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
             // The extension config in the Java extension is just a view on the @config member of the Ruby part
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
-            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[0], Block.NULL_BLOCK);
+            // First create only the instance passing in the block name
             setProcessor(
                     getProcessorClass()
-                            .getConstructor(Map.class)
-                            .newInstance(
-                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
+                            .getConstructor()
+                            .newInstance());
+
+            // Then create the config hash that may contain config options defined in the Java constructor
+            RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(context.getRuntime(), getProcessor().getConfig());
+
+            // Initialize the Ruby part and pass in the config options
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[] {config}, Block.NULL_BLOCK);
+
+            // Reset the Java config options to the decorated Ruby hash, so that Java and Ruby work on the same config map
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         }
 
         return null;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
@@ -99,13 +99,21 @@ public class InlineMacroProcessorProxy extends AbstractMacroProcessorProxy<Inlin
             // because the accessor is routed to the Java Processor.config
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
-            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, args, Block.NULL_BLOCK);
+            // First create only the instance passing in the block name
             setProcessor(
                     getProcessorClass()
-                            .getConstructor(String.class, Map.class)
+                            .getConstructor(String.class)
                             .newInstance(
-                                    RubyUtils.rubyToJava(getRuntime(), args[0], String.class),
-                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
+                                    RubyUtils.rubyToJava(getRuntime(), args[0], String.class)));
+
+            // Then create the config hash that may contain config options defined in the Java constructor
+            RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(context.getRuntime(), getProcessor().getConfig());
+
+            // Initialize the Ruby part and pass in the config options
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[] {args[0], config}, Block.NULL_BLOCK);
+
+            // Reset the Java config options to the decorated Ruby hash, so that Java and Ruby work on the same config map
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         }
         return null;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
@@ -78,12 +78,20 @@ public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
             // The extension config in the Java extension is just a view on the @config member of the Ruby part
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
-            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[0], Block.NULL_BLOCK);
+            // First create only the instance passing in the block name
             setProcessor(
                     getProcessorClass()
-                            .getConstructor(Map.class)
-                            .newInstance(
-                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
+                            .getConstructor()
+                            .newInstance());
+
+            // Then create the config hash that may contain config options defined in the Java constructor
+            RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(context.getRuntime(), getProcessor().getConfig());
+
+            // Initialize the Ruby part and pass in the config options
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[] {config}, Block.NULL_BLOCK);
+
+            // Reset the Java config options to the decorated Ruby hash, so that Java and Ruby work on the same config map
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         }
         return null;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
@@ -78,12 +78,20 @@ public class TreeprocessorProxy extends AbstractProcessorProxy<Treeprocessor> {
             // The extension config in the Java extension is just a view on the @config member of the Ruby part
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
-            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[0], Block.NULL_BLOCK);
+            // First create only the instance passing in the block name
             setProcessor(
                     getProcessorClass()
-                            .getConstructor(Map.class)
-                            .newInstance(
-                                    new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG))));
+                            .getConstructor()
+                            .newInstance());
+
+            // Then create the config hash that may contain config options defined in the Java constructor
+            RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(context.getRuntime(), getProcessor().getConfig());
+
+            // Initialize the Ruby part and pass in the config options
+            Helpers.invokeSuper(context, this, getMetaClass(), METHOD_NAME_INITIALIZE, new IRubyObject[]{config}, Block.NULL_BLOCK);
+
+            // Reset the Java config options to the decorated Ruby hash, so that Java and Ruby work on the same config map
+            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         }
         return null;
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ChangeAttributeValuePreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ChangeAttributeValuePreprocessor.java
@@ -6,6 +6,8 @@ import java.util.Map;
 
 public class ChangeAttributeValuePreprocessor extends Preprocessor {
 
+	public ChangeAttributeValuePreprocessor() {}
+
 	public ChangeAttributeValuePreprocessor(Map<String, Object> config) {
 		super(config);
 	}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/CustomFooterPostProcessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/CustomFooterPostProcessor.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 public class CustomFooterPostProcessor extends Postprocessor {
 
+    public CustomFooterPostProcessor() {}
+
     public CustomFooterPostProcessor(Map<String, Object> config) {
         super(config);
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/GistMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/GistMacro.java
@@ -8,6 +8,10 @@ import org.asciidoctor.ast.Block;
 
 public class GistMacro extends BlockMacroProcessor {
 
+    public GistMacro(String macroName) {
+        super(macroName);
+    }
+
     public GistMacro(String macroName, Map<String, Object> config) {
         super(macroName, config);
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/HasMoreLinesPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/HasMoreLinesPreprocessor.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertThat;
 
 public class HasMoreLinesPreprocessor extends Preprocessor {
 
+	public HasMoreLinesPreprocessor() {}
+
 	public HasMoreLinesPreprocessor(Map<String, Object> config) {
 		super(config);
 	}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
@@ -7,6 +7,10 @@ import java.util.Map;
 
 public class ManpageMacro extends InlineMacroProcessor {
 
+    public ManpageMacro(String macroName) {
+        super(macroName);
+    }
+
     public ManpageMacro(String macroName, Map<String, Object> config) {
         super(macroName, config);
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NextLineEmptyPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NextLineEmptyPreprocessor.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertThat;
 
 public class NextLineEmptyPreprocessor extends Preprocessor {
 
+	public NextLineEmptyPreprocessor() {}
+
 	public NextLineEmptyPreprocessor(Map<String, Object> config) {
 		super(config);
 	}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NumberLinesPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NumberLinesPreprocessor.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertThat;
 
 public class NumberLinesPreprocessor extends Preprocessor {
 
+	public NumberLinesPreprocessor() {}
+
 	public NumberLinesPreprocessor(Map<String, Object> config) {
 		super(config);
 	}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
@@ -12,7 +12,9 @@ import java.util.Map;
 public class TerminalCommandTreeprocessor extends Treeprocessor {
 
 	private DocumentRuby document;
-	
+
+    public TerminalCommandTreeprocessor() {}
+
     public TerminalCommandTreeprocessor(Map<String, Object> config) {
         super(config);
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/UriIncludeProcessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/UriIncludeProcessor.java
@@ -12,6 +12,8 @@ import org.asciidoctor.ast.DocumentRuby;
 
 public class UriIncludeProcessor extends IncludeProcessor {
 
+    public UriIncludeProcessor() {}
+
     public UriIncludeProcessor(Map<String, Object> config) {
         super(config);
     }


### PR DESCRIPTION
…stantiated.

https://github.com/asciidoctor/asciidoctorj/commit/009d94887d333139ff8264242e07984fe90bd105 changed the way that BlockProcessors are instantiated if they are registered as classes.
This PR repeats the same for all other processor classes.

Thereby all processor classes now registered as a class now require a constructor without a config map, that is either only with a String or a no-arg constructor.
IMO it does not make much sense to always invoke a constructor with an empty or null config map.