### PR TITLE
Added Arquillian extension that creates, destroys  and injects Asciid…

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -1,3 +1,9 @@
+configurations {
+  arquillianExtension
+  testCompile.extendsFrom arquillianExtension
+}
+
+
 dependencies {
   compile "org.jruby:jruby-complete:$jrubyVersion"
   compile "com.beust:jcommander:$jcommanderVersion"
@@ -15,6 +21,12 @@ dependencies {
   testCompile "com.google.guava:guava:$guavaVersion"
   testCompile "org.jsoup:jsoup:$jsoupVersion"
   testCompile project(path: ':asciidoctorj-test-support', configuration: 'tests')
+
+  arquillianExtension "org.jboss.arquillian.container:arquillian-container-spi:$arquillianVersion"
+  arquillianExtension "org.jboss.arquillian.container:arquillian-container-test-spi:$arquillianVersion"
+  arquillianExtension "org.jboss.arquillian.container:arquillian-container-impl-base:$arquillianVersion"
+  arquillianExtension "org.jboss.arquillian.container:arquillian-container-test-impl-base:$arquillianVersion"
+  arquillianExtension "org.jboss.arquillian.junit:arquillian-junit-container:$arquillianVersion"
 }
 
 def gemFiles = fileTree(jruby.gemInstallDir) {
@@ -33,3 +45,15 @@ jrubyPrepareGems << {
 //jruby {
 //	execVersion = '1.7.20'
 //}
+
+task arquillianExtensionJar(type: Jar, dependsOn: testClasses) {
+  baseName = "arquillianExtension-${project.archivesBaseName}"
+  from sourceSets.test.output
+  include 'org/asciidoctor/arquillian/**/*'
+  include 'META-INF/services/*'
+}
+
+
+artifacts {
+  arquillianExtension arquillianExtensionJar
+}

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   testCompile "org.jsoup:jsoup:$jsoupVersion"
   testCompile project(path: ':asciidoctorj-test-support', configuration: 'tests')
 
+  arquillianExtension project(path: ':asciidoctorj-test-support', configuration: 'tests')
   arquillianExtension "org.jboss.arquillian.container:arquillian-container-spi:$arquillianVersion"
   arquillianExtension "org.jboss.arquillian.container:arquillian-container-test-spi:$arquillianVersion"
   arquillianExtension "org.jboss.arquillian.container:arquillian-container-impl-base:$arquillianVersion"

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenExtensionsAreRegisteredAsService.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenExtensionsAreRegisteredAsService.groovy
@@ -3,25 +3,32 @@ package org.asciidoctor.extension
 import org.asciidoctor.Asciidoctor
 import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
-import org.asciidoctor.internal.JRubyAsciidoctor
+import org.asciidoctor.arquillian.api.Unshared
 import org.asciidoctor.util.ClasspathResources
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 import spock.lang.Ignore
 import spock.lang.Specification
 
 import static org.asciidoctor.OptionsBuilder.options
 
+@RunWith(ArquillianSputnik)
 class WhenExtensionsAreRegisteredAsService extends Specification {
 
     static final String FILENAME_HTML = 'rendersample.html'
 
-    @Rule
-    ClasspathResources classpath = new ClasspathResources()
+    @ArquillianResource
+    ClasspathResources classpath
+
+    @ArquillianResource(Unshared)
+    Asciidoctor asciidoctor
 
     @Rule
     TemporaryFolder testFolder = new TemporaryFolder()
@@ -40,9 +47,6 @@ class WhenExtensionsAreRegisteredAsService extends Specification {
     @Ignore('Test is ignored because currently it is not possible to register two block extensions in same instance. This may require deep changes on Asciidoctor Extensions API')
     @Test
     def 'extensions should be correctly added'() throws IOException {
-
-        given:
-        Asciidoctor asciidoctor = JRubyAsciidoctor.create()
 
         when:
         //To avoid registering the same extension over and over for all tests, service is instantiated manually.
@@ -69,7 +73,7 @@ class WhenExtensionsAreRegisteredAsService extends Specification {
 
     }
 
-    def "the active TCCL when creatin the Asciidoctor instance should be used to load extensions"() {
+    def "the active TCCL when creating the Asciidoctor instance should be used to load extensions"() {
 
         when:
         URLClassLoader tccl1 = new URLClassLoader(classpath.getResource('serviceloadertest/1').toURI().toURL() as URL[])

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenExtensionsAreRegisteredAsService.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenExtensionsAreRegisteredAsService.groovy
@@ -10,7 +10,6 @@ import org.jboss.arquillian.test.api.ArquillianResource
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
@@ -30,8 +29,8 @@ class WhenExtensionsAreRegisteredAsService extends Specification {
     @ArquillianResource(Unshared)
     Asciidoctor asciidoctor
 
-    @Rule
-    TemporaryFolder testFolder = new TemporaryFolder()
+    @ArquillianResource
+    TemporaryFolder testFolder
 
     ClassLoader originalTCCL
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiated.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiated.java
@@ -29,25 +29,30 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.internal.AsciidoctorCoreException;
-import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.xml.sax.SAXException;
 
 import com.google.common.io.CharStreams;
 
+@RunWith(Arquillian.class)
 public class WhenAnAsciidoctorClassIsInstantiated {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
     @Test
     public void content_should_be_read_from_reader_and_written_to_writer() throws IOException, SAXException,

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiated.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiated.java
@@ -34,7 +34,6 @@ import org.asciidoctor.internal.AsciidoctorCoreException;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -48,8 +47,8 @@ public class WhenAnAsciidoctorClassIsInstantiated {
     @ArquillianResource
     private ClasspathResources classpath;
 
-    @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
+    @ArquillianResource
+    private TemporaryFolder testFolder;
 
     @ArquillianResource(Unshared.class)
     private Asciidoctor asciidoctor;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -13,15 +13,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.ast.AbstractBlock;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Section;
 import org.asciidoctor.internal.IOUtils;
-import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.util.ClasspathResources;
-import org.junit.Rule;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenAsciiDocIsRenderedToDocument {
 
     private static final String DOCUMENT = "= Document Title\n" + 
@@ -55,10 +58,11 @@ public class WhenAsciiDocIsRenderedToDocument {
             "\n" +
             "content";
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath = new ClasspathResources();
 
     @Test
     public void should_return_section_blocks() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -4,7 +4,6 @@ import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -19,8 +18,8 @@ public class WhenAsciidoctorLogsToConsole {
     @ArquillianResource
     private ClasspathResources classpath = new ClasspathResources();
 
-    @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
+    @ArquillianResource
+    private TemporaryFolder testFolder;
 
     @ArquillianResource(Unshared.class)
     private Asciidoctor asciidoctor;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -1,24 +1,29 @@
 package org.asciidoctor;
 
-import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 
 import static org.asciidoctor.OptionsBuilder.options;
 
+@RunWith(Arquillian.class)
 public class WhenAsciidoctorLogsToConsole {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath = new ClasspathResources();
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
     @Test
     public void shouldBeRedirectToAsciidoctorJLoggerSystem() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -29,8 +29,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 
-import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -38,19 +40,22 @@ import org.jsoup.select.Elements;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.xml.sax.SAXException;
 
 import com.google.common.io.CharStreams;
 
+@RunWith(Arquillian.class)
 public class WhenAttributesAreUsedInAsciidoctor {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath = new ClasspathResources();
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
     @Test
     public void qualified_http_url_inline_with_hide_uri_scheme_set() throws IOException {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -37,7 +37,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -51,8 +50,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @ArquillianResource
     private ClasspathResources classpath = new ClasspathResources();
 
-    @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
+    @ArquillianResource
+    private TemporaryFolder testFolder;
 
     @ArquillianResource(Unshared.class)
     private Asciidoctor asciidoctor;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenCustomTemplatesAreUsed.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenCustomTemplatesAreUsed.java
@@ -11,7 +11,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenCustomTemplatesAreUsed.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenCustomTemplatesAreUsed.java
@@ -4,20 +4,25 @@ import static org.asciidoctor.OptionsBuilder.options;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenCustomTemplatesAreUsed {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
-    
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource
+    private ClasspathResources classpath;
+
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
     
     @Test
     public void document_should_be_rendered_using_given_template_dir() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenDirectoriesWithAsciidocFilesAreScanned.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenDirectoriesWithAsciidocFilesAreScanned.java
@@ -10,11 +10,10 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.asciidoctor.arquillian.api.Shared;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -25,8 +24,8 @@ public class WhenDirectoriesWithAsciidocFilesAreScanned {
     @ArquillianResource
     private ClasspathResources classpath;
 
-	@ClassRule
-	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@ArquillianResource(Shared.class)
+	public TemporaryFolder temporaryFolder;
 	
 	@Test
 	public void only_asciidoc_files_should_be_returned() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenDirectoriesWithAsciidocFilesAreScanned.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenDirectoriesWithAsciidocFilesAreScanned.java
@@ -11,15 +11,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenDirectoriesWithAsciidocFilesAreScanned {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
 	@ClassRule
 	public static TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenDocumentHeaderIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenDocumentHeaderIsRequired.java
@@ -7,24 +7,29 @@ import static org.junit.Assert.assertThat;
 import java.util.List;
 import java.util.Map;
 
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.ast.Author;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.RevisionInfo;
-import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenDocumentHeaderIsRequired {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
     
 	@Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
-	
-	private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+
+	@ArquillianResource(Unshared.class)
+	private Asciidoctor asciidoctor;
 	
 	@Test
 	public void doctitle_blocks_and_attributes_should_be_returned() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenDocumentHeaderIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenDocumentHeaderIsRequired.java
@@ -14,7 +14,6 @@ import org.asciidoctor.ast.RevisionInfo;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -25,8 +24,8 @@ public class WhenDocumentHeaderIsRequired {
     @ArquillianResource
     private ClasspathResources classpath;
     
-	@Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
+	@ArquillianResource
+    public TemporaryFolder testFolder;
 
 	@ArquillianResource(Unshared.class)
 	private Asciidoctor asciidoctor;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
@@ -1,8 +1,11 @@
 package org.asciidoctor;
 
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.util.List;
@@ -13,10 +16,11 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.assertThat;
 
+@RunWith(Arquillian.class)
 public class WhenGlobExpressionIsUsedForScanning {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
     @Test
     public void all_files_with_given_extension_of_current_directory_should_be_returned() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
@@ -3,7 +3,6 @@ package org.asciidoctor;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenStructuredDocumentIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenStructuredDocumentIsRequired.java
@@ -11,24 +11,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.ast.ContentPart;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.StructuredDocument;
-import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenStructuredDocumentIsRequired {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
 	@Rule
 	public TemporaryFolder testFolder = new TemporaryFolder();
 
-	private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+	@ArquillianResource(Unshared.class)
+	private Asciidoctor asciidoctor;
 
 	@Test
 	public void empty_parent_title_makes_subsection_be_null_when_is_parsed() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenStructuredDocumentIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenStructuredDocumentIsRequired.java
@@ -18,7 +18,6 @@ import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -29,8 +28,8 @@ public class WhenStructuredDocumentIsRequired {
     @ArquillianResource
     private ClasspathResources classpath;
 
-	@Rule
-	public TemporaryFolder testFolder = new TemporaryFolder();
+	@ArquillianResource
+	private TemporaryFolder testFolder;
 
 	@ArquillianResource(Unshared.class)
 	private Asciidoctor asciidoctor;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenUserRequiresTheAsciidoctorRuntimeVersion.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenUserRequiresTheAsciidoctorRuntimeVersion.java
@@ -3,14 +3,22 @@ package org.asciidoctor;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import org.junit.Test;
 
+import org.asciidoctor.arquillian.api.Unshared;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
 public class WhenUserRequiresTheAsciidoctorRuntimeVersion {
+
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
     @Test
     public void current_version_should_be_retrieved() {
         
-        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
         String asciidoctorVersion = asciidoctor.asciidoctorVersion();
         
         assertThat(asciidoctorVersion, is(notNullValue()));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AnnotationUtils.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AnnotationUtils.java
@@ -1,0 +1,25 @@
+package org.asciidoctor.arquillian;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class AnnotationUtils {
+
+    private AnnotationUtils() {}
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Annotation> T filterAnnotation(Annotation[] annotations, Class<T> annotationClass) {
+        if(annotations == null) {
+            return null;
+        }
+        List<Annotation> filtered = new ArrayList<Annotation>();
+        for(Annotation annotation : annotations) {
+            if(annotationClass.isInstance(annotation)) {
+                return (T) annotation;
+            }
+        }
+        return null;
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AsciidoctorExtension.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AsciidoctorExtension.java
@@ -1,0 +1,15 @@
+package org.asciidoctor.arquillian;
+
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+public class AsciidoctorExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(ResourceProvider.class, AsciidoctorResourceProvider.class);
+        builder.service(ResourceProvider.class, ClasspathResourcesResourceProvider.class);
+        builder.observer(AsciidoctorTestObserver.class);
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AsciidoctorExtension.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AsciidoctorExtension.java
@@ -9,6 +9,7 @@ public class AsciidoctorExtension implements LoadableExtension {
     public void register(ExtensionBuilder builder) {
         builder.service(ResourceProvider.class, AsciidoctorResourceProvider.class);
         builder.service(ResourceProvider.class, ClasspathResourcesResourceProvider.class);
+        builder.service(ResourceProvider.class, TemporaryFolderResourceProvider.class);
         builder.observer(AsciidoctorTestObserver.class);
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AsciidoctorResourceProvider.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AsciidoctorResourceProvider.java
@@ -1,0 +1,34 @@
+package org.asciidoctor.arquillian;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.arquillian.api.Shared;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+
+public class AsciidoctorResourceProvider implements ResourceProvider {
+
+    @Inject @ApplicationScoped
+    private Instance<ScopedAsciidoctor> scopedAsciidoctorInstance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return Asciidoctor.class == type;
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        if (resource.value() == ArquillianResource.class // Default is ArquillianResource and should be unshared
+                || resource.value() == Unshared.class) {
+            return scopedAsciidoctorInstance.get().getUnsharedAsciidoctor();
+        } else if (resource.value() == Shared.class) {
+            return scopedAsciidoctorInstance.get().getSharedAsciidoctor();
+        }
+        return null;
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AsciidoctorTestObserver.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/AsciidoctorTestObserver.java
@@ -1,0 +1,123 @@
+package org.asciidoctor.arquillian;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.arquillian.api.Shared;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.event.suite.After;
+import org.jboss.arquillian.test.spi.event.suite.AfterClass;
+import org.jboss.arquillian.test.spi.event.suite.Before;
+import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class AsciidoctorTestObserver {
+
+    @Inject @ApplicationScoped
+    private InstanceProducer<ScopedAsciidoctor> scopedAsciidoctor;
+
+    @Inject @ApplicationScoped
+    private InstanceProducer<ClasspathResources> classpathResourcesInstanceProducer;
+
+
+    public void beforeTestClassCreateScopedResourceHolder(@Observes(precedence = 100) BeforeClass beforeClass) {
+        scopedAsciidoctor.set(new ScopedAsciidoctor());
+    }
+
+    public void beforeTestClassCreateSharedAsciidoctorInstance(@Observes(precedence = -100) BeforeClass beforeClass) {
+        if (isSharedAsciidoctorInstanceRequired(beforeClass.getTestClass().getJavaClass())) {
+            scopedAsciidoctor.get().setSharedAsciidoctor(
+                    Asciidoctor.Factory.create());
+        }
+    }
+
+    public void beforeTestClassCreateClasspathResources(@Observes BeforeClass beforeClass) {
+        ClasspathResources classpathResources = new ClasspathResources(beforeClass.getTestClass().getJavaClass());
+        classpathResourcesInstanceProducer.set(classpathResources);
+    }
+
+
+    public void beforeTestCreateUnsharedAsciidoctorInstance(@Observes(precedence = 5) Before before) {
+
+        if (isUnsharedAsciidoctorInstanceRequired(before.getTestClass().getJavaClass())
+                || isUnsharedAsciidoctorInstanceRequired(before.getTestMethod())) {
+            scopedAsciidoctor.get().setUnsharedAsciidoctor(
+                    Asciidoctor.Factory.create());
+        }
+
+    }
+
+    public void afterTestShutdownUnsharedAsciidoctorInstance(@Observes After after) {
+        Asciidoctor asciidoctor = scopedAsciidoctor.get().getUnsharedAsciidoctor();
+        if (asciidoctor != null) {
+            asciidoctor.shutdown();
+            scopedAsciidoctor.get().setUnsharedAsciidoctor(null);
+        }
+    }
+
+    public void afterTestClassShutdownSharedAsciidoctorInstance(@Observes AfterClass afterClass) {
+        Asciidoctor asciidoctor = scopedAsciidoctor.get().getSharedAsciidoctor();
+        if (asciidoctor != null) {
+            asciidoctor.shutdown();
+            scopedAsciidoctor.get().setSharedAsciidoctor(null);
+        }
+
+    }
+
+    private boolean isSharedAsciidoctorInstanceRequired(Class<?> testClass) {
+        for (Field f: SecurityActions.getFieldsWithAnnotation(testClass, ArquillianResource.class)) {
+            ArquillianResource arquillianResource = SecurityActions.getAnnotation(f, ArquillianResource.class);
+            if (f.getType() == Asciidoctor.class && arquillianResource.value() == Shared.class) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isUnsharedAsciidoctorInstanceRequired(Class<?> testClass) {
+        for (Field f: SecurityActions.getFieldsWithAnnotation(testClass, ArquillianResource.class)) {
+            ArquillianResource arquillianResource = SecurityActions.getAnnotation(f, ArquillianResource.class);
+            if (f.getType() == Asciidoctor.class &&
+                    (arquillianResource.value() == ArquillianResource.class || arquillianResource.value() == Unshared.class)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isSharedAsciidoctorInstanceRequired(Method testMethod) {
+        for (int i = 0; i < testMethod.getParameterTypes().length; i++) {
+            if (testMethod.getParameterTypes()[i] == Asciidoctor.class) {
+                ArquillianResource arquillianResource =
+                        AnnotationUtils.filterAnnotation(testMethod.getParameterAnnotations()[i], ArquillianResource.class);
+                if (arquillianResource != null
+                        && arquillianResource.value() == Unshared.class) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    private boolean isUnsharedAsciidoctorInstanceRequired(Method testMethod) {
+        for (int i = 0; i < testMethod.getParameterTypes().length; i++) {
+            if (testMethod.getParameterTypes()[i] == Asciidoctor.class) {
+                ArquillianResource arquillianResource =
+                        AnnotationUtils.filterAnnotation(testMethod.getParameterAnnotations()[i], ArquillianResource.class);
+                if (arquillianResource != null &&
+                        (arquillianResource.value() == ArquillianResource.class // Default value is ArquillianResoure.class is Unshared
+                                || arquillianResource.value() == Unshared.class)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/ClasspathResourcesResourceProvider.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/ClasspathResourcesResourceProvider.java
@@ -1,0 +1,27 @@
+package org.asciidoctor.arquillian;
+
+import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+
+public class ClasspathResourcesResourceProvider implements ResourceProvider {
+
+    @Inject
+    @ApplicationScoped
+    private Instance<ClasspathResources> classpathResourcesInstance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return type == ClasspathResources.class;
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        return classpathResourcesInstance.get();
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/ScopedAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/ScopedAsciidoctor.java
@@ -1,0 +1,27 @@
+package org.asciidoctor.arquillian;
+
+import org.asciidoctor.Asciidoctor;
+
+public class ScopedAsciidoctor {
+
+    private Asciidoctor sharedAsciidoctor;
+
+    private Asciidoctor unsharedAsciidoctor;
+
+    public void setSharedAsciidoctor(Asciidoctor sharedAsciidoctor) {
+        this.sharedAsciidoctor = sharedAsciidoctor;
+    }
+
+    public Asciidoctor getSharedAsciidoctor() {
+        return sharedAsciidoctor;
+    }
+
+    public void setUnsharedAsciidoctor(Asciidoctor unsharedAsciidoctor) {
+        this.unsharedAsciidoctor = unsharedAsciidoctor;
+    }
+
+    public Asciidoctor getUnsharedAsciidoctor() {
+        return unsharedAsciidoctor;
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/ScopedTemporaryFolder.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/ScopedTemporaryFolder.java
@@ -1,0 +1,26 @@
+package org.asciidoctor.arquillian;
+
+import org.junit.rules.TemporaryFolder;
+
+public class ScopedTemporaryFolder {
+
+    private TemporaryFolder sharedTemporaryFolder;
+
+    private TemporaryFolder unsharedTemporaryFolder;
+
+    public TemporaryFolder getSharedTemporaryFolder() {
+        return sharedTemporaryFolder;
+    }
+
+    public void setSharedTemporaryFolder(TemporaryFolder sharedTemporaryFolder) {
+        this.sharedTemporaryFolder = sharedTemporaryFolder;
+    }
+
+    public TemporaryFolder getUnsharedTemporaryFolder() {
+        return unsharedTemporaryFolder;
+    }
+
+    public void setUnsharedTemporaryFolder(TemporaryFolder unsharedTemporaryFolder) {
+        this.unsharedTemporaryFolder = unsharedTemporaryFolder;
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/SecurityActions.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/SecurityActions.java
@@ -1,0 +1,363 @@
+package org.asciidoctor.arquillian;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.List;
+
+final class SecurityActions {
+    //-------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * No instantiation
+     */
+    private SecurityActions()
+    {
+        throw new UnsupportedOperationException("No instantiation");
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Utility Methods --------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Obtains the Thread Context ClassLoader
+     */
+    static ClassLoader getThreadContextClassLoader()
+    {
+        return AccessController.doPrivileged(GetTcclAction.INSTANCE);
+    }
+
+    static boolean isClassPresent(String name)
+    {
+        try
+        {
+            loadClass(name);
+            return true;
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
+    }
+
+    static Class<?> loadClass(String className)
+    {
+        try
+        {
+            return Class.forName(className, true, getThreadContextClassLoader());
+        }
+        catch (ClassNotFoundException e)
+        {
+            try
+            {
+                return Class.forName(className, true, SecurityActions.class.getClassLoader());
+            }
+            catch (ClassNotFoundException e2)
+            {
+                throw new RuntimeException("Could not load class " + className, e2);
+            }
+        }
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
+    {
+        @SuppressWarnings("unchecked")
+        Class<T> implClass = (Class<T>) loadClass(className);
+        if (!expectedType.isAssignableFrom(implClass)) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+        }
+        return newInstance(implClass, argumentTypes, arguments);
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)
+    {
+        Class<?> clazz = null;
+        try
+        {
+            clazz = Class.forName(className, false, classLoader);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Could not load class " + className, e);
+        }
+        Object obj = newInstance(clazz, argumentTypes, arguments);
+        try
+        {
+            return expectedType.cast(obj);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType, e);
+        }
+    }
+
+    /**
+     * Create a new instance by finding a constructor that matches the argumentTypes signature
+     * using the arguments for instantiation.
+     *
+     * @param implClass Full classname of class to create
+     * @param argumentTypes The constructor argument types
+     * @param arguments The constructor arguments
+     * @return a new instance
+     * @throws IllegalArgumentException if className, argumentTypes, or arguments are null
+     * @throws RuntimeException if any exceptions during creation
+     * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+     * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+     */
+    static <T> T newInstance(final Class<T> implClass, final Class<?>[] argumentTypes, final Object[] arguments)
+    {
+        if (implClass == null)
+        {
+            throw new IllegalArgumentException("ImplClass must be specified");
+        }
+        if (argumentTypes == null)
+        {
+            throw new IllegalArgumentException("ArgumentTypes must be specified. Use empty array if no arguments");
+        }
+        if (arguments == null)
+        {
+            throw new IllegalArgumentException("Arguments must be specified. Use empty array if no arguments");
+        }
+        final T obj;
+        try
+        {
+            Constructor<T> constructor = getConstructor(implClass, argumentTypes);
+            if(!constructor.isAccessible()) {
+                constructor.setAccessible(true);
+            }
+            obj = constructor.newInstance(arguments);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Could not create new instance of " + implClass, e);
+        }
+
+        return obj;
+    }
+
+    /**
+     * Obtains the Constructor specified from the given Class and argument types
+     * @param clazz
+     * @param argumentTypes
+     * @return
+     * @throws NoSuchMethodException
+     */
+    static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argumentTypes)
+            throws NoSuchMethodException
+    {
+        try
+        {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Constructor<T>>()
+            {
+                public Constructor<T> run() throws NoSuchMethodException
+                {
+                    return clazz.getDeclaredConstructor(argumentTypes);
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae)
+        {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchMethodException)
+            {
+                throw (NoSuchMethodException) t;
+            }
+            else
+            {
+                // No other checked Exception thrown by Class.getConstructor
+                try
+                {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce)
+                {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set a single Field value
+     *
+     * @param target The object to set it on
+     * @param fieldName The field name
+     * @param value The new value
+     */
+    public static void setFieldValue(final Class<?> source, final Object target, final String fieldName, final Object value) throws NoSuchFieldException
+    {
+        try
+        {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>()
+            {
+                @Override
+                public Void run() throws Exception
+                {
+                    Field field = source.getDeclaredField(fieldName);
+                    if(!field.isAccessible())
+                    {
+                        field.setAccessible(true);
+                    }
+                    field.set(target, value);
+                    return null;
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae)
+        {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchFieldException)
+            {
+                throw (NoSuchFieldException) t;
+            }
+            else
+            {
+                // No other checked Exception thrown by Class.getConstructor
+                try
+                {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce)
+                {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    public static List<Field> getFieldsWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass)
+    {
+        List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>()
+        {
+            public List<Field> run()
+            {
+                List<Field> foundFields = new ArrayList<Field>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for(Field field : nextSource.getDeclaredFields())
+                    {
+                        if(field.isAnnotationPresent(annotationClass))
+                        {
+                            if(!field.isAccessible())
+                            {
+                                field.setAccessible(true);
+                            }
+                            foundFields.add(field);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundFields;
+            }
+        });
+        return declaredAccessableFields;
+    }
+
+    public static List<Method> getMethodsWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass)
+    {
+        List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>()
+        {
+            public List<Method> run()
+            {
+                List<Method> foundMethods = new ArrayList<Method>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for(Method method : nextSource.getDeclaredMethods())
+                    {
+                        if(method.isAnnotationPresent(annotationClass))
+                        {
+                            if(!method.isAccessible())
+                            {
+                                method.setAccessible(true);
+                            }
+                            foundMethods.add(method);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundMethods;
+            }
+        });
+        return declaredAccessableMethods;
+    }
+
+    static String getProperty(final String key) {
+        try {
+            String value = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+                public String run() {
+                    return System.getProperty(key);
+                }
+            });
+            return value;
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof SecurityException) {
+                throw (SecurityException) t;
+            }
+            if (t instanceof NullPointerException) {
+                throw (NullPointerException) t;
+            } else if (t instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) t;
+            } else {
+                // No other checked Exception thrown by System.getProperty
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    public static <T extends Annotation> T getAnnotation(final Field f, final Class<T> annotationClass) {
+        return AccessController.doPrivileged(new PrivilegedAction<T>() {
+            @Override
+            public T run() {
+                Annotation[] annotations = f.getDeclaredAnnotations();
+                for (Annotation annotation: annotations) {
+                    if (annotationClass.isInstance(annotation)) {
+                        return (T) annotation;
+                    }
+                }
+                return null;
+            }
+        });
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Inner Classes ----------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Single instance to get the TCCL
+     */
+    private enum GetTcclAction implements PrivilegedAction<ClassLoader> {
+        INSTANCE;
+
+        public ClassLoader run()
+        {
+            return Thread.currentThread().getContextClassLoader();
+        }
+
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/TemporaryFolderResourceProvider.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/TemporaryFolderResourceProvider.java
@@ -1,0 +1,35 @@
+package org.asciidoctor.arquillian;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.arquillian.api.Shared;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+import org.junit.rules.TemporaryFolder;
+
+import java.lang.annotation.Annotation;
+
+public class TemporaryFolderResourceProvider implements ResourceProvider {
+
+    @Inject @ApplicationScoped
+    private Instance<ScopedTemporaryFolder> scopedTemporaryFolderInstance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return TemporaryFolder.class == type;
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        if (resource.value() == ArquillianResource.class // Default is ArquillianResource and should be unshared
+                || resource.value() == Unshared.class) {
+            return scopedTemporaryFolderInstance.get().getUnsharedTemporaryFolder();
+        } else if (resource.value() == Shared.class) {
+            return scopedTemporaryFolderInstance.get().getSharedTemporaryFolder();
+        }
+        return null;
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/api/Shared.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/api/Shared.java
@@ -1,0 +1,22 @@
+package org.asciidoctor.arquillian.api;
+
+/**
+ * A marker class passed to the {@link org.jboss.arquillian.test.api.ArquillianResource} annotation
+ * to mark the {@link org.asciidoctor.Asciidoctor} instance as shared between multiple test methods.
+ *
+ * <p>Example for a field that is shared among multiple test methods</p>
+ * <pre><code>
+ *     &#64;ArquillianResource(Shared.class)
+ *     private Asciidoctor sharedAsciidoctor;
+ * </code></pre>
+ *
+ * <p>Example for a parameter that is shared among multiple test methods</p>
+ * <pre><code>
+ *     public void test(&#64;ArquillianResource(Shared.class) Asciidoctor asciidoctor) {...}
+ * </code></pre>
+ *
+ * <p>Without using the {@code Shared} marker Asciidoctor instances are not shared and behave
+ * as if the {@link Unshared} marker is used.</p>
+ */
+public class Shared {
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/api/Unshared.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/arquillian/api/Unshared.java
@@ -1,0 +1,19 @@
+package org.asciidoctor.arquillian.api;
+
+/**
+ * A marker class passed to the {@link org.jboss.arquillian.test.api.ArquillianResource} annotation
+ * to mark the {@link org.asciidoctor.Asciidoctor} instance as only created and used for a single test method.
+ *
+ * <p>Example for a field that is injected newly for every test method.</p>
+ * <pre><code>
+ *     &#64;ArquillianResource(Unshared.class)
+ *     private Asciidoctor sharedAsciidoctor;
+ * </code></pre>
+ *
+ * <p>Example for a parameter that is created only for this test method.</p>
+ * <pre><code>
+ *     public void test(&#64;ArquillianResource(Shared.class) Asciidoctor asciidoctor) {...}
+ * </code></pre>
+ */
+public class Unshared {
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -29,8 +29,8 @@ public class WhenAsciidoctorIsCalledUsingCli {
     @ArquillianResource
     private ClasspathResources classpath;
 
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@ArquillianResource
+	public TemporaryFolder temporaryFolder;
 
     public String pwd = new File("").getAbsolutePath();
 	

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -13,17 +13,21 @@ import java.io.PrintStream;
 import java.io.StringWriter;
 
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenAsciidoctorIsCalledUsingCli {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
@@ -4,9 +4,13 @@ import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.util.ClasspathResources;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -16,12 +20,14 @@ import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+@RunWith(Arquillian.class)
 public class WhenConverterIsRegistered {
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
     @After
     public void cleanUp() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -1,14 +1,22 @@
 package org.asciidoctor.extension;
 
-import static org.asciidoctor.OptionsBuilder.options;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.asciidoctor.SafeMode;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -18,34 +26,24 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.Options;
-import org.asciidoctor.SafeMode;
-import org.asciidoctor.ast.DocumentRuby;
-import org.asciidoctor.internal.JRubyAsciidoctor;
-import org.asciidoctor.util.ClasspathResources;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.asciidoctor.OptionsBuilder.options;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
+@RunWith(Arquillian.class)
 public class WhenJavaExtensionIsRegistered {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
     class RubyIncludeSource extends IncludeProcessor {
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -39,8 +39,8 @@ public class WhenJavaExtensionIsRegistered {
     @ArquillianResource
     private ClasspathResources classpath;
 
-    @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
+    @ArquillianResource
+    public TemporaryFolder testFolder;
 
     @ArquillianResource(Unshared.class)
     private Asciidoctor asciidoctor;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenReaderIsManipulatedInExtension.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenReaderIsManipulatedInExtension.java
@@ -7,17 +7,21 @@ import java.io.File;
 import java.util.HashMap;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
-import org.junit.Rule;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenReaderIsManipulatedInExtension {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
-	private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+	@ArquillianResource(Unshared.class)
+	private Asciidoctor asciidoctor;
 
 	@Test
 	public void currentLineNumberShouldBeReturned() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
@@ -5,20 +5,24 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenRubyExtensionIsRegistered {
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
     @Test
     public void ruby_extension_should_be_registered() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenDocumentIsRenderedWithPreloading.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenDocumentIsRenderedWithPreloading.java
@@ -6,13 +6,21 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.util.Map;
 
+import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jruby.RubyBoolean;
 import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenDocumentIsRenderedWithPreloading {
+
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
     @Test
     public void coderay_gem_should_be_preloaded() {
@@ -20,10 +28,8 @@ public class WhenDocumentIsRenderedWithPreloading {
         Map<String, Object> options = OptionsBuilder.options()
                 .attributes(AttributesBuilder.attributes().sourceHighlighter("coderay").get()).asMap();
 
-        JRubyAsciidoctor asciidoctor = (JRubyAsciidoctor) JRubyAsciidoctor.create();
-
-        asciidoctor.rubyGemsPreloader.preloadRequiredLibraries(options);
-        RubyBoolean evalScriptlet = (RubyBoolean) asciidoctor.rubyRuntime.evalScriptlet("require 'coderay'");
+        ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
+        RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'coderay'");
         assertThat(evalScriptlet.isFalse(), is(true));
 
     }
@@ -34,10 +40,8 @@ public class WhenDocumentIsRenderedWithPreloading {
         Map<String, Object> options = OptionsBuilder.options()
                 .attributes(AttributesBuilder.attributes().sourceHighlighter("pygments").get()).asMap();
 
-        JRubyAsciidoctor asciidoctor = (JRubyAsciidoctor) JRubyAsciidoctor.create();
-
-        asciidoctor.rubyGemsPreloader.preloadRequiredLibraries(options);
-        RubyBoolean evalScriptlet = (RubyBoolean) asciidoctor.rubyRuntime.evalScriptlet("require 'coderay'");
+        ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
+        RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'coderay'");
         assertThat(evalScriptlet.isTrue(), is(true));
 
     }
@@ -47,10 +51,8 @@ public class WhenDocumentIsRenderedWithPreloading {
 
         Map<String, Object> options = OptionsBuilder.options().eruby("erubis").asMap();
 
-        JRubyAsciidoctor asciidoctor = (JRubyAsciidoctor) JRubyAsciidoctor.create();
-
-        asciidoctor.rubyGemsPreloader.preloadRequiredLibraries(options);
-        RubyBoolean evalScriptlet = (RubyBoolean) asciidoctor.rubyRuntime.evalScriptlet("require 'erubis'");
+        ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
+        RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'erubis'");
         assertThat(evalScriptlet.isFalse(), is(true));
 
     }
@@ -60,10 +62,8 @@ public class WhenDocumentIsRenderedWithPreloading {
 
         Map<String, Object> options = OptionsBuilder.options().eruby("erb").asMap();
 
-        JRubyAsciidoctor asciidoctor = (JRubyAsciidoctor) JRubyAsciidoctor.create();
-
-        asciidoctor.rubyGemsPreloader.preloadRequiredLibraries(options);
-        RubyBoolean evalScriptlet = (RubyBoolean) asciidoctor.rubyRuntime.evalScriptlet("require 'erubis'");
+        ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
+        RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'erubis'");
         assertThat(evalScriptlet.isTrue(), is(true));
 
     }
@@ -73,10 +73,8 @@ public class WhenDocumentIsRenderedWithPreloading {
 
         Map<String, Object> options = OptionsBuilder.options().templateDir(new File(".")).asMap();
 
-        JRubyAsciidoctor asciidoctor = (JRubyAsciidoctor) JRubyAsciidoctor.create();
-
-        asciidoctor.rubyGemsPreloader.preloadRequiredLibraries(options);
-        RubyBoolean evalScriptlet = (RubyBoolean) asciidoctor.rubyRuntime.evalScriptlet("require 'tilt'");
+        ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
+        RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'tilt'");
         assertThat(evalScriptlet.isFalse(), is(true));
 
     }
@@ -87,10 +85,8 @@ public class WhenDocumentIsRenderedWithPreloading {
         Map<String, Object> options = OptionsBuilder.options()
                 .attributes(AttributesBuilder.attributes().dataUri(true).get()).asMap();
 
-        JRubyAsciidoctor asciidoctor = (JRubyAsciidoctor) JRubyAsciidoctor.create();
-
-        asciidoctor.rubyGemsPreloader.preloadRequiredLibraries(options);
-        RubyBoolean evalScriptlet = (RubyBoolean) asciidoctor.rubyRuntime.evalScriptlet("require 'base64'");
+        ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
+        RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'base64'");
         assertThat(evalScriptlet.isFalse(), is(true));
 
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenLoadingExtensionFromUnusualPackage.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenLoadingExtensionFromUnusualPackage.java
@@ -1,30 +1,23 @@
 package org.asciidoctor.internal;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.SafeMode;
-import org.asciidoctor.ast.AbstractBlock;
-import org.asciidoctor.ast.Block;
-import org.asciidoctor.extension.BlockMacroProcessor;
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.extension.JavaExtensionRegistry;
-import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.util.ClasspathResources;
-import org.junit.Rule;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import unusual.extension.BoldifyPostProcessor;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Map;
-
-import static org.asciidoctor.OptionsBuilder.options;
-
+@RunWith(Arquillian.class)
 public class WhenLoadingExtensionFromUnusualPackage {
 
-  @Rule
-  public ClasspathResources classpath = new ClasspathResources();
+  @ArquillianResource
+  private ClasspathResources classpath;
 
-  private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+  @ArquillianResource(Unshared.class)
+  private Asciidoctor asciidoctor;
 
   @Test
   public void shouldAllowLoadingUsingInstance() {

--- a/asciidoctorj-core/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/asciidoctorj-core/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.asciidoctor.arquillian.AsciidoctorExtension

--- a/asciidoctorj-diagram/build.gradle
+++ b/asciidoctorj-diagram/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   compile project(':asciidoctorj')
   testCompile project(path: ':asciidoctorj-test-support', configuration: 'tests')
+  testCompile project(path: ':asciidoctorj', configuration: 'arquillianExtension')
   gems("rubygems:asciidoctor-diagram:$asciidoctorDiagramGemVersion") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'

--- a/asciidoctorj-diagram/src/test/java/org/asciidoctor/WhenDocumentContainsDitaaDiagram.java
+++ b/asciidoctorj-diagram/src/test/java/org/asciidoctor/WhenDocumentContainsDitaaDiagram.java
@@ -2,20 +2,26 @@ package org.asciidoctor;
 
 import java.io.File;
 
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.asciidoctor.OptionsBuilder.options;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+@RunWith(Arquillian.class)
 public class WhenDocumentContainsDitaaDiagram {
 
-    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
     @Test
     public void png_should_be_rendered_for_diagram() {

--- a/asciidoctorj-epub3/build.gradle
+++ b/asciidoctorj-epub3/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   compile project(':asciidoctorj')
   testCompile project(path: ':asciidoctorj-test-support', configuration: 'tests')
+  testCompile project(path: ':asciidoctorj', configuration: 'arquillianExtension')
   gems("rubygems:asciidoctor-epub3:$asciidoctorEpub3GemVersion") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'

--- a/asciidoctorj-epub3/src/test/java/org/asciidoctor/WhenEpub3BackendIsUsed.java
+++ b/asciidoctorj-epub3/src/test/java/org/asciidoctor/WhenEpub3BackendIsUsed.java
@@ -6,18 +6,21 @@ import static org.junit.Assert.assertThat;
 
 import java.io.File;
 
-import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
-import org.junit.Rule;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenEpub3BackendIsUsed {
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
     
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
     
     @Test
     public void epub3_should_be_rendered_for_epub3_backend() {

--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -2,6 +2,7 @@ dependencies {
   compile project(':asciidoctorj')
 
   testCompile project(path: ':asciidoctorj-test-support', configuration: 'tests')
+  testCompile project(path: ':asciidoctorj', configuration: 'arquillianExtension')
 
   gems("rubygems:asciidoctor-pdf:$asciidoctorPdfGemVersion") {
     // Exclude gems provided by AsciidoctorJ core

--- a/asciidoctorj-pdf/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
+++ b/asciidoctorj-pdf/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
@@ -7,17 +7,23 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class WhenBackendIsPdf {
 
-    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
 
-    @Rule
-    public ClasspathResources classpath = new ClasspathResources();
+    @ArquillianResource
+    private ClasspathResources classpath;
 
     @Test
     public void pdf_should_be_rendered_for_pdf_backend() {

--- a/asciidoctorj-test-support/src/test/java/org/asciidoctor/util/ClasspathResources.java
+++ b/asciidoctorj-test-support/src/test/java/org/asciidoctor/util/ClasspathResources.java
@@ -11,6 +11,12 @@ import org.junit.runners.model.Statement;
  */
 public class ClasspathResources extends ClasspathHelper implements TestRule {
 
+    public ClasspathResources() {}
+
+    public ClasspathResources(Class<?> clazz) {
+        setClassloader(clazz);
+    }
+
     protected void before(Class<?> clazz) throws Throwable {
         super.setClassloader(clazz);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ ext {
   statusIsRelease = (status == 'release')
 
   // jar versions
+  arquillianVersion = '1.1.8.Final'
+  arquillianSpockVersion = '1.0.0.Beta3'
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
@@ -97,6 +99,8 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
       exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
     testCompile "org.codehaus.groovy:groovy-all:$groovyVersion"
+    testCompile "org.jboss.arquillian.junit:arquillian-junit-container:$arquillianVersion"
+    testCompile "org.jboss.arquillian.spock:arquillian-spock-container:$arquillianSpockVersion"
   }
   apply plugin: 'codenarc'
   codenarc {


### PR DESCRIPTION
…octor as Arquillian Resources and ClasspathResources.
The Arquillian extension is part of asciidoctorj-core in the test sources.
An own arquillianExtension configuration bundles only the Arquillian extension excluding the core test classes and is referenced by the pdf, epub and diagram modules.

Asciidoctor instances are destroyed using the already available method `shutdown()`.

TemporaryFolder Rules are not replaced yet by the Arquillian extension.
Maybe they could also be replaced in the next step by the Arquillian extension so that it creates the TemporaryFolder instances and invokes `before()` and `after()` (so that we can completely remove the Rule annotation)