### PR TITLE
Upgrade asciidoctor-pdf to 1.5.0-alpha7

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -25,6 +25,8 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   include "gems/prawn-$prawnGemVersion/VERSION"
   include "gems/prawn-$prawnGemVersion/data/*.txt"
   include "gems/prawn-$prawnGemVersion/data/encodings/*"
+  // Accomodate Addressable's non-conforming packaging
+  include "gems/addressable-*/data/*.data"
 }
 
 jrubyPrepareGems << {

--- a/asciidoctorj-pdf/gradle.properties
+++ b/asciidoctorj-pdf/gradle.properties
@@ -1,3 +1,3 @@
 properName=AsciidoctorJ PDF
 description=AsciidoctorJ PDF bundles the Asciidoctor PDF RubyGem (asciidoctor-pdf) so it can be loaded into the JVM using JRuby.
-version=1.5.0-alpha.6
+version=1.5.0-alpha.7


### PR DESCRIPTION
Had to add manually copying content from the addressable gem, otherwise addressable-
/data/unicode.data is not available.