### PR TITLE
Cache Java AST nodes at Ruby nodes to always convert every Ruby node …

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
@@ -26,7 +26,6 @@ public interface AbstractBlock extends AbstractNode {
     Object content();
     Object getContent();
     String convert();
-    AbstractBlock delegate();
     List<AbstractBlock> findBy(Map<Object, Object> selector);
     int getLevel();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -5,24 +5,22 @@ import java.util.List;
 import java.util.Map;
 
 import org.asciidoctor.converter.ConverterProxy;
+import org.asciidoctor.internal.RubyBlockListDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyObject;
 import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock {
 
     private static final String BLOCK_CLASS = "Block";
     private static final String SECTION_CLASS = "Section";
     
-    protected AbstractBlock delegate;
-
-
-    public AbstractBlockImpl(AbstractBlock blockDelegate, Ruby runtime) {
-        super(blockDelegate, runtime);
-        this.delegate = blockDelegate;
+    public AbstractBlockImpl(IRubyObject blockDelegate) {
+        super(blockDelegate);
     }
 
     @Override
@@ -32,7 +30,7 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
     @Override
     public String getTitle() {
-        return delegate.getTitle();
+        return getString("title");
     }
 
     @Override
@@ -42,7 +40,7 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
     @Override
     public String getStyle() {
-        return delegate.getStyle();
+        return getString("style");
     }
 
     @Override
@@ -52,16 +50,8 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
     @Override
     public List<AbstractBlock> getBlocks() {
-        List<AbstractBlock> rubyBlocks = delegate.getBlocks();
-
-        for (int i = 0; i < rubyBlocks.size(); i++) {
-            Object abstractBlock = rubyBlocks.get(i);
-            if (!(abstractBlock instanceof RubyArray)) {
-                rubyBlocks.set(i, (AbstractBlock) NodeConverter.createASTNode(abstractBlock));
-            }
-        }
-
-        return rubyBlocks;
+        RubyArray rubyBlocks = (RubyArray) getProperty("blocks");
+        return new RubyBlockListDecorator(rubyBlocks);
     }
 
     @Override
@@ -71,44 +61,25 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
     @Override
     public Object getContent() {
-        return delegate.content();
-    }
-
-    @Override
-    public String getNodeName() {
-        return delegate.getNodeName();
+        return JavaEmbedUtils.rubyToJava(getProperty("content"));
     }
 
     @Override
     public String convert() {
-        return delegate.convert();
+        return getString("convert");
     }
 
     @Override
     public int getLevel() {
-        return delegate.getLevel();
-    }
-
-    @Override
-    public AbstractBlock delegate() {
-        return delegate;
+        return getInt("level");
     }
 
     @Override
     public List<AbstractBlock> findBy(Map<Object, Object> selector) {
 
-        @SuppressWarnings("unchecked")
-        List<?> findBy = delegate.findBy(RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,
+        RubyArray rubyBlocks = (RubyArray) getProperty("find_by", RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,
                 selector));
-
-        List<AbstractBlock> ret = new ArrayList<AbstractBlock>(findBy.size());
-        for (Object abstractBlock: findBy) {
-            if (!(abstractBlock instanceof RubyArray)) {
-                ret.add((AbstractBlock) NodeConverter.createASTNode(abstractBlock));
-            }
-
-        }
-        return ret;
+        return new RubyBlockListDecorator(rubyBlocks);
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -1,17 +1,11 @@
 package org.asciidoctor.ast;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.asciidoctor.converter.ConverterProxy;
 import org.asciidoctor.internal.RubyBlockListDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
-import org.asciidoctor.internal.RubyUtils;
-import org.jruby.Ruby;
 import org.jruby.RubyArray;
-import org.jruby.RubyObject;
-import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock {
@@ -50,7 +44,7 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
     @Override
     public List<AbstractBlock> getBlocks() {
-        RubyArray rubyBlocks = (RubyArray) getProperty("blocks");
+        RubyArray rubyBlocks = (RubyArray) getRubyProperty("blocks");
         return new RubyBlockListDecorator(rubyBlocks);
     }
 
@@ -61,7 +55,7 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
     @Override
     public Object getContent() {
-        return JavaEmbedUtils.rubyToJava(getProperty("content"));
+        return getProperty("content");
     }
 
     @Override
@@ -77,7 +71,7 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     @Override
     public List<AbstractBlock> findBy(Map<Object, Object> selector) {
 
-        RubyArray rubyBlocks = (RubyArray) getProperty("find_by", RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,
+        RubyArray rubyBlocks = (RubyArray) getRubyProperty("find_by", RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,
                 selector));
         return new RubyBlockListDecorator(rubyBlocks);
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.ast;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -55,9 +56,8 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
 
         for (int i = 0; i < rubyBlocks.size(); i++) {
             Object abstractBlock = rubyBlocks.get(i);
-            if (!(abstractBlock instanceof RubyArray) && !(abstractBlock instanceof AbstractNode)) {
-                RubyObject rubyObject = (RubyObject) abstractBlock;
-                rubyBlocks.set(i, (AbstractBlock) NodeConverter.createASTNode(rubyObject));
+            if (!(abstractBlock instanceof RubyArray)) {
+                rubyBlocks.set(i, (AbstractBlock) NodeConverter.createASTNode(abstractBlock));
             }
         }
 
@@ -98,18 +98,17 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     public List<AbstractBlock> findBy(Map<Object, Object> selector) {
 
         @SuppressWarnings("unchecked")
-        List<AbstractBlock> findBy = delegate.findBy(RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,
+        List<?> findBy = delegate.findBy(RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,
                 selector));
 
-        for (int i = 0; i < findBy.size(); i++) {
-            Object abstractBlock = findBy.get(i);
-            if (!(abstractBlock instanceof RubyArray) && !(abstractBlock instanceof AbstractBlock)) {
-                RubyObject rubyObject = (RubyObject)abstractBlock;
-                findBy.set(i, (AbstractBlock) NodeConverter.createASTNode(rubyObject));
+        List<AbstractBlock> ret = new ArrayList<AbstractBlock>(findBy.size());
+        for (Object abstractBlock: findBy) {
+            if (!(abstractBlock instanceof RubyArray)) {
+                ret.add((AbstractBlock) NodeConverter.createASTNode(abstractBlock));
             }
 
         }
-        return findBy;
+        return ret;
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
@@ -50,8 +50,5 @@ public interface AbstractNode {
     String readAsset(String path, Map<Object, Object> opts);
     String normalizeWebPath(String path, String start, boolean preserveUriTarget);
 
-    String getStyle();
 
-    String listMarkerKeyword();
-    String listMarkerKeyword(String listType);
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNode.java
@@ -5,7 +5,17 @@ import java.util.Map;
 
 public interface AbstractNode {
 
+    /**
+     * @deprecated Please use {@link #getId()}
+     * @return A unique ID for this node
+     */
     String id();
+
+    /**
+     * @return A unique ID for this node
+     */
+    String getId();
+
     String getNodeName();
     /**
      * @deprecated Use {@linkplain #getParent()}  instead.

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
@@ -1,7 +1,6 @@
 package org.asciidoctor.ast;
 
 import org.asciidoctor.internal.RubyAttributesMapDecorator;
-import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
@@ -13,12 +12,10 @@ import org.jruby.RubyNil;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
-import org.jruby.java.proxies.RubyObjectHolderProxy;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +53,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public AbstractNode getParent() {
-        return NodeConverter.createASTNode(getProperty("parent"));
+        return NodeConverter.createASTNode(getRubyProperty("parent"));
     }
 
     @Override
@@ -66,7 +63,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public DocumentRuby getDocument() {
-        return (DocumentRuby) NodeConverter.createASTNode(getProperty("document"));
+        return (DocumentRuby) NodeConverter.createASTNode(getRubyProperty("document"));
     }
 
     public IRubyObject getRubyObject() {
@@ -90,22 +87,22 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public Map<String, Object> getAttributes() {
-        return new RubyAttributesMapDecorator((RubyHash) getProperty("attributes"));
+        return new RubyAttributesMapDecorator((RubyHash) getRubyProperty("attributes"));
     }
 
     @Override
     public Object getAttr(Object name, Object defaultValue, boolean inherit) {
-        return JavaEmbedUtils.rubyToJava(getProperty("attr", name, defaultValue, inherit));
+        return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name, defaultValue, inherit));
     }
 
     @Override
     public Object getAttr(Object name, Object defaultValue) {
-        return JavaEmbedUtils.rubyToJava(getProperty("attr", name, defaultValue));
+        return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name, defaultValue));
     }
 
     @Override
     public Object getAttr(Object name) {
-        return JavaEmbedUtils.rubyToJava(getProperty("attr", name));
+        return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name));
     }
 
     @Override
@@ -193,24 +190,8 @@ public abstract class AbstractNodeImpl implements AbstractNode {
         return getString("normalize_web_path", path, start, preserveUriTarget);
     }
 
-    @Override
-    public String getStyle() {
-        return getString("@style");
-    }
-
-    @Override
-    public String listMarkerKeyword() {
-        return getString("list_marker_keyword");
-    }
-
-    @Override
-    public String listMarkerKeyword(String listType) {
-        return getString("list_marker_keyword", listType);
-    }
-
-
     protected String getString(String propertyName, Object... args) {
-        IRubyObject result = getProperty(propertyName, args);
+        IRubyObject result = getRubyProperty(propertyName, args);
 
         if (result instanceof RubyNil) {
             return null;
@@ -222,7 +203,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
     }
 
     protected boolean getBoolean(String propertyName, Object... args) {
-        IRubyObject result = getProperty(propertyName, args);
+        IRubyObject result = getRubyProperty(propertyName, args);
         if (result instanceof RubyNil) {
             return false;
         } else {
@@ -231,7 +212,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
     }
 
     protected int getInt(String propertyName, Object... args) {
-        IRubyObject result = getProperty(propertyName, args);
+        IRubyObject result = getRubyProperty(propertyName, args);
         if (result instanceof RubyNil) {
             return 0;
         } else {
@@ -240,7 +221,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
     }
 
     protected <T> List<T> getList(String propertyName, Class<T> elementClass, Object... args) {
-        IRubyObject result = getProperty(propertyName, args);
+        IRubyObject result = getRubyProperty(propertyName, args);
         if (result instanceof RubyNil) {
             return null;
         } else {
@@ -254,7 +235,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
     }
 
 
-    protected IRubyObject getProperty(String propertyName, Object... args) {
+    protected IRubyObject getRubyProperty(String propertyName, Object... args) {
         ThreadContext threadContext = runtime.getThreadService().getCurrentContext();
 
         IRubyObject result = null;
@@ -275,6 +256,18 @@ public abstract class AbstractNodeImpl implements AbstractNode {
             }
         }
         return result;
+    }
+
+    protected Object getProperty(String propertyName, Object... args) {
+        return toJava(getRubyProperty(propertyName, args));
+    }
+
+    protected Object toJava(IRubyObject rubyObject) {
+        return JavaEmbedUtils.rubyToJava(rubyObject);
+    }
+
+    protected <T> T toJava(IRubyObject rubyObject, Class<T> targetClass) {
+        return (T) JavaEmbedUtils.rubyToJava(runtime, rubyObject, targetClass);
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
@@ -33,6 +33,11 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public String id() {
+        return getId();
+    }
+
+    @Override
+    public String getId() {
         return getString("id");
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
@@ -44,7 +44,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public AbstractNode getParent() {
-        return this.abstractNode.getParent();
+        return NodeConverter.createASTNode(this.abstractNode.getParent());
     }
 
     @Override
@@ -54,7 +54,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public DocumentRuby getDocument() {
-        return this.abstractNode.getDocument();
+        return (DocumentRuby) NodeConverter.createASTNode(this.abstractNode.getDocument());
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
@@ -1,30 +1,42 @@
 package org.asciidoctor.ast;
 
+import org.asciidoctor.internal.RubyAttributesMapDecorator;
+import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyHash;
+import org.jruby.RubyNil;
+import org.jruby.RubyNumeric;
+import org.jruby.RubyString;
+import org.jruby.RubySymbol;
 import org.jruby.java.proxies.RubyObjectHolderProxy;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractNodeImpl implements AbstractNode {
 
     protected Ruby runtime;
-    protected AbstractNode abstractNode;
+    protected IRubyObject rubyNode;
 
-    public AbstractNodeImpl(AbstractNode abstractNode, Ruby ruby) {
-        if (!(abstractNode instanceof IRubyObject) && !(abstractNode instanceof RubyObjectHolderProxy)) {
-            throw new IllegalArgumentException("Node delegate must be an IRubyObject or RubyObjectHolderProxy!");
-        }
-        this.runtime = ruby;
-        this.abstractNode = abstractNode;
+    public AbstractNodeImpl(IRubyObject rubyNode) {
+        this.rubyNode = rubyNode;
+        this.runtime = rubyNode.getRuntime();
     }
 
     @Override
     public String id() {
-        return this.abstractNode.id();
+        return getString("id");
     }
 
     @Override
@@ -34,7 +46,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public String getContext() {
-        return this.abstractNode.getContext();
+        return getString("context");
     }
 
     @Override
@@ -44,7 +56,7 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public AbstractNode getParent() {
-        return NodeConverter.createASTNode(this.abstractNode.getParent());
+        return NodeConverter.createASTNode(getProperty("parent"));
     }
 
     @Override
@@ -54,157 +66,215 @@ public abstract class AbstractNodeImpl implements AbstractNode {
 
     @Override
     public DocumentRuby getDocument() {
-        return (DocumentRuby) NodeConverter.createASTNode(this.abstractNode.getDocument());
+        return (DocumentRuby) NodeConverter.createASTNode(getProperty("document"));
+    }
+
+    public IRubyObject getRubyObject() {
+        return rubyNode;
     }
 
     @Override
     public String getNodeName() {
-        return this.abstractNode.getNodeName();
+        return getString("node_name");
     }
 
     @Override
     public boolean isInline() {
-        return this.abstractNode.isInline();
+        return getBoolean("inline?");
     }
 
     @Override
     public boolean isBlock() {
-        return this.abstractNode.isBlock();
+        return getBoolean("block?");
     }
 
     @Override
     public Map<String, Object> getAttributes() {
-        return this.abstractNode.getAttributes();
+        return new RubyAttributesMapDecorator((RubyHash) getProperty("attributes"));
     }
 
     @Override
     public Object getAttr(Object name, Object defaultValue, boolean inherit) {
-        return this.abstractNode.getAttr(name, defaultValue, inherit);
+        return JavaEmbedUtils.rubyToJava(getProperty("attr", name, defaultValue, inherit));
     }
 
     @Override
     public Object getAttr(Object name, Object defaultValue) {
-        return this.abstractNode.getAttr(name, defaultValue, true);
+        return JavaEmbedUtils.rubyToJava(getProperty("attr", name, defaultValue));
     }
 
     @Override
     public Object getAttr(Object name) {
-        return this.abstractNode.getAttr(name, null, true);
+        return JavaEmbedUtils.rubyToJava(getProperty("attr", name));
     }
 
     @Override
     public boolean isAttr(Object name, Object expected, boolean inherit) {
-        return this.abstractNode.isAttr(name, expected, inherit);
+        return getBoolean("attr?", name, expected, inherit);
     }
 
     @Override
     public boolean isAttr(Object name, Object expected) {
-        return this.abstractNode.isAttr(name, expected, true);
+        return getBoolean("attr?", name, expected);
     }
 
     @Override
     public boolean setAttr(Object name, Object value, boolean overwrite) {
-        return this.abstractNode.setAttr(name, value, overwrite);
+        return getBoolean("set_attr", name, value, overwrite);
     }
 
     @Override
     public boolean isOption(Object name) {
-        return this.abstractNode.isOption(name);
+        return getBoolean("option?", name);
     }
 
     @Override
     public boolean isRole() {
-        return this.abstractNode.isRole();
+        return getBoolean("role?");
     }
 
     @Override
     public String getRole() {
-        return this.abstractNode.getRole();
+        return getString("role");
     }
 
     @Override
     public String role() {
-        return this.abstractNode.role();
+        return getRole();
     }
 
     @Override
     public List<String> getRoles() {
-        return this.abstractNode.getRoles();
+        return getList("roles", String.class);
     }
 
     @Override
     public boolean hasRole(String role) {
-        return this.abstractNode.hasRole(role);
+        return getBoolean("role?", role);
     }
 
     @Override
     public boolean isReftext() {
-        return this.abstractNode.isReftext();
+        return getBoolean("reftext?");
     }
 
     @Override
     public String getReftext() {
-        return this.abstractNode.getReftext();
+        return getString("reftext");
     }
 
     @Override
     public String iconUri(String name) {
-        return this.abstractNode.iconUri(name);
+        return getString("icon_uri", name);
     }
 
     @Override
     public String mediaUri(String target) {
-        return this.abstractNode.mediaUri(target);
+        return getString("media_uri", target);
     }
 
     @Override
     public String imageUri(String targetImage) {
-        return this.abstractNode.imageUri(targetImage);
+        return getString("image_uri", targetImage);
     }
 
     @Override
     public String imageUri(String targetImage, String assetDirKey) {
-        return this.abstractNode.imageUri(targetImage, assetDirKey);
+        return getString("image_uri", targetImage, assetDirKey);
     }
 
     @Override
     public String readAsset(String path, Map<Object, Object> opts) {
-        return this.abstractNode.readAsset(path, RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime, opts));
+        return getString("read_asset", path, RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime, opts));
     }
 
     @Override
     public String normalizeWebPath(String path, String start, boolean preserveUriTarget) {
-        return this.abstractNode.normalizeWebPath(path, start, preserveUriTarget);
+        return getString("normalize_web_path", path, start, preserveUriTarget);
     }
 
     @Override
     public String getStyle() {
-
-        IRubyObject style = ((RubyObjectHolderProxy) this.abstractNode).__ruby_object()
-                .getInstanceVariables()
-                .getInstanceVariable("@style");
-
-        if (style == null) {
-            return null;
-        } else {
-            return RubyUtils.rubyToJava(runtime, style, String.class);
-        }
+        return getString("@style");
     }
 
     @Override
     public String listMarkerKeyword() {
-        return abstractNode.listMarkerKeyword();
+        return getString("list_marker_keyword");
     }
 
     @Override
     public String listMarkerKeyword(String listType) {
-        return abstractNode.listMarkerKeyword(listType);
+        return getString("list_marker_keyword", listType);
     }
 
-    /**
-     * @return The nodes delegate in the Ruby world
-     */
-    public AbstractNode getDelegate() {
-        return abstractNode;
+
+    protected String getString(String propertyName, Object... args) {
+        IRubyObject result = getProperty(propertyName, args);
+
+        if (result instanceof RubyNil) {
+            return null;
+        } else if (result instanceof RubySymbol) {
+            return ((RubySymbol) result).asJavaString();
+        } else {
+            return ((RubyString) result).asJavaString();
+        }
     }
+
+    protected boolean getBoolean(String propertyName, Object... args) {
+        IRubyObject result = getProperty(propertyName, args);
+        if (result instanceof RubyNil) {
+            return false;
+        } else {
+            return ((RubyBoolean) result).isTrue();
+        }
+    }
+
+    protected int getInt(String propertyName, Object... args) {
+        IRubyObject result = getProperty(propertyName, args);
+        if (result instanceof RubyNil) {
+            return 0;
+        } else {
+            return (int) ((RubyNumeric) result).getLongValue();
+        }
+    }
+
+    protected <T> List<T> getList(String propertyName, Class<T> elementClass, Object... args) {
+        IRubyObject result = getProperty(propertyName, args);
+        if (result instanceof RubyNil) {
+            return null;
+        } else {
+            List<T> ret = new ArrayList<T>();
+            RubyArray array = (RubyArray) result;
+            for (int i = 0; i < array.size(); i++) {
+                ret.add(RubyUtils.rubyToJava(runtime, array.at(RubyFixnum.newFixnum(runtime, i)), elementClass));
+            }
+            return ret;
+        }
+    }
+
+
+    protected IRubyObject getProperty(String propertyName, Object... args) {
+        ThreadContext threadContext = runtime.getThreadService().getCurrentContext();
+
+        IRubyObject result = null;
+        if (propertyName.startsWith("@")) {
+            if (args != null) {
+                throw new IllegalArgumentException("No args allowed for direct field access");
+            }
+            result = rubyNode.getInstanceVariables().getInstanceVariable(propertyName);
+        } else {
+            if (args == null) {
+                result = rubyNode.callMethod(threadContext, propertyName);
+            } else {
+                IRubyObject[] rubyArgs = new IRubyObject[args.length];
+                for (int i = 0; i < args.length; i++) {
+                    rubyArgs[i] = JavaEmbedUtils.javaToRuby(runtime, args[i]);
+                }
+                result = rubyNode.callMethod(threadContext, propertyName, rubyArgs);
+            }
+        }
+        return result;
+    }
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Block.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Block.java
@@ -3,6 +3,26 @@ package org.asciidoctor.ast;
 import java.util.List;
 
 public interface Block extends AbstractBlock {
+    /**
+     * @deprecated Please use {@link #getLines}
+     * @return The original content of this block
+     */
     List<String> lines();
+
+    /**
+     * @return The original content of this block
+     */
+    List<String> getLines();
+
+    /**
+     * @deprecated Please use {@link #getSource}
+     * @return the String containing the lines joined together or null if there are no lines
+     */
     String source();
+
+    /**
+     * @return the String containing the lines joined together or null if there are no lines
+     */
+    String getSource();
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/BlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/BlockImpl.java
@@ -3,22 +3,21 @@ package org.asciidoctor.ast;
 import java.util.List;
 
 import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public class BlockImpl extends AbstractBlockImpl implements Block {
-    private Block blockDelegate;
 
-    public BlockImpl(Block blockDelegate, Ruby runtime) {
-        super(blockDelegate, runtime);
-        this.blockDelegate = blockDelegate;
+    public BlockImpl(IRubyObject blockDelegate) {
+        super(blockDelegate);
     }
 
     @Override
     public List<String> lines() {
-        return blockDelegate.lines();
+        return getList("lines", String.class);
     }
     
     @Override
     public String source() {
-        return blockDelegate.source();
+        return getString("source");
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/BlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/BlockImpl.java
@@ -2,7 +2,6 @@ package org.asciidoctor.ast;
 
 import java.util.List;
 
-import org.jruby.Ruby;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class BlockImpl extends AbstractBlockImpl implements Block {
@@ -13,11 +12,22 @@ public class BlockImpl extends AbstractBlockImpl implements Block {
 
     @Override
     public List<String> lines() {
+        return getLines();
+    }
+
+    @Override
+    public List<String> getLines() {
         return getList("lines", String.class);
     }
-    
+
     @Override
     public String source() {
+        return getSource();
+    }
+
+    @Override
+    public String getSource() {
         return getString("source");
     }
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
@@ -3,51 +3,48 @@ package org.asciidoctor.ast;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyHash;
+import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class Document extends AbstractBlockImpl implements DocumentRuby {
 
-    private DocumentRuby documentDelegate;
-
-    public Document(DocumentRuby documentRuby, Ruby runtime) {
-        super(documentRuby, runtime);
-        this.documentDelegate = documentRuby;
-    }
-
-    public DocumentRuby getDocumentRuby() {
-        return documentDelegate;
+    public Document(IRubyObject documentRuby) {
+        super(documentRuby);
     }
 
     @Override
     public boolean basebackend(String backend) {
-        return documentDelegate.basebackend(backend);
+        return getBoolean("basebackend?", backend);
     }
 
     @Override
     public Map<Object, Object> getOptions() {
-        Map<Object, Object> options = (Map<Object, Object>)documentDelegate.getOptions();
-        return RubyHashUtil.convertRubyHashMapToMap(options);
+        return RubyHashUtil.convertRubyHashMapToMap((RubyHash) getProperty("options"));
     }
 
     @Override
     public Object doctitle(Map<Object, Object> opts) {
         RubyHash mapWithSymbols = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime, opts);
 
-        Object doctitle = documentDelegate.doctitle(mapWithSymbols);
+        Object doctitle = getProperty("doctitle", mapWithSymbols);
 
-        if (doctitle instanceof IRubyObject) {
-            doctitle = RubyUtils.rubyToJava(runtime, (IRubyObject) doctitle, Title.class);
+        if (doctitle instanceof RubyString) {
+            return ((RubyString) doctitle).asJavaString();
+        } else if (doctitle instanceof String) {
+            return doctitle;
+        } else {
+            return RubyUtils.rubyToJava(runtime, (IRubyObject) doctitle, Title.class);
         }
 
-        return doctitle;
     }
 
     public String doctitle() {
-        return (String) doctitle(new HashMap<Object, Object>());
+        return getString("doctitle");
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
@@ -3,8 +3,11 @@ package org.asciidoctor.ast;
 import java.util.Map;
 
 import org.asciidoctor.internal.RubyHashUtil;
+import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyHash;
 import org.jruby.RubyString;
+import org.jruby.RubySymbol;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class Document extends AbstractBlockImpl implements DocumentRuby {
@@ -29,23 +32,24 @@ public class Document extends AbstractBlockImpl implements DocumentRuby {
     }
 
     @Override
-    public Object doctitle(Map<Object, Object> opts) {
-        RubyHash mapWithSymbols = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime, opts);
+    public Title getStructuredDoctitle() {
+        Ruby runtime = getRubyObject().getRuntime();
+        RubyHash options = RubyHash.newHash(runtime);
+        RubySymbol partitioned = RubySymbol.newSymbol(runtime, "partition");
+        options.put(partitioned, RubyBoolean.newBoolean(runtime, true));
 
-        Object doctitle = getRubyProperty("doctitle", mapWithSymbols);
+        Object doctitle = getRubyProperty("doctitle", options);
 
-        if (doctitle instanceof RubyString) {
-            return ((RubyString) doctitle).asJavaString();
-        } else if (doctitle instanceof String) {
-            return doctitle;
-        } else {
-            return toJava((IRubyObject) doctitle, Title.class);
-        }
+        return toJava((IRubyObject) doctitle, Title.class);
 
     }
 
-    public String doctitle() {
+    public String getDoctitle() {
         return getString("doctitle");
+    }
+
+    public String doctitle() {
+        return getDoctitle();
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
@@ -1,12 +1,8 @@
 package org.asciidoctor.ast;
 
-import java.util.HashMap;
 import java.util.Map;
 
-import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
-import org.asciidoctor.internal.RubyUtils;
-import org.jruby.Ruby;
 import org.jruby.RubyHash;
 import org.jruby.RubyString;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -18,27 +14,32 @@ public class Document extends AbstractBlockImpl implements DocumentRuby {
     }
 
     @Override
-    public boolean basebackend(String backend) {
+    public boolean isBasebackend(String backend) {
         return getBoolean("basebackend?", backend);
     }
 
     @Override
+    public boolean basebackend(String backend) {
+        return isBasebackend(backend);
+    }
+
+    @Override
     public Map<Object, Object> getOptions() {
-        return RubyHashUtil.convertRubyHashMapToMap((RubyHash) getProperty("options"));
+        return RubyHashUtil.convertRubyHashMapToMap((RubyHash) getRubyProperty("options"));
     }
 
     @Override
     public Object doctitle(Map<Object, Object> opts) {
         RubyHash mapWithSymbols = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime, opts);
 
-        Object doctitle = getProperty("doctitle", mapWithSymbols);
+        Object doctitle = getRubyProperty("doctitle", mapWithSymbols);
 
         if (doctitle instanceof RubyString) {
             return ((RubyString) doctitle).asJavaString();
         } else if (doctitle instanceof String) {
             return doctitle;
         } else {
-            return RubyUtils.rubyToJava(runtime, (IRubyObject) doctitle, Title.class);
+            return toJava((IRubyObject) doctitle, Title.class);
         }
 
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DocumentRuby.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DocumentRuby.java
@@ -6,22 +6,23 @@ import java.util.Map;
 public interface DocumentRuby extends AbstractBlock {
 
     /**
-     * Get doc title
-     * 
-     * @param opts
-     *            to get the doc title. Key should be Ruby symbols.
-     * @return String if partition flag is not set to false or not present, Title if partition is set to true.
+     * @return The Title structure for this document.
      * @see Title
      */
-    Object doctitle(Map<Object, Object> opts);
+    Title getStructuredDoctitle();
 
     /**
-     * Get doc title
-     *
-     * @return String if partition flag is not set to false or not present, Title if partition is set to true.
+     * @return The title as a String.
      * @see Title
      */
-    Object doctitle();
+    String getDoctitle();
+
+    /**
+     * @deprecated Please use {@link #getDoctitle()}
+     * @return The title as a String.
+     * @see Title
+     */
+    String doctitle();
 
     /**
      * 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DocumentRuby.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DocumentRuby.java
@@ -1,7 +1,5 @@
 package org.asciidoctor.ast;
 
-import org.jruby.RubySymbol;
-
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +36,12 @@ public interface DocumentRuby extends AbstractBlock {
     Map<String, Object> getAttributes();
 
     /**
-     * 
+     * @return basebackend attribute value
+     */
+    boolean isBasebackend(String backend);
+
+    /**
+     * @deprecated Please use {@link #isBasebackend(String)}
      * @return basebackend attribute value
      */
     boolean basebackend(String backend);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/InlineImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/InlineImpl.java
@@ -1,38 +1,36 @@
 package org.asciidoctor.ast;
 
 import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public class InlineImpl extends AbstractNodeImpl implements Inline  {
 
-    protected Inline delegate;
-
-    public InlineImpl(Inline delegate, Ruby ruby) {
-        super(delegate, ruby);
-        this.delegate = delegate;
+    public InlineImpl(IRubyObject delegate) {
+        super(delegate);
     }
 
     @Override
     public String render() {
-        return delegate.render();
+        return getString("render");
     }
 
     @Override
     public String convert() {
-        return delegate.convert();
+        return getString("convert");
     }
 
     @Override
     public String getType() {
-        return delegate.getType();
+        return getString("type");
     }
 
     @Override
     public String getText() {
-        return delegate.getText();
+        return getString("text");
     }
 
     @Override
     public String getTarget() {
-        return delegate.getTarget();
+        return getString("target");
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListImpl.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.ast;
 
-import org.jruby.Ruby;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.List;
@@ -17,7 +16,7 @@ public class ListImpl extends AbstractBlockImpl implements ListNode {
     }
 
     @Override
-    public boolean isItem() {
+    public boolean hasItems() {
         return getBoolean("items?");
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListImpl.java
@@ -1,35 +1,33 @@
 package org.asciidoctor.ast;
 
 import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.List;
 
 public class ListImpl extends AbstractBlockImpl implements ListNode {
 
-    private final ListNode listDelegate;
-
-    public ListImpl(ListNode delegate, Ruby rubyRuntime) {
-        super(delegate, rubyRuntime);
-        this.listDelegate = delegate;
+    public ListImpl(IRubyObject delegate) {
+        super(delegate);
     }
 
     @Override
     public List<AbstractBlock> getItems() {
-        return blocks();
+        return getBlocks();
     }
 
     @Override
     public boolean isItem() {
-        return isBlock();
+        return getBoolean("items?");
     }
 
     @Override
     public String render() {
-        return listDelegate.render();
+        return getString("render");
     }
 
     @Override
     public String convert() {
-        return listDelegate.convert();
+        return getString("convert");
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItemImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItemImpl.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.ast;
 
-import org.jruby.Ruby;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class ListItemImpl extends AbstractBlockImpl implements ListItem {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItemImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItemImpl.java
@@ -1,28 +1,26 @@
 package org.asciidoctor.ast;
 
 import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public class ListItemImpl extends AbstractBlockImpl implements ListItem {
 
-    private final ListItem listDelegate;
-
-    public ListItemImpl(ListItem listDelegate, Ruby runtime) {
-        super(listDelegate, runtime);
-        this.listDelegate = listDelegate;
+    public ListItemImpl(IRubyObject listDelegate) {
+        super(listDelegate);
     }
 
     @Override
     public String getMarker() {
-        return listDelegate.getMarker();
+        return getString("marker");
     }
 
     @Override
     public String getText() {
-        return listDelegate.getText();
+        return getString("text");
     }
 
     @Override
     public boolean hasText() {
-        return listDelegate.hasText();
+        return getBoolean("text?");
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListNode.java
@@ -4,7 +4,7 @@ public interface ListNode extends AbstractBlock {
 
     java.util.List<AbstractBlock> getItems();
 
-    boolean isItem();
+    boolean hasItems();
 
     @Deprecated
     public String render();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeCache.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeCache.java
@@ -1,0 +1,49 @@
+package org.asciidoctor.ast;
+
+import org.jruby.Ruby;
+import org.jruby.RubyHash;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * This class helps at attaching AsciidoctorJ specific information to Ruby AST nodes.
+ * For example the Java counterpart of a Ruby node can be attached to the Ruby node to always return the
+ * same Java instance for the same Ruby node
+ */
+public class NodeCache {
+
+
+    private static final String ASCIIDOCTORJ_CACHE = "asciidoctorj_cache";
+
+    private static final String KEY_AST_NODE = "asciidoctorj_node";
+
+    private final RubyHash cache;
+    private Ruby runtime;
+
+    public static NodeCache get(IRubyObject rubyObject) {
+
+        RubyHash cache = (RubyHash) rubyObject.getInstanceVariables().getInstanceVariable(ASCIIDOCTORJ_CACHE);
+        if (cache == null) {
+            cache = RubyHash.newHash(rubyObject.getRuntime());
+            rubyObject.getInstanceVariables().setInstanceVariable(ASCIIDOCTORJ_CACHE, cache);
+        }
+        return new NodeCache(cache);
+    }
+
+    private NodeCache(RubyHash cache) {
+        this.cache = cache;
+        this.runtime = cache.getRuntime();
+    }
+
+    public AbstractNode getASTNode() {
+        AbstractNode astNode = (AbstractNode) cache.get(getRuntime().newSymbol(KEY_AST_NODE));
+        return astNode;
+    }
+
+    public void setASTNode(AbstractNode astNode) {
+        cache.put(getRuntime().newSymbol(KEY_AST_NODE), astNode);
+    }
+
+    Ruby getRuntime() {
+        return cache.getRuntime();
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
@@ -42,23 +42,17 @@ public final class NodeConverter {
             String rubyClassName = rubyObject.getMetaClass().getRealClass().getName();
             AbstractNode ret = null;
             if (BLOCK_CLASS.equals(rubyClassName)) {
-                Block blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, Block.class);
-                ret = new BlockImpl(blockRuby, runtime);
+                ret = new BlockImpl(rubyObject);
             } else if (SECTION_CLASS.equals(rubyClassName)) {
-                Section blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, Section.class);
-                ret = new SectionImpl(blockRuby, runtime);
+                ret = new SectionImpl(rubyObject);
             } else if (DOCUMENT_CLASS.equals(rubyClassName)) {
-                DocumentRuby blockRuby = RubyUtils.rubyToJava(runtime, rubyObject, DocumentRuby.class);
-                ret = new Document(blockRuby, runtime);
+                ret = new Document(rubyObject);
             } else if (INLINE_CLASS.equals(rubyClassName)) {
-                Inline inline = RubyUtils.rubyToJava(runtime, rubyObject, Inline.class);
-                ret = new InlineImpl(inline, runtime);
+                ret = new InlineImpl(rubyObject);
             } else if (LIST_CLASS.equals(rubyClassName)) {
-                ListNode list = RubyUtils.rubyToJava(runtime, rubyObject, ListNode.class);
-                ret = new ListImpl(list, runtime);
+                ret = new ListImpl(rubyObject);
             } else if (LIST_ITEM_CLASS.equals(rubyClassName)) {
-                ListItem list = RubyUtils.rubyToJava(runtime, rubyObject, ListItem.class);
-                ret = new ListItemImpl(list, runtime);
+                ret = new ListItemImpl(rubyObject);
             } else {
                 throw new IllegalArgumentException("Don't know what to do with a " + rubyObject);
             }
@@ -75,7 +69,7 @@ public final class NodeConverter {
         }
     }
 
-    private static IRubyObject asRubyObject(Object o) {
+    public static IRubyObject asRubyObject(Object o) {
         if (o instanceof IRubyObject) {
             return (IRubyObject) o;
         } else if (o instanceof RubyObjectHolderProxy) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Section.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Section.java
@@ -2,9 +2,59 @@ package org.asciidoctor.ast;
 
 public interface Section extends AbstractBlock {
 
+    /**
+     * @deprecated Please use {@link #getIndex()}
+     * @return the 0-based index order of this section within the parent block
+     */
     int index();
+
+    /**
+     * @return the 0-based index order of this section within the parent block
+     */
+    int getIndex();
+
+    /**
+     * @deprecated Please use {@link #getNumber()}
+     * @return the number of this section within the parent block
+     */
     int number();
+
+    /**
+     * @return the number of this section within the parent block
+     */
+    int getNumber();
+
+    /**
+     * @deprecated Please use {@link #getSectionName()}
+     * @return the section name of this section
+     */
     String sectname();
+
+    /**
+     * @return the section name of this section
+     */
+    String getSectionName();
+
+    /**
+     * @deprecated Please use {@link #isSpecial()}
+     * @return Get the flag to indicate whether this is a special section or a child of one
+     */
     boolean special();
-    int numbered();
+
+    /**
+     * @return Get the flag to indicate whether this is a special section or a child of one
+     */
+    boolean isSpecial();
+
+    /**
+     * @deprecated Please use {@link #isNumbered()}
+     * @return the state of the numbered attribute at this section (need to preserve for creating TOC)
+     */
+    boolean numbered();
+
+    /**
+     * @return the state of the numbered attribute at this section (need to preserve for creating TOC)
+     */
+    boolean isNumbered();
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/SectionImpl.java
@@ -1,39 +1,37 @@
 package org.asciidoctor.ast;
 
 import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public class SectionImpl extends AbstractBlockImpl implements Section {
 
-    private Section delegate;
-    
-    public SectionImpl(Section blockDelegate, Ruby runtime) {
-        super(blockDelegate, runtime);
-        this.delegate = blockDelegate;
+    public SectionImpl(IRubyObject blockDelegate) {
+        super(blockDelegate);
     }
 
     @Override
     public int index() {
-        return this.delegate.index();
+        return getInt("index");
     }
 
     @Override
     public int number() {
-        return this.delegate.number();
+        return getInt("number");
     }
 
     @Override
     public String sectname() {
-        return this.delegate.sectname();
+        return getString("sectname");
     }
 
     @Override
     public boolean special() {
-        return this.delegate.special();
+        return getBoolean("special");
     }
 
     @Override
     public int numbered() {
-        return this.delegate.number();
+        return getInt("numbered");
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/SectionImpl.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.ast;
 
-import org.jruby.Ruby;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class SectionImpl extends AbstractBlockImpl implements Section {
@@ -11,27 +10,52 @@ public class SectionImpl extends AbstractBlockImpl implements Section {
 
     @Override
     public int index() {
+        return getIndex();
+    }
+
+    @Override
+    public int getIndex() {
         return getInt("index");
     }
 
     @Override
     public int number() {
+        return getNumber();
+    }
+
+    @Override
+    public int getNumber() {
         return getInt("number");
     }
 
     @Override
     public String sectname() {
+        return getSectionName();
+    }
+
+    @Override
+    public String getSectionName() {
         return getString("sectname");
     }
 
     @Override
     public boolean special() {
+        return isSpecial();
+    }
+
+    @Override
+    public boolean isSpecial() {
         return getBoolean("special");
     }
 
     @Override
-    public int numbered() {
-        return getInt("numbered");
+    public boolean numbered() {
+        return isNumbered();
+    }
+
+    @Override
+    public boolean isNumbered() {
+        return getBoolean("numbered");
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Postprocessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Postprocessor.java
@@ -3,7 +3,6 @@ package org.asciidoctor.extension;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
 
 public abstract class Postprocessor extends Processor {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
@@ -1,9 +1,12 @@
 package org.asciidoctor.extension.processorproxies;
 
+import org.asciidoctor.ast.AbstractNodeImpl;
 import org.asciidoctor.extension.Processor;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
+import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
 
@@ -42,6 +45,14 @@ public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
 
     public void finalizeJavaConfig() {
         getProcessor().setConfigFinalized();
+    }
+
+    protected IRubyObject convertProcessorResult(Object o) {
+        if (o instanceof AbstractNodeImpl) {
+            return ((AbstractNodeImpl) o).getRubyObject();
+        } else {
+            return JavaEmbedUtils.javaToRuby(getRuntime(), o);
+        }
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
@@ -1,6 +1,8 @@
 package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.AbstractNode;
+import org.asciidoctor.ast.AbstractNodeImpl;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.BlockMacroProcessor;
 import org.asciidoctor.internal.RubyHashMapDecorator;
@@ -103,12 +105,13 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
 
     @JRubyMethod(name = "process", required = 3)
     public IRubyObject process(ThreadContext context, IRubyObject parent, IRubyObject target, IRubyObject attributes) {
-        return JavaEmbedUtils.javaToRuby(
-                getRuntime(),
-                getProcessor().process(
-                        (AbstractBlock) NodeConverter.createASTNode(parent),
-                        RubyUtils.rubyToJava(getRuntime(), target, String.class),
-                        RubyUtils.rubyToJava(getRuntime(), attributes, Map.class)));
+        Object o = getProcessor().process(
+                (AbstractBlock) NodeConverter.createASTNode(parent),
+                RubyUtils.rubyToJava(getRuntime(), target, String.class),
+                RubyUtils.rubyToJava(getRuntime(), attributes, Map.class));
+
+        return convertProcessorResult(o);
+
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.AbstractNodeImpl;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.BlockProcessor;
 import org.asciidoctor.extension.Reader;
@@ -116,12 +117,12 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
 
     @JRubyMethod(name = "process", required = 3)
     public IRubyObject process(ThreadContext context, IRubyObject parent, IRubyObject reader, IRubyObject attributes) {
-        return JavaEmbedUtils.javaToRuby(
-                getRuntime(),
-                getProcessor().process(
-                        (AbstractBlock) NodeConverter.createASTNode(parent),
-                        RubyUtils.rubyToJava(getRuntime(), reader, Reader.class),
-                        RubyUtils.rubyToJava(getRuntime(), attributes, Map.class)));
+        Object o = getProcessor().process(
+                (AbstractBlock) NodeConverter.createASTNode(parent),
+                RubyUtils.rubyToJava(getRuntime(), reader, Reader.class),
+                RubyUtils.rubyToJava(getRuntime(), attributes, Map.class));
+
+        return convertProcessorResult(o);
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
@@ -2,6 +2,7 @@ package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.DocinfoProcessor;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
@@ -104,10 +105,7 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
     public IRubyObject process(ThreadContext context, IRubyObject document) {
         return JavaEmbedUtils.javaToRuby(
                 getRuntime(),
-                getProcessor().process(
-                        new Document(
-                                RubyUtils.rubyToJava(getRuntime(), document, DocumentRuby.class),
-                                getRuntime())));
+                getProcessor().process((DocumentRuby) NodeConverter.createASTNode(document)));
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
@@ -2,6 +2,7 @@ package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.IncludeProcessor;
 import org.asciidoctor.extension.PreprocessorReader;
 import org.asciidoctor.internal.RubyHashMapDecorator;
@@ -110,10 +111,7 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
 
     @JRubyMethod(name = "process", required = 4)
     public IRubyObject process(ThreadContext context, IRubyObject[] args) {
-        DocumentRuby document =
-                new Document(
-                        RubyUtils.rubyToJava(getRuntime(), args[0], DocumentRuby.class),
-                        getRuntime());
+        DocumentRuby document = (DocumentRuby) NodeConverter.createASTNode(args[0]);
         PreprocessorReader reader = RubyUtils.rubyToJava(getRuntime(), args[1], PreprocessorReader.class);
         String target = RubyUtils.rubyToJava(getRuntime(), args[2], String.class);
         Map<String, Object> attributes = RubyUtils.rubyToJava(getRuntime(), args[3], Map.class);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.AbstractNodeImpl;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.internal.RubyHashMapDecorator;
@@ -122,12 +123,11 @@ public class InlineMacroProcessorProxy extends AbstractMacroProcessorProxy<Inlin
 
     @JRubyMethod(name = "process", required = 3)
     public IRubyObject process(ThreadContext context, IRubyObject parent, IRubyObject target, IRubyObject attributes) {
-        return JavaEmbedUtils.javaToRuby(
-                getRuntime(),
-                getProcessor().process(
-                        (AbstractBlock) NodeConverter.createASTNode(parent),
-                        RubyUtils.rubyToJava(getRuntime(), target, String.class),
-                        RubyUtils.rubyToJava(getRuntime(), attributes, Map.class)));
+        Object o = getProcessor().process(
+                (AbstractBlock) NodeConverter.createASTNode(parent),
+                RubyUtils.rubyToJava(getRuntime(), target, String.class),
+                RubyUtils.rubyToJava(getRuntime(), attributes, Map.class));
+        return convertProcessorResult(o);
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
@@ -1,7 +1,9 @@
 package org.asciidoctor.extension.processorproxies;
 
+import org.asciidoctor.ast.AbstractNodeImpl;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.Postprocessor;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
@@ -100,13 +102,11 @@ public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
 
     @JRubyMethod(name = "process", required = 2)
     public IRubyObject process(ThreadContext context, IRubyObject document, IRubyObject output) {
-        return JavaEmbedUtils.javaToRuby(
-                getRuntime(),
-                getProcessor().process(
-                        new Document(
-                                RubyUtils.rubyToJava(getRuntime(), document, DocumentRuby.class),
-                                getRuntime()),
-                        RubyUtils.rubyToJava(getRuntime(), output, String.class)));
+        Object o = getProcessor().process(
+                (DocumentRuby) NodeConverter.createASTNode(document),
+                RubyUtils.rubyToJava(getRuntime(), output, String.class));
+
+        return convertProcessorResult(o);
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
@@ -1,7 +1,9 @@
 package org.asciidoctor.extension.processorproxies;
 
+import org.asciidoctor.ast.AbstractNodeImpl;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.Preprocessor;
 import org.asciidoctor.extension.PreprocessorReader;
 import org.asciidoctor.internal.RubyHashMapDecorator;
@@ -98,12 +100,10 @@ public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
 
     @JRubyMethod(name = "process", required = 2)
     public IRubyObject process(ThreadContext context, IRubyObject document, IRubyObject preprocessorReader) {
-        return JavaEmbedUtils.javaToRuby(
-                getRuntime(),
-                getProcessor().process(
-                        new Document(
-                                RubyUtils.rubyToJava(getRuntime(), document, DocumentRuby.class),
-                                getRuntime()),
-                        RubyUtils.rubyToJava(getRuntime(), preprocessorReader, PreprocessorReader.class)));
+        Object o = getProcessor().process(
+                (DocumentRuby) NodeConverter.createASTNode(document),
+                RubyUtils.rubyToJava(getRuntime(), preprocessorReader, PreprocessorReader.class));
+
+        return convertProcessorResult(o);
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/ProcessorProxyUtil.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/ProcessorProxyUtil.java
@@ -19,7 +19,7 @@ public final class ProcessorProxyUtil {
      * from Asciidoctor::Extensions, e.g. Asciidoctor::Extensions::Treeprocessor
      * @param rubyRuntime
      * @param processorClassName
-     * @return
+     * @return The Ruby class object for the given extension class name, e.g. Asciidoctor::Extensions::TreeProcessor
      */
     public static RubyClass getExtensionBaseClass(Ruby rubyRuntime, String processorClassName) {
         RubyModule extensionsModule = getExtensionsModule(rubyRuntime);
@@ -29,7 +29,7 @@ public final class ProcessorProxyUtil {
     /**
      * Returns the Ruby module Asciidoc::Extensions.
      * @param rubyRuntime
-     * @return
+     * @return The Ruby object for the module Asciidoc::Extensions.
      */
     private static RubyModule getExtensionsModule(Ruby rubyRuntime) {
         RubyModule asciidoctorModule = rubyRuntime.getModule("Asciidoctor");

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
@@ -2,6 +2,7 @@ package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.Treeprocessor;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
@@ -100,11 +101,8 @@ public class TreeprocessorProxy extends AbstractProcessorProxy<Treeprocessor> {
 
     @JRubyMethod(name = "process", required = 1)
     public IRubyObject process(ThreadContext context, IRubyObject document) {
-        return JavaEmbedUtils.javaToRuby(
-                getRuntime(),
-                getProcessor().process(
-                        new Document(
-                                RubyUtils.rubyToJava(getRuntime(), document, DocumentRuby.class),
-                                getRuntime())));
+        Object o = getProcessor().process(
+                (DocumentRuby) NodeConverter.createASTNode(document));
+        return convertProcessorResult(o);
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -169,12 +169,10 @@ public class JRubyAsciidoctor implements Asciidoctor {
     }
 
     private DocumentHeader toDocumentHeader(DocumentRuby documentRuby) {
-        Map<Object, Object> opts = new HashMap<Object, Object>();
-        opts.put("partition", true);
 
         Document document = (Document) NodeConverter.createASTNode(documentRuby);
 
-        return DocumentHeader.createDocumentHeader((Title) document.doctitle(opts), document.title(),
+        return DocumentHeader.createDocumentHeader((Title) document.getStructuredDoctitle(), document.getDoctitle(),
                 document.getAttributes());
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -10,6 +10,7 @@ import org.asciidoctor.ast.ContentPart;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.ast.Title;
 import org.asciidoctor.converter.JavaConverterRegistry;
@@ -591,13 +592,13 @@ public class JRubyAsciidoctor implements Asciidoctor {
     @Override
     public Document load(String content, Map<String, Object> options) {
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
-        return new Document(this.asciidoctorModule.load(content, rubyHash), this.rubyRuntime);
+        return (Document) NodeConverter.createASTNode(this.asciidoctorModule.load(content, rubyHash));
     }
 
     @Override
     public Document loadFile(File file, Map<String, Object> options) {
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
-        return new Document(this.asciidoctorModule.load(file.getAbsolutePath(), rubyHash), this.rubyRuntime);
+        return (Document) NodeConverter.createASTNode(this.asciidoctorModule.load(file.getAbsolutePath(), rubyHash));
 
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -172,17 +172,17 @@ public class JRubyAsciidoctor implements Asciidoctor {
         Map<Object, Object> opts = new HashMap<Object, Object>();
         opts.put("partition", true);
 
-        Document document = new Document(documentRuby, rubyRuntime);
+        Document document = (Document) NodeConverter.createASTNode(documentRuby);
 
-        return DocumentHeader.createDocumentHeader((Title) document.doctitle(opts), documentRuby.title(),
-                documentRuby.getAttributes());
+        return DocumentHeader.createDocumentHeader((Title) document.doctitle(opts), document.title(),
+                document.getAttributes());
     }
 
     private StructuredDocument toDocument(DocumentRuby documentRuby, Ruby rubyRuntime, int maxDeepLevel) {
 
-        Document document = new Document(documentRuby, rubyRuntime);
-        List<ContentPart> contentParts = getContents(document.blocks(), 1, maxDeepLevel);
-        return StructuredDocument.createStructuredDocument(toDocumentHeader(documentRuby), contentParts);
+        Document document = (Document) NodeConverter.createASTNode(documentRuby);
+        List<ContentPart> contentParts = getContents(document.getBlocks(), 1, maxDeepLevel);
+        return StructuredDocument.createStructuredDocument(toDocumentHeader(document), contentParts);
     }
 
     private List<ContentPart> getContents(List<AbstractBlock> blocks, int level, int maxDeepLevel) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyAttributesMapDecorator.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyAttributesMapDecorator.java
@@ -1,0 +1,138 @@
+package org.asciidoctor.internal;
+
+import org.jruby.RubyHash;
+import org.jruby.RubyString;
+import org.jruby.RubySymbol;
+import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class RubyAttributesMapDecorator implements Map<String, Object> {
+
+    private final RubyHash rubyHash;
+
+    public RubyAttributesMapDecorator(RubyHash rubyHash) {
+        this.rubyHash = rubyHash;
+    }
+
+    @Override
+    public int size() {
+        return rubyHash.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return rubyHash.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (!(key instanceof String)) {
+            return false;
+        }
+        return rubyHash.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return rubyHash.containsValue(value);
+    }
+
+    @Override
+    public Object get(Object key) {
+        if (!(key instanceof String)) {
+            return false;
+        }
+        Object value = rubyHash.get(key);
+        return convertRubyValue(value);
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        Object oldValue = get(key);
+        rubyHash.put(key, convertJavaValue(value));
+        return oldValue;
+    }
+
+    @Override
+    public Object remove(Object key) {
+        if (!(key instanceof String)) {
+            return null;
+        }
+        Object oldValue = get(key);
+        rubyHash.remove(key);
+        return convertRubyValue(oldValue);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ?> m) {
+        for (Entry<? extends String, ?> entry: m.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public void clear() {
+        rubyHash.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return createJavaMap().keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return createJavaMap().values();
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        return createJavaMap().entrySet();
+    }
+
+    private Map<String, Object> createJavaMap() {
+        Map<String, Object> copy = new HashMap<String, Object>();
+        Set<Entry<Object, Object>> rubyEntrySet = rubyHash.entrySet();
+        for (Entry<Object, Object> o: rubyEntrySet) {
+            String key;
+            Object value;
+            Object rubyKey = o.getKey();
+            Object rubyValue = o.getValue();
+            if (rubyKey instanceof RubyString) {
+                key = ((RubyString) rubyKey).asJavaString();
+            } else if (rubyKey instanceof String) {
+                key = (String) rubyKey;
+            } else {
+                throw new IllegalStateException("Did not expect key " + rubyKey + " of type " + rubyKey.getClass());
+            }
+            value = convertRubyValue(rubyValue);
+            copy.put(key, value);
+        }
+        return copy;
+    }
+
+    private Object convertRubyValue(Object rubyValue) {
+        if (rubyValue == null) {
+            return null;
+        } else if (rubyValue instanceof IRubyObject) {
+            return JavaEmbedUtils.rubyToJava((IRubyObject) rubyValue);
+        } else {
+            return rubyValue;
+        }
+    }
+
+    private IRubyObject convertJavaValue(Object value) {
+        if (value == null) {
+            return null;
+        } else if (value instanceof String && ((String) value).startsWith(":")) {
+            return rubyHash.getRuntime().getSymbolTable().getSymbol(((String) value).substring(1));
+        } else {
+            return JavaEmbedUtils.javaToRuby(rubyHash.getRuntime(), value);
+        }
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyBlockListDecorator.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyBlockListDecorator.java
@@ -1,0 +1,209 @@
+package org.asciidoctor.internal;
+
+import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.AbstractBlockImpl;
+import org.asciidoctor.ast.NodeConverter;
+import org.jruby.RubyArray;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+
+
+public class RubyBlockListDecorator implements List<AbstractBlock> {
+
+    private final RubyArray rubyBlockList;
+
+    public RubyBlockListDecorator(RubyArray rubyBlockList) {
+        this.rubyBlockList = rubyBlockList;
+    }
+
+    @Override
+    public int size() {
+        return rubyBlockList.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return rubyBlockList.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if (!(o instanceof AbstractBlockImpl)) {
+            return false;
+        }
+        return rubyBlockList.contains(((AbstractBlockImpl) o).getRubyObject());
+    }
+
+    @Override
+    public Iterator<AbstractBlock> iterator() {
+        return new Iterator<AbstractBlock>() {
+            int index = 0;
+            @Override
+            public boolean hasNext() {
+                return index < size();
+            }
+
+            @Override
+            public AbstractBlock next() {
+                return get(index++);
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public Object[] toArray() {
+        return getJavaBlockList().toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return getJavaBlockList().toArray(a);
+    }
+
+    private List<AbstractBlock> getJavaBlockList() {
+        List<AbstractBlock> javaBlockList = new ArrayList<AbstractBlock>(rubyBlockList.size());
+        Object[] ret = new Object[size()];
+        for (int i = 0; i < rubyBlockList.size(); i++) {
+            javaBlockList.add((AbstractBlock) NodeConverter.createASTNode(rubyBlockList.get(i)));
+        }
+        return javaBlockList;
+    }
+
+    @Override
+    public boolean add(AbstractBlock abstractBlock) {
+        return rubyBlockList.add(((AbstractBlockImpl) abstractBlock).getRubyObject());
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (!(o instanceof AbstractBlock)) {
+            return false;
+        }
+        return rubyBlockList.remove(((AbstractBlockImpl) o).getRubyObject());
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return rubyBlockList.containsAll(getDelegateCollection(c));
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends AbstractBlock> c) {
+        return rubyBlockList.addAll(getDelegateCollection(c));
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends AbstractBlock> c) {
+        return rubyBlockList.addAll(index, getDelegateCollection(c));
+    }
+
+    private Collection<Object> getDelegateCollection(Collection<?> c) {
+        Collection<Object> delegateList = new ArrayList<Object>(c.size());
+        for (Object o: c) {
+            if (o instanceof AbstractBlockImpl) {
+                delegateList.add(((AbstractBlockImpl) o).getRubyObject());
+            } else {
+                delegateList.add(o);
+            }
+        }
+        return delegateList;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return rubyBlockList.removeAll(getDelegateCollection(c));
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return rubyBlockList.retainAll(getDelegateCollection(c));
+    }
+
+    @Override
+    public void clear() {
+        rubyBlockList.clear();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof RubyBlockListDecorator) {
+            return rubyBlockList.equals(((RubyBlockListDecorator) o).rubyBlockList);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return rubyBlockList.hashCode();
+    }
+
+    @Override
+    public AbstractBlock get(int index) {
+        return (AbstractBlock) NodeConverter.createASTNode(rubyBlockList.get(index));
+    }
+
+    @Override
+    public AbstractBlock set(int index, AbstractBlock element) {
+        Object oldObject = rubyBlockList.set(index, ((AbstractBlockImpl) element).getRubyObject());
+        return (AbstractBlock) NodeConverter.createASTNode(oldObject);
+    }
+
+    @Override
+    public void add(int index, AbstractBlock element) {
+        rubyBlockList.add(index, ((AbstractBlockImpl) element).getRubyObject());
+    }
+
+    @Override
+    public AbstractBlock remove(int index) {
+        Object oldObject = rubyBlockList.remove(index);
+        if (oldObject == null) {
+            return null;
+        } else {
+            return (AbstractBlock) NodeConverter.createASTNode(oldObject);
+        }
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        if (o instanceof AbstractBlock) {
+            return rubyBlockList.indexOf(((AbstractBlockImpl) o).getRubyObject());
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        if (o instanceof AbstractBlock) {
+            return rubyBlockList.lastIndexOf(((AbstractBlockImpl) o).getRubyObject());
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public ListIterator<AbstractBlock> listIterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListIterator<AbstractBlock> listIterator(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<AbstractBlock> subList(int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAstIsIterated.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAstIsIterated.groovy
@@ -1,0 +1,52 @@
+package org.asciidoctor.extension
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.DocumentRuby
+import spock.lang.Specification
+
+class WhenAstIsIterated extends Specification {
+
+    Asciidoctor asciidoctor = Asciidoctor.Factory.create()
+
+    final static DOCUMENT = '''
+= Hello World
+
+This is a test document
+
+== This is the first section
+
+This is a paragraph
+
+== Another section
+
+A list with items
+
+* One
+* Two
+* Three
+'''
+
+
+    def "getDocument should always return the same instance"() {
+        when:
+        DocumentRuby document = asciidoctor.load(DOCUMENT, [:])
+        List<AbstractBlock>  allBlocks = document.findBy([:])
+
+        then:
+        document.is(document.getDocument())
+        allBlocks.every { block -> document.is(block.getDocument()) }
+    }
+
+    def "getParent should always return the same instance"() {
+        when:
+        DocumentRuby document = asciidoctor.load(DOCUMENT, [:])
+        def allBlocks = document.findBy([:])
+
+        then: 'Every block of the document should return the same node as the parent from getParent()'
+        allBlocks.every {
+            block -> block.getBlocks().every { child -> block.is(child.getParent()) }
+        }
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -213,12 +213,6 @@ public class WhenAsciiDocIsRenderedToDocument {
     }
 
     @Test
-    public void should_be_able_to_get_list_marker_keyword() {
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
-        assertThat(document.listMarkerKeyword("upperalpha"), is("A"));
-    }
-
-    @Test
     public void should_be_able_to_set_attribute() {
         final Object attributeName = "testattribute";
         final Object attributeValue = "testvalue";

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -1,6 +1,8 @@
 package org.asciidoctor;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
@@ -98,6 +100,7 @@ public class WhenAsciiDocIsRenderedToDocument {
         assertThat(findBy, hasSize(2));
         
         assertThat((String)findBy.get(0).getAttributes().get("target"), is("tiger.png"));
+        assertThat(findBy.get(0).getLevel(), greaterThan(0));
         
     }
 
@@ -146,7 +149,7 @@ public class WhenAsciiDocIsRenderedToDocument {
         AbstractBlock abstractBlock = document.blocks().get(0);
         assertThat(abstractBlock.getRole(), is("famous"));
         assertThat(abstractBlock.hasRole("famous"), is(true));
-        //assertThat(abstractBlock.isRole(), is(true));
+        assertThat(abstractBlock.isRole(), is(true));
         assertThat(abstractBlock.getRoles(), contains("famous"));
     }
 
@@ -207,6 +210,32 @@ public class WhenAsciiDocIsRenderedToDocument {
         File inputFile = classpath.getResource("rendersample.asciidoc");
         String content = document.readAsset(inputFile.getAbsolutePath(), new HashMap<Object, Object>());
         assertThat(content, is(IOUtils.readFull(new FileReader(inputFile))));
+    }
+
+    @Test
+    public void should_be_able_to_get_list_marker_keyword() {
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        assertThat(document.listMarkerKeyword("upperalpha"), is("A"));
+    }
+
+    @Test
+    public void should_be_able_to_set_attribute() {
+        final Object attributeName = "testattribute";
+        final Object attributeValue = "testvalue";
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        assertThat(document.setAttr(attributeName, attributeValue, true), is(true));
+        assertThat(document.getAttr(attributeName), is(attributeValue));
+        assertThat(document.getAttributes().get(attributeName), is(attributeValue));
+    }
+
+    @Test
+    public void should_be_able_to_set_attribute_on_attributes_map() {
+        final String attributeName = "testattribute";
+        final Object attributeValue = "testvalue";
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        document.getAttributes().put(attributeName, attributeValue);
+        assertThat(document.getAttr(attributeName), is(attributeValue));
+        assertThat(document.getAttributes().get(attributeName), is(attributeValue));
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/CustomFooterPostProcessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/CustomFooterPostProcessor.java
@@ -19,7 +19,7 @@ public class CustomFooterPostProcessor extends Postprocessor {
         
         String copyright  = "Copyright Acme, Inc.";
         
-        if(document.basebackend("html")) {
+        if(document.isBasebackend("html")) {
             org.jsoup.nodes.Document doc = Jsoup.parse(output, "UTF-8");
 
             Element contentElement = doc.getElementById("footer-text");

--- a/asciidoctorj-core/src/test/java/unusual/extension/BoldifyPostProcessor.java
+++ b/asciidoctorj-core/src/test/java/unusual/extension/BoldifyPostProcessor.java
@@ -11,7 +11,7 @@ import org.asciidoctor.extension.Postprocessor;
  */
 public class BoldifyPostProcessor extends Postprocessor {
   @Override public String process(DocumentRuby document, String output) {
-    if (document.basebackend("html")) {
+    if (document.isBasebackend("html")) {
       return output.replaceAll("bold", "<b>bold</b>");
     } else {
       return output;


### PR DESCRIPTION
…to the same Java node

With this PR the NodeConverter will first ask the NodeCache if there is already a Java Node for the given Ruby node.
The NodeCache caches such information in the new member `@asciidoctorj_cache` that is a RubyHash and will contain the Java object under the key `:asciidoctorj_node`.

Additionally I changed the methods like getDocument(), getParent() & findBy() to always invoke the NodeConverter when returning a node.