### PR TITLE
Use only one way to initialize a Ruby instance

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -705,6 +705,8 @@ public interface Asciidoctor {
          * @param classloader
          * @return Asciidoctor instance which uses JRuby to wraps Asciidoctor
          *         Ruby calls.
+         * @deprecated Please use {@link #create()} and set the TCCL before or {@link #create(List)} passing the paths
+         * that you would have used to create the ClassLoader.
          */
         public static Asciidoctor create(ClassLoader classloader) {
             return JRubyAsciidoctor.create(classloader);
@@ -715,9 +717,26 @@ public interface Asciidoctor {
          * @param classloader
          * @param gemPath
          * @return Asciidoctor instance which uses JRuby to wraps Asciidoctor
+         * @deprecated Please use {@link #create(String)} and set the TCCL before or {@link #create(List, String)}
+         * passing the paths that you would have used to create the ClassLoader.
          */
         public static Asciidoctor create(ClassLoader classloader, String gemPath) {
             return JRubyAsciidoctor.create(classloader, gemPath);
+        }
+
+        /**
+         * Creates a new instance of Asciidoctor and sets loadPath to provided paths.
+         * The gem path of the Ruby instance is set to the gemPath parameter.
+         *
+         * @param loadPaths
+         *            where Ruby libraries are located.
+         * @param gemPath
+         *           where gems are located.
+         * @return Asciidoctor instance which uses JRuby to wraps Asciidoctor
+         *         Ruby calls.
+         */
+        public static Asciidoctor create(List<String> loadPaths, String gemPath) {
+            return JRubyAsciidoctor.create(loadPaths, gemPath);
         }
 
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -656,8 +656,9 @@ public interface Asciidoctor {
      * @author lordofthejars
      * 
      */
-    public static class Factory {
+    public static final class Factory {
 
+        private Factory() {}
         /**
          * Creates a new instance of Asciidoctor.
          * 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -73,6 +73,10 @@ public class JRubyAsciidoctor implements Asciidoctor {
         return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), classloader, gemPath));
     }
 
+    public static JRubyAsciidoctor create(List<String> loadPaths, String gemPath) {
+        return processRegistrations(createJRubyAsciidoctorInstance(null, loadPaths, null, gemPath));
+    }
+
     private static JRubyAsciidoctor processRegistrations(JRubyAsciidoctor asciidoctor) {
         registerExtensions(asciidoctor);
         registerConverters(asciidoctor);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -29,7 +29,6 @@ import org.jruby.javasupport.JavaEmbedUtils;
 
 import java.io.*;
 import java.util.*;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class JRubyAsciidoctor implements Asciidoctor {
@@ -52,47 +51,31 @@ public class JRubyAsciidoctor implements Asciidoctor {
     }
 
     public static JRubyAsciidoctor create() {
-        Map<String, Object> env = new HashMap<String, Object>();
+        //Map<String, Object> env = new HashMap<String, Object>();
         // ideally, we want to clear GEM_PATH by default, but for backwards compatibility we play nice
         //env.put(GEM_PATH, null);
-        JRubyAsciidoctor asciidoctor = createJRubyAsciidoctorInstance(env);
-        registerExtensions(asciidoctor);
-        registerConverters(asciidoctor);
-
-        return asciidoctor;
+        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), null, null));
     }
 
     public static JRubyAsciidoctor create(String gemPath) {
-        Map<String, Object> env = new HashMap<String, Object>();
-        // a null value will clear the GEM_PATH and GEM_HOME
-        env.put(GEM_PATH, gemPath);
-
-        JRubyAsciidoctor asciidoctor = createJRubyAsciidoctorInstance(env);
-        registerExtensions(asciidoctor);
-        registerConverters(asciidoctor);
-
-        return asciidoctor;
+        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), null, gemPath));
     }
 
     public static JRubyAsciidoctor create(List<String> loadPaths) {
-        JRubyAsciidoctor asciidoctor = createJRubyAsciidoctorInstance(loadPaths);
-        registerExtensions(asciidoctor);
-        registerConverters(asciidoctor);
-
-        return asciidoctor;
+        return processRegistrations(createJRubyAsciidoctorInstance(null, loadPaths, null, null));
     }
 
     public static JRubyAsciidoctor create(ClassLoader classloader) {
-        JRubyAsciidoctor asciidoctor = createJRubyAsciidoctorInstance(classloader, null);
-        registerExtensions(asciidoctor);
-
-        return asciidoctor;
+        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), classloader, null));
     }
+
     public static JRubyAsciidoctor create(ClassLoader classloader, String gemPath) {
-        JRubyAsciidoctor asciidoctor = createJRubyAsciidoctorInstance(classloader, gemPath);
+        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), classloader, gemPath));
+    }
+
+    private static JRubyAsciidoctor processRegistrations(JRubyAsciidoctor asciidoctor) {
         registerExtensions(asciidoctor);
         registerConverters(asciidoctor);
-
         return asciidoctor;
     }
 
@@ -106,42 +89,29 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
     private static JRubyAsciidoctor createJRubyAsciidoctorInstance(List<String> loadPaths) {
 
-        RubyInstanceConfig config = createOptimizedConfiguration();
-
-        Ruby rubyRuntime = JavaEmbedUtils.initialize(loadPaths, config);
-
-        JRubyAsciidoctorModuleFactory jRubyAsciidoctorModuleFactory = new JRubyAsciidoctorModuleFactory(rubyRuntime);
-
-        AsciidoctorModule asciidoctorModule = jRubyAsciidoctorModuleFactory.createAsciidoctorModule();
-        JRubyAsciidoctor jRubyAsciidoctor = new JRubyAsciidoctor(asciidoctorModule, rubyRuntime);
-
-        return jRubyAsciidoctor;
+        return createJRubyAsciidoctorInstance(null, loadPaths, null, null);
     }
 
     private static JRubyAsciidoctor createJRubyAsciidoctorInstance(Map<String, Object> environmentVars) {
 
-        RubyInstanceConfig config = createOptimizedConfiguration();
-        injectEnvironmentVariables(config, environmentVars);
-
-        Ruby rubyRuntime = JavaEmbedUtils.initialize(Collections.EMPTY_LIST, config);
-
-        JRubyAsciidoctorModuleFactory jRubyAsciidoctorModuleFactory = new JRubyAsciidoctorModuleFactory(rubyRuntime);
-
-        AsciidoctorModule asciidoctorModule = jRubyAsciidoctorModuleFactory.createAsciidoctorModule();
-
-        JRubyAsciidoctor jRubyAsciidoctor = new JRubyAsciidoctor(asciidoctorModule, rubyRuntime);
-        return jRubyAsciidoctor;
+        return createJRubyAsciidoctorInstance(environmentVars, new ArrayList<String>(), null, null);
     }
 
-    private static JRubyAsciidoctor createJRubyAsciidoctorInstance(ClassLoader classloader, String gemPath) {
+    private static JRubyAsciidoctor createJRubyAsciidoctorInstance(Map<String, Object> environmentVars, List<String> loadPaths, ClassLoader classloader, String gemPath) {
 
-        Map<String, Object> env = new HashMap<String, Object>();
-        env.put(GEM_PATH, gemPath);
+        Map<String, Object> env = environmentVars != null ?
+                new HashMap<String, Object>(environmentVars) : new HashMap<String, Object>();
+        if (gemPath != null) {
+            env.put(GEM_PATH, gemPath);
+        }
 
-        ScriptingContainer container = new ScriptingContainer();
-        injectEnvironmentVariables(container.getProvider().getRubyInstanceConfig(), env);
-        container.setClassLoader(classloader);
-        Ruby rubyRuntime = container.getProvider().getRuntime();
+        RubyInstanceConfig config = createOptimizedConfiguration();
+        if (classloader != null) {
+            config.setLoader(classloader);
+        }
+        injectEnvironmentVariables(config, env);
+
+        Ruby rubyRuntime = JavaEmbedUtils.initialize(loadPaths, config);
 
         JRubyAsciidoctorModuleFactory jRubyAsciidoctorModuleFactory = new JRubyAsciidoctorModuleFactory(rubyRuntime);
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenTwoAsciidoctorInstancesAreCreated.groovy
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenTwoAsciidoctorInstancesAreCreated.groovy
@@ -1,0 +1,43 @@
+package org.asciidoctor
+
+import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.extension.BlockMacroProcessor
+import spock.lang.Specification
+
+class WhenTwoAsciidoctorInstancesAreCreated extends Specification {
+
+    private static final String PARAGRAPH = 'paragraph'
+
+    private static final String TEST_STRING = 'Hello World'
+
+    def "then every Asciidoctor instance has its own extension registry"() {
+
+        given:
+        String document = '''= Test document
+
+testmacro::Test[]
+'''
+
+        when:
+        Asciidoctor asciidoctor1 = Asciidoctor.Factory.create(getClass().classLoader)
+        Asciidoctor asciidoctor2 = Asciidoctor.Factory.create(getClass().classLoader)
+
+        asciidoctor1.javaExtensionRegistry().blockMacro('testmacro', TestBlockMacroProcessor)
+
+        then:
+        asciidoctor1.convert(document, OptionsBuilder.options().headerFooter(false)).contains(TEST_STRING)
+        !asciidoctor2.convert(document, OptionsBuilder.options().headerFooter(false)).contains(TEST_STRING)
+    }
+
+
+    static class TestBlockMacroProcessor extends BlockMacroProcessor {
+        TestBlockMacroProcessor(String macroName) {
+            super(macroName)
+        }
+
+        @Override
+        Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+            createBlock(parent, PARAGRAPH, TEST_STRING)
+        }
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenClassloaderIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenClassloaderIsRequired.java
@@ -6,11 +6,6 @@ import org.asciidoctor.Asciidoctor;
 import org.junit.Test;
 
  class AsciiDoctorJClassloaderTestRunnable implements Runnable {
-    public AsciiDoctorJClassloaderTestRunnable(Asciidoctor.Factory instance){
-        asciidoctorfactory = instance;
-    }
-    private Asciidoctor.Factory asciidoctorfactory = null;
-
     private boolean loadingsucceeded = false;
     private ClassLoader classloader = null;
 
@@ -25,9 +20,9 @@ import org.junit.Test;
     public void run() {
         try{
             if(classloader == null) {
-                asciidoctorfactory.create();
+                Asciidoctor.Factory.create();
             } else {
-                asciidoctorfactory.create(classloader);
+                Asciidoctor.Factory.create(classloader);
             }
             loadingsucceeded = true;
         } catch(org.jruby.exceptions.RaiseException exp) {
@@ -49,7 +44,7 @@ public class WhenClassloaderIsRequired {
     public void contentsOfJRubyCompleteShouldFailToLoadWithoutPassingClassloader() throws Exception{
         ClassLoader currentclassloader =  this.getClass().getClassLoader();
         ClassLoader rootclassloader =  currentclassloader.getParent();
-        AsciiDoctorJClassloaderTestRunnable runnable = new AsciiDoctorJClassloaderTestRunnable(new Asciidoctor.Factory());
+        AsciiDoctorJClassloaderTestRunnable runnable = new AsciiDoctorJClassloaderTestRunnable();
         final Thread thread = new Thread( runnable );
         // make the thread use  classloader context  without JRuby and all
         thread.setContextClassLoader(rootclassloader);
@@ -62,7 +57,7 @@ public class WhenClassloaderIsRequired {
     public void contentsOfJRubyCompleteShouldSucceedWhenPassingTheCorrectClassloader() throws Exception{
         ClassLoader currentclassloader =  this.getClass().getClassLoader();
         ClassLoader rootclassloader =  currentclassloader.getParent();
-        AsciiDoctorJClassloaderTestRunnable runnable = new AsciiDoctorJClassloaderTestRunnable(new Asciidoctor.Factory());
+        AsciiDoctorJClassloaderTestRunnable runnable = new AsciiDoctorJClassloaderTestRunnable();
         runnable.setClassloader(currentclassloader);
         final Thread thread = new Thread( runnable );
         // make the thread use  classloader context  without JRuby and all


### PR DESCRIPTION
This PR solves #339 
Instead of getting the Ruby instance from ScriptingContainer when passing a ClassLoader it is now always created via `JavaEmbedUtils.initialize()` and the classloader is passed to `RubyInstanceConfig.setLoader()`.

Personally I'd prefer to remove the factory method with a classloader completely, but we have to keep it because the ant plugin uses it, so I had to keep this method.
I think this way to initialize an Asciidoctor instance could be removed because:

1. Passing a classloader is equivalent to passing load paths (see https://github.com/jruby/jruby/wiki/ClasspathAndLoadPath#classpath-and-load-path-unification )
2. A new `RubyInstanceConfig` initially uses the current TCCL as classloader until it is reset (by `Asciidoctor.Factory.create(ClassLoader)` atm). So instead of passing the classloader to the factory method the ant plugin could also set the TCCL before creation of the instance and reset it afterwards again. 