### PR TITLE
Add OSGi metadata to asciidoctorj-core jar

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -39,12 +39,12 @@ jar {
   manifest {
     symbolicName = 'org.asciidoctor'
     instruction 'Export-Package',
-      'org.asciidoctor',
-      'org.asciidoctor.ast',
-      'org.asciidoctor.converter',
-      'org.asciidoctor.converter.spi',
-      'org.asciidoctor.extension',
-      'org.asciidoctor.extension.spi'
+      "org.asciidoctor;version=\"${version}\"",
+      "org.asciidoctor.ast;version=\"${version}\"",
+      "org.asciidoctor.converter;version=\"${version}\"",
+      "org.asciidoctor.converter.spi;version=\"${version}\"",
+      "org.asciidoctor.extension;version=\"${version}\"",
+      "org.asciidoctor.extension.spi;version=\"${version}\""
     instruction 'Import-Package',
       'com.beust.jcommander;resolution:=optional',
       '*'

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'osgi'
+
 dependencies {
   compile "org.jruby:jruby-complete:$jrubyVersion"
   compile "com.beust:jcommander:$jcommanderVersion"
@@ -32,3 +34,19 @@ jrubyPrepareGems << {
 //jruby {
 //	execVersion = '1.7.20'
 //}
+
+jar {
+  manifest {
+    symbolicName = 'org.asciidoctor'
+    instruction 'Export-Package',
+      'org.asciidoctor',
+      'org.asciidoctor.ast',
+      'org.asciidoctor.converter',
+      'org.asciidoctor.converter.spi',
+      'org.asciidoctor.extension',
+      'org.asciidoctor.extension.spi'
+    instruction 'Import-Package',
+      'com.beust.jcommander;resolution:=optional',
+      '*'
+  }
+}


### PR DESCRIPTION
This just added some OSGi Metadata to the asciidoctorj-core.jar and makes it a OSGi bundle. That way, it can be loaded and used in OSGi environments as-is.

It does not add any special OSGi support, e.g. a `BundleActivator` or some service registrations. See also #297.