### PR TITLE
Added constant for the regexp config option of InlineMacroProcessors …

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
@@ -1,16 +1,30 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.internal.RubyUtils;
-import org.jruby.RubyRegexp;
-import org.jruby.util.RegexpOptions;
-
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class InlineMacroProcessor extends MacroProcessor {
 
-    protected RubyRegexp regexp;
-    
+    /**
+     * This value is used as the config option key when defining a regular expression that should be
+     * used to match an inline macro invocation.
+     * Its value must be a String containing a regular expression :
+     *
+     * <p>Example to make a InlineMacroProcessor work on inline macros of the form {@code man:[A-Za-z0-9]+\\[.*?\\]}:
+     * <pre>
+     * <verbatim>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put(REGEXP, "man:([A-Za-z0-9]+)\\[(.*?)\\]");
+     * InlineMacroProcessor inlineMacroProcessor = new InlineMacroProcessor("man", config);
+     * asciidoctor.javaExtensionRegistry().inlineMacro(inlineMacroProcessor);
+     * </verbatim>
+     * </pre>
+     * </p>
+     * <p>Note the parens {@code (} and {@code )} in the regular expression in the example to capture
+     * the target and attributes of the macro invocation.</p>
+     */
+    public static final String REGEXP = "regexp";
+
     public InlineMacroProcessor(String macroName) {
         this(macroName, new HashMap<String, Object>());
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
@@ -146,12 +146,12 @@ public class JavaExtensionRegistry {
     
     public void inlineMacro(String blockName,
             Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
-        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor, blockName);
+        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
         this.asciidoctorModule.inline_macro(rubyClass, blockName);
     }
     
     public void inlineMacro(String blockName, String inlineMacroProcessor) {
-        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor, blockName);
+        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
         this.asciidoctorModule.inline_macro(rubyClass, blockName);
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
@@ -10,8 +10,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.RubyRegexp;
-import org.jruby.RubyRegexp$INVOKER$i$0$0$casefold_p;
-import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaEmbedUtils;
@@ -29,33 +27,29 @@ public class InlineMacroProcessorProxy extends AbstractMacroProcessorProxy<Inlin
 
     private static final String SUPER_CLASS_NAME = "InlineMacroProcessor";
 
-    private static String blockName;
-
-    public InlineMacroProcessorProxy(Ruby runtime, RubyClass metaClass, Class<? extends InlineMacroProcessor> inlineMacroProcessorClass, String blockName) {
+    public InlineMacroProcessorProxy(Ruby runtime, RubyClass metaClass, Class<? extends InlineMacroProcessor> inlineMacroProcessorClass) {
         super(runtime, metaClass, inlineMacroProcessorClass);
-        this.blockName = blockName;
     }
 
     public InlineMacroProcessorProxy(Ruby runtime, RubyClass metaClass, InlineMacroProcessor inlineMacroProcessor) {
         super(runtime, metaClass, inlineMacroProcessor);
-        this.blockName = inlineMacroProcessor.getName();
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final String inlineMacroProcessorClassName, final String blockName) {
+    public static RubyClass register(final Ruby rubyRuntime, final String inlineMacroProcessorClassName) {
 
         try {
             Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessorClassName);
-            return register(rubyRuntime, inlineMacroProcessorClass, blockName);
+            return register(rubyRuntime, inlineMacroProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final Class<? extends InlineMacroProcessor> inlineMacroProcessor, final String blockName) {
+    public static RubyClass register(final Ruby rubyRuntime, final Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
         RubyClass rubyClass = ProcessorProxyUtil.defineProcessorClass(rubyRuntime, SUPER_CLASS_NAME, new ObjectAllocator() {
             @Override
             public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-                return new InlineMacroProcessorProxy(runtime, klazz, inlineMacroProcessor, blockName);
+                return new InlineMacroProcessorProxy(runtime, klazz, inlineMacroProcessor);
             }
         });
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, InlineMacroProcessorProxy.class);
@@ -80,7 +74,7 @@ public class InlineMacroProcessorProxy extends AbstractMacroProcessorProxy<Inlin
             // instead of those passed by asciidoctor
 
             // If options contains a String with a Regexp create the RubyRegexp from it
-            RubySymbol regexpSymbol = RubySymbol.newSymbol(getRuntime(), "regexp");
+            RubySymbol regexpSymbol = RubySymbol.newSymbol(getRuntime(), InlineMacroProcessor.REGEXP);
             Object regexp = getProcessor().getConfig().get(regexpSymbol);
             if (regexp != null && regexp instanceof String) {
                 getProcessor().getConfig().put(regexpSymbol, convertRegexp(regexp));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -120,7 +120,7 @@ public class WhenJavaExtensionIsRegistered {
 
             @Override
             public void process(DocumentRuby documentRuby, PreprocessorReader reader, String target,
-                    Map<String, Object> attributes) {
+                                Map<String, Object> attributes) {
                 StringBuilder content = readContent(target);
                 reader.push_include(content.toString(), target, target, 1, attributes);
             }
@@ -543,7 +543,7 @@ public class WhenJavaExtensionIsRegistered {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> options = new HashMap<String, Object>();
-        options.put("content_model", ":raw");
+        options.put(BlockMacroProcessor.CONTENT_MODEL, BlockMacroProcessor.CONTENT_MODEL_RAW);
 
         javaExtensionRegistry.blockMacro(new GistMacro("gist", options));
 
@@ -596,7 +596,7 @@ public class WhenJavaExtensionIsRegistered {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> options = new HashMap<String, Object>();
-        options.put("regexp", "man(?:page)?:(\\S+?)\\[(.*?)\\]");
+        options.put(InlineMacroProcessor.REGEXP, "man(?:page)?:(\\S+?)\\[(.*?)\\]");
 
         ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
         javaExtensionRegistry.inlineMacro(inlineMacroProcessor);
@@ -618,7 +618,7 @@ public class WhenJavaExtensionIsRegistered {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> options = new HashMap<String, Object>();
-        options.put("regexp", "man(?:page)?:(ThisDoesNotMatch)\\[(.*?)\\]");
+        options.put(InlineMacroProcessor.REGEXP, "man(?:page)?:(ThisDoesNotMatch)\\[(.*?)\\]");
 
         ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
         javaExtensionRegistry.inlineMacro(inlineMacroProcessor);


### PR DESCRIPTION
…and some code cleanup in InlineMacroProcessorProxy

Main point of this PR is adding a constant InlineMacroProcessor.REGEXP and some javadoc for it.

Also did some code cleanup in the InlineMacroProcessorProxy that slipped through the last changes.