### PR TITLE
Adds target to inline

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Inline.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Inline.java
@@ -10,4 +10,6 @@ public interface Inline extends AbstractNode {
     public String getType();
 
     public String getText();
+
+    public String getTarget();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/InlineImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/InlineImpl.java
@@ -30,4 +30,9 @@ public class InlineImpl extends AbstractNodeImpl implements Inline  {
     public String getText() {
         return delegate.getText();
     }
+
+    @Override
+    public String getTarget() {
+        return delegate.getTarget();
+    }
 }


### PR DESCRIPTION
This adds a missing method for the Inline type. Anchors of type `link` require the `target` property.