### PR TITLE
Fixes #307. Upgraded slim to 3.0.3 (was 2.1.0)

### DIFF
--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenSlimTemplatesAreUsed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenSlimTemplatesAreUsed.groovy
@@ -1,0 +1,39 @@
+package org.asciidoctor
+
+import org.asciidoctor.internal.JRubyAsciidoctor
+import org.asciidoctor.util.ClasspathResources
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.junit.Rule
+import spock.lang.Specification
+
+import static org.asciidoctor.OptionsBuilder.options
+
+class WhenSlimTemplatesAreUsed extends Specification {
+
+    @Rule
+    ClasspathResources classpath = new ClasspathResources()
+
+    Asciidoctor asciidoctor = JRubyAsciidoctor.create()
+
+    def 'the slim paragraph template should be used when rendering a document inline'() {
+        given:
+        Options options = options().templateDir(classpath.getResource('src/custom-backends/slim')).toFile(false).headerFooter(false).get()
+
+        String sourceDocument = '''
+= Hello World
+
+This will be replaced by static content from the template
+'''
+
+        when:
+        String renderContent = asciidoctor.render(sourceDocument, options)
+
+        then:
+        Document doc = Jsoup.parse(renderContent, 'UTF-8')
+        Element paragraph = doc.select('p').first()
+        paragraph.text() == 'This is static content'
+    }
+
+}

--- a/asciidoctorj-core/src/test/resources/src/custom-backends/slim/block_paragraph.html.slim
+++ b/asciidoctorj-core/src/test/resources/src/custom-backends/slim/block_paragraph.html.slim
@@ -1,0 +1,1 @@
+p This is static content

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
   hamlGemVersion = '4.0.5'
   openUriCachedGemVersion = '0.0.5'
   prawnGemVersion = '1.2.1'
-  slimGemVersion = '2.1.0'
+  slimGemVersion = '3.0.3'
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.4'
   tiltGemVersion = '2.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
   hamlGemVersion = '4.0.5'
   openUriCachedGemVersion = '0.0.5'
   prawnGemVersion = '1.2.1'
-  slimGemVersion = '2.0.3'
+  slimGemVersion = '2.1.0'
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.4'
   tiltGemVersion = '2.0.1'


### PR DESCRIPTION
As Asciidoctor currently depends on sth slim 2.0.0-ish I chose to only upgrade to slim 2.1.0.
I added only a very basic test to see if the slim template is used at all.
It would probably be better to somehow check that really slim 2.1.0 is used...