### PR TITLE
JRuby & jruby-gradle version bumps.

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -28,3 +28,7 @@ jrubyPrepareGems << {
     into sourceSets.main.output.resourcesDir
   }
 }
+
+//jruby {
+//	execVersion = '1.7.20'
+//}

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 // modern plugins config
 plugins {
-  id 'com.github.jruby-gradle.base' version '0.1.11'
+  id 'com.github.jruby-gradle.base' version '0.1.17'
   // Adding the nebula-publishing plugin when using JDK6 causes the build to abort
   //id 'nebula.nebula-publishing' version '2.0.0'
   id 'com.jfrog.bintray' version '1.0'
@@ -31,7 +31,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '1.7.18'
+  jrubyVersion = '1.7.20'
   jsoupVersion = '1.8.1'
   junitVersion = '4.12'
   saxonVersion = '9.5.1-6'


### PR DESCRIPTION
Bumped the `jruby-gradle-base` plugin to `0.1.17` and the jruby version to `1.7.20`. This fixes the OOM that is seen when building under JDK6. It also adds all the performance improvements in jruby 1.7.20 to asciidoctorj.

This builds happily on my Mac with `1.6.0_65`.