### PR TITLE
Added annotation based processor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ clone_depth: 10
 environment:
   TERM: dumb
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ContentModel.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ContentModel.java
@@ -8,6 +8,19 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation defines how to handle content created by a {@code BlockProcessor}.
+ * Applicable for:
+ * <table>
+ * <tr><td>BlockMacroProcessor</td><td></td></tr>
+ * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>BlockProcessor</td><td></td></tr>
+ * <tr><td>DocInfoProcessor</td><td></td></tr>
+ * <tr><td>IncludeProcessor</td><td></td></tr>
+ * <tr><td>InlineMacroProcessor</td><td></td></tr>
+ * <tr><td>Postprocessor</td><td></td></tr>
+ * <tr><td>Preprocessor</td><td></td></tr>
+ * <tr><td>Treeprocessor</td><td></td></tr>
+ * </table>
+
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ContentModel.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ContentModel.java
@@ -1,0 +1,58 @@
+package org.asciidoctor.extension;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation defines how to handle content created by a {@code BlockProcessor}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ContentModel {
+
+    /**
+     * Predefined constant to let Asciidoctor know that this BlockProcessor creates zero or more child blocks.
+     */
+    public static final String COMPOUND = ":compound";
+
+    /**
+     * Predefined constant to let Asciidoctor know that this BlockProcessor creates simple paragraph content.
+     */
+    public static final String SIMPLE =":simple";
+
+    /**
+     * Predefined constant to let Asciidoctor know that this BlockProcessor creates literal content.
+     */
+    public static final String VERBATIM =":verbatim";
+
+    /**
+     * Predefined constant to make Asciidoctor pass through the content unprocessed.
+     */
+    public static final String RAW =":raw";
+
+    /**
+     * Predefined constant to make Asciidoctor drop the content.
+     */
+    public static final String SKIP =":skip";
+
+    /**
+     * Predefined constant to make Asciidoctor not expect any content.
+     */
+    public static final String EMPTY =":empty";
+
+    /**
+     * Predefined constant to make Asciidoctor parse content as attributes.
+     */
+    public static final String ATTRIBUTES =":attributes";
+
+    /**
+     * See the constants defined in this enumeration for possible values.
+     * @return The defined content model
+     */
+    String value();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Contexts.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Contexts.java
@@ -1,0 +1,111 @@
+package org.asciidoctor.extension;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation defines what type of blocks a {@link BlockProcessor} processes.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Contexts {
+
+    /**
+     * Predefined constant for making a Processor work on open blocks.
+     * <pre>
+     * [foo]
+     * --
+     * An open block can be an anonymous container,
+     * or it can masquerade as any other block.
+     * --
+     * </pre>
+     */
+    public static final String CONTEXT_OPEN = ":open";
+
+    /**
+     * Predefined constant for making a Processor work on example blocks.
+     * <pre>
+     * [foo]
+     * ====
+     * This is just a neat example.
+     * ====
+     * </pre>
+     */
+    public static final String CONTEXT_EXAMPLE = ":example";
+
+    /**
+     * Predefined constant for making a Processor work on sidebar blocks.
+     * <pre>
+     * [foo]
+     * ****
+     * This is just a sidebar.
+     * ****
+     * </pre>
+     */
+    public static final String CONTEXT_SIDEBAR = ":sidebar";
+
+    /**
+     * Predefined constant for making a Processor work on literal blocks.
+     * <pre>
+     * [foo]
+     * ....
+     * This is just a literal block.
+     * ....
+     * </pre>
+     */
+    public static final String CONTEXT_LITERAL = ":literal";
+
+    /**
+     * Predefined constant for making a Processor work on source blocks.
+     * <pre>
+     * [foo]
+     * ....
+     * This is just a literal block.
+     * ....
+     * </pre>
+     */
+    public static final String CONTEXT_LISTING = ":listing";
+
+    /**
+     * Predefined constant for making a Processor work on quote blocks.
+     * <pre>
+     * [foo]
+     * ____
+     * To be or not to be...
+     * ____
+     * </pre>
+     */
+    public static final String CONTEXT_QUOTE = ":quote";
+
+    /**
+     * Predefined constant for making a Processor work on passthrough blocks.
+     *
+     * <pre>
+     * [foo]
+     * ++++
+     * &lt;h1&gt;Big text&lt;/h1&gt;
+     * ++++
+     * </pre>
+     */
+    public static final String CONTEXT_PASS = ":pass";
+
+    /**
+     * Predefined constant for making a Processor work on paragraph blocks.
+     *
+     * <pre>
+     * [foo]
+     * Please process this paragraph.
+     *
+     * And don't process this.
+     * </pre>
+     */
+    public static final String CONTEXT_PARAGRAPH = ":paragraph";
+
+
+    String[] value();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Contexts.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Contexts.java
@@ -8,6 +8,40 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation defines what type of blocks a {@link BlockProcessor} processes.
+ * Example for a BlockProcessor that transforms all open blocks with the name {@code yell} to upper case:
+ * <pre><code>
+ * &#64;Name("yell")
+ * &#64;Contexts(Contexts.CONTEXT_OPEN)
+ * &#64;ContentModel(ContentModel.SIMPLE)
+ * class YellBlockProcessor extends BlockProcessor {
+ *     public YellBlockProcessor(String blockName) {
+ *         super(blockName);
+ *     }
+ *
+ *     public Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+ *         List<String> lines = reader.readLines();
+ *         List<String> newLines = new ArrayList<>();
+ *         for (String line: lines) {
+ *             newLines.add(line.toUpperCase());
+ *         }
+ *         return createBlock(parent, 'paragraph', newLines)
+ *     }
+ * }
+ * </code>
+ * </pre>
+ *
+ * Applicable for:
+ * <table>
+ * <tr><td>BlockMacroProcessor</td><td></td></tr>
+ * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>BlockProcessor</td><td></td></tr>
+ * <tr><td>DocInfoProcessor</td><td></td></tr>
+ * <tr><td>IncludeProcessor</td><td></td></tr>
+ * <tr><td>InlineMacroProcessor</td><td></td></tr>
+ * <tr><td>Postprocessor</td><td></td></tr>
+ * <tr><td>Preprocessor</td><td></td></tr>
+ * <tr><td>Treeprocessor</td><td></td></tr>
+ * </table>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DefaultAttribute.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DefaultAttribute.java
@@ -1,0 +1,21 @@
+package org.asciidoctor.extension;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines default attributes passed to the {@code process()} method of a processor.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DefaultAttribute {
+
+    public String key();
+
+    public String value();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DefaultAttribute.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DefaultAttribute.java
@@ -8,6 +8,18 @@ import java.lang.annotation.Target;
 
 /**
  * Defines default attributes passed to the {@code process()} method of a processor.
+ * <p>Applicable for:
+ * <table>
+ * <tr><td>BlockMacroProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>DocInfoProcessor</td><td></td></tr>
+ * <tr><td>IncludeProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>InlineMacroProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>Postprocessor</td><td></td></tr>
+ * <tr><td>Preprocessor</td><td></td></tr>
+ * <tr><td>Treeprocessor</td><td></td></tr>
+ * </table>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DefaultAttributes.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DefaultAttributes.java
@@ -1,0 +1,19 @@
+package org.asciidoctor.extension;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation allows to define multiple {@link DefaultAttribute} annotations for one type.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DefaultAttributes {
+
+    public DefaultAttribute[] value();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DocinfoProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DocinfoProcessor.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
 
 import java.util.HashMap;
@@ -9,19 +8,13 @@ import java.util.Map;
 public abstract class DocinfoProcessor extends Processor {
 
     public DocinfoProcessor() {
-        super(defaultLocation(new HashMap<String, Object>()));
+        super(new HashMap<String, Object>());
     }
 
     public DocinfoProcessor(Map<String, Object> config) {
-        super(defaultLocation(config));
+        super(config);
     }
 
     public abstract String process(DocumentRuby document);
 
-    private static final Map<String, Object> defaultLocation(Map<String, Object> map) {
-        if(!map.containsKey("location")) {
-            map.put("location", ":header");
-        }
-        return map;
-    }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Format.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Format.java
@@ -18,6 +18,18 @@ import java.lang.annotation.Target;
  *  <dd>the regular expression defined by the {@linkplain #regexp()} has to match the macro. The first capture will
  *  be mapped to the target, the second to the attributes.</dd>
  * </dl>
+ * <p>Applicable for:
+ * <table>
+ * <tr><td>BlockMacroProcessor</td><td></td></tr>
+ * <tr><td>BlockProcessor</td><td></td></tr>
+ * <tr><td>BlockProcessor</td><td></td></tr>
+ * <tr><td>DocInfoProcessor</td><td></td></tr>
+ * <tr><td>IncludeProcessor</td><td></td></tr>
+ * <tr><td>InlineMacroProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>Postprocessor</td><td></td></tr>
+ * <tr><td>Preprocessor</td><td></td></tr>
+ * <tr><td>Treeprocessor</td><td></td></tr>
+ * </table>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Format.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Format.java
@@ -1,0 +1,31 @@
+package org.asciidoctor.extension;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation defines how an {@link InlineMacroProcessor} is applied.
+ * Possible values are:
+ * <dl>
+ *  <dt>{@link FormatType#LONG}</dt>
+ *  <dd>to match inline macros of the form: {@code <macro name> ':' <target> '[' <attributes> ']'}</dd>
+ *  <dt>{@link FormatType#SHORT}</dt>
+ *  <dd>to match inline macros of the form: {@code <macro name> ':' '[' <attributes> ']'}</dd>
+ *  <dt>{@link FormatType#CUSTOM}</dt>
+ *  <dd>the regular expression defined by the {@linkplain #regexp()} has to match the macro. The first capture will
+ *  be mapped to the target, the second to the attributes.</dd>
+ * </dl>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Format {
+
+    public FormatType value() default FormatType.CUSTOM;
+
+    public String regexp() default "";
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/FormatType.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/FormatType.java
@@ -1,5 +1,8 @@
 package org.asciidoctor.extension;
 
+/**
+ * Inline macro format used by the {@link Format} annotation.
+ */
 public enum FormatType {
     LONG(":long"),
     SHORT(":short"),

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/FormatType.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/FormatType.java
@@ -1,0 +1,17 @@
+package org.asciidoctor.extension;
+
+public enum FormatType {
+    LONG(":long"),
+    SHORT(":short"),
+    CUSTOM(":regexp");
+
+    private final String optionValue;
+
+    private FormatType(String optionValue) {
+        this.optionValue = optionValue;
+    }
+
+    public String optionValue() {
+        return optionValue;
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
@@ -34,8 +34,12 @@ public class JavaExtensionRegistry {
     }
 
     public void docinfoProcessor(String docInfoProcessor) {
-        RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
-        this.asciidoctorModule.docinfo_processor(rubyClass);
+        try {
+            Class<? extends DocinfoProcessor>  docinfoProcessorClass = (Class<? extends DocinfoProcessor>) Class.forName(docInfoProcessor);
+            docinfoProcessor(docinfoProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void preprocessor(Class<? extends Preprocessor> preprocessor) {
@@ -49,13 +53,21 @@ public class JavaExtensionRegistry {
     }
     
     public void preprocessor(String preprocessor) {
-        RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
-        this.asciidoctorModule.preprocessor(rubyClass);
+        try {
+            Class<? extends Preprocessor>  preprocessorClass = (Class<? extends Preprocessor>) Class.forName(preprocessor);
+            preprocessor(preprocessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
     
     public void postprocessor(String postprocessor) {
-        RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
-        this.asciidoctorModule.postprocessor(rubyClass);
+        try {
+            Class<? extends Postprocessor>  postprocessorClass = (Class<? extends Postprocessor>) Class.forName(postprocessor);
+            postprocessor(postprocessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
     
     public void postprocessor(Class<? extends Postprocessor> postprocessor) {
@@ -69,8 +81,12 @@ public class JavaExtensionRegistry {
     }
 
     public void includeProcessor(String includeProcessor) {
-        RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
-        this.asciidoctorModule.include_processor(rubyClass);
+        try {
+            Class<? extends IncludeProcessor>  includeProcessorClass = (Class<? extends IncludeProcessor>) Class.forName(includeProcessor);
+            includeProcessor(includeProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
     
     public void includeProcessor(
@@ -95,20 +111,42 @@ public class JavaExtensionRegistry {
     }
     
     public void treeprocessor(String treeProcessor) {
-        RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeProcessor);
-        this.asciidoctorModule.treeprocessor(rubyClass);
+        try {
+            Class<? extends Treeprocessor>  treeProcessorClass = (Class<? extends Treeprocessor>) Class.forName(treeProcessor);
+            treeprocessor(treeProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void block(String blockName,
            String blockProcessor) {
-        RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-        this.asciidoctorModule.block_processor(rubyClass, blockName);
+        try {
+            Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
+            block(blockName, blockProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void block(String blockProcessor) {
+        try {
+            Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
+            block(blockProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void block(String blockName,
             Class<? extends BlockProcessor> blockProcessor) {
         RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
         this.asciidoctorModule.block_processor(rubyClass, blockName);
+    }
+
+    public void block(Class<? extends BlockProcessor> blockProcessor) {
+        String name = getName(blockProcessor);
+        block(name, blockProcessor);
     }
 
     public void block(BlockProcessor blockProcessor) {
@@ -128,12 +166,31 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.block_macro(rubyClass, blockName);
     }
 
+    public void blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor) {
+        String name = getName(blockMacroProcessor);
+        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+        this.asciidoctorModule.block_macro(rubyClass, name);
+    }
+
     public void blockMacro(String blockName,
             String blockMacroProcessor) {
-        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-        this.asciidoctorModule.block_macro(rubyClass, blockName);
+        try {
+            Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
+            blockMacro(blockName, blockMacroProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
-    
+
+    public void blockMacro(String blockMacroProcessor) {
+        try {
+            Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
+            blockMacro(blockMacroProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void blockMacro(BlockMacroProcessor blockMacroProcessor) {
         RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
         this.asciidoctorModule.block_macro(rubyClass, blockMacroProcessor.getName());
@@ -149,9 +206,36 @@ public class JavaExtensionRegistry {
         RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
         this.asciidoctorModule.inline_macro(rubyClass, blockName);
     }
-    
-    public void inlineMacro(String blockName, String inlineMacroProcessor) {
+
+    public void inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
+        String name = getName(inlineMacroProcessor);
         RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        this.asciidoctorModule.inline_macro(rubyClass, blockName);
+        this.asciidoctorModule.inline_macro(rubyClass, name);
+    }
+
+    public void inlineMacro(String blockName, String inlineMacroProcessor) {
+        try {
+            Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
+            inlineMacro(blockName, inlineMacroProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void inlineMacro(String inlineMacroProcessor) {
+        try {
+            Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
+            inlineMacro(inlineMacroProcessorClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getName(Class<?> clazz) {
+        Name nameAnnotation = clazz.getAnnotation(Name.class);
+        if (nameAnnotation == null || nameAnnotation.value() == null) {
+            throw new IllegalArgumentException(clazz + " must be registered with a name or it must have a Name annotation!");
+        }
+        return nameAnnotation.value();
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Location.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Location.java
@@ -1,0 +1,19 @@
+package org.asciidoctor.extension;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation defines the location where the content created by a {@link DocinfoProcessor} will be added.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Location {
+
+    public LocationType value() default LocationType.HEADER;
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Location.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Location.java
@@ -8,6 +8,32 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation defines the location where the content created by a {@link DocinfoProcessor} will be added.
+ * <p>The following example will add a robots meta tag to the head element of the resulting HTML document:
+ * <pre>
+ * <ode>
+ * &#64;Location(LocationType.HEADER)
+ * class RobotsDocinfoProcessor extends DocinfoProcessor {
+ *
+ *     public static final String META_TAG = "&lt;meta name=\"robots\" content=\"index, follow\"/&gt;";
+ *
+ *     public String process(DocumentRuby document) {
+ *         return META_TAG;
+ *     }
+ * }
+ * </ode>
+ * </pre>
+ * <p>Applicable for:
+ * <table>
+ * <tr><td>BlockMacroProcessor</td><td></td></tr>
+ * <tr><td>BlockProcessor</td><td></td></tr>
+ * <tr><td>BlockProcessor</td><td></td></tr>
+ * <tr><td>DocInfoProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>IncludeProcessor</td><td></td></tr>
+ * <tr><td>InlineMacroProcessor</td><td></td></tr>
+ * <tr><td>Postprocessor</td><td></td></tr>
+ * <tr><td>Preprocessor</td><td></td></tr>
+ * <tr><td>Treeprocessor</td><td></td></tr>
+ * </table>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/LocationType.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/LocationType.java
@@ -1,0 +1,17 @@
+package org.asciidoctor.extension;
+
+public enum LocationType {
+
+    HEADER(":header"),
+    FOOTER(":footer");
+
+    private final String optionValue;
+
+    private LocationType(String optionValue) {
+        this.optionValue = optionValue;
+    }
+
+    public String optionValue() {
+        return optionValue;
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/LocationType.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/LocationType.java
@@ -1,5 +1,8 @@
 package org.asciidoctor.extension;
 
+/**
+ * Location used by the {@link Location} annotation.
+ */
 public enum LocationType {
 
     HEADER(":header"),

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Name.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Name.java
@@ -1,0 +1,20 @@
+package org.asciidoctor.extension;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to define the block name handled by a {@link BlockProcessor}, or the macro name of a
+ * {@link BlockMacroProcessor} or {@link InlineMacroProcessor}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Name {
+
+    String value();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Name.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Name.java
@@ -9,6 +9,18 @@ import java.lang.annotation.Target;
 /**
  * Use this annotation to define the block name handled by a {@link BlockProcessor}, or the macro name of a
  * {@link BlockMacroProcessor} or {@link InlineMacroProcessor}.
+ * <p>Applicable for:
+ * <table>
+ * <tr><td>BlockMacroProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>DocInfoProcessor</td><td></td></tr>
+ * <tr><td>IncludeProcessor</td><td></td></tr>
+ * <tr><td>InlineMacroProcessor</td><td></td></tr>
+ * <tr><td>Postprocessor</td><td></td></tr>
+ * <tr><td>Preprocessor</td><td></td></tr>
+ * <tr><td>Treeprocessor</td><td></td></tr>
+ * </table>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PositionalAttributes.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PositionalAttributes.java
@@ -7,7 +7,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation allows to define multiple {@link DefaultAttribute} annotations for one type.
+ * Defines the on which attributes the first, second, etc attribute of a macro is mapped.
+ * <p>Example: For this inline macro that defines {@code section} as the first positional parameter:
+ * <pre>
+ * <code>&#64;PositionalAttribute("section")
+ * &#64;('man')
+ * public class ManPageMacroProcessor extends InlineMacroProcessor {
+ *     public ManPageMacroProcessor(String macroName) {
+ *         super(macroName)
+ *     }
+ *
+ *     public Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+ *         assertEquals(attributes.get("section"), "7")
+ *     }
+ * }
+ * </code>
+ * </pre>
+ *
+ * this macro invocation will pass {@code "7"} as value for the attribute {@code section}:
+ *
+ * {@code man:gittutorial[7]}
  * <p>Applicable for:
  * <table>
  * <tr><td>BlockMacroProcessor</td><td>&#10003;</td></tr>
@@ -24,8 +43,8 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface DefaultAttributes {
+public @interface PositionalAttributes {
 
-    public DefaultAttribute[] value();
+    public String[] value();
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
@@ -9,6 +9,7 @@ import org.asciidoctor.extension.Format;
 import org.asciidoctor.extension.FormatType;
 import org.asciidoctor.extension.Location;
 import org.asciidoctor.extension.Name;
+import org.asciidoctor.extension.PositionalAttributes;
 import org.asciidoctor.extension.Processor;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -79,6 +80,8 @@ public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
 
         handleDefaultAttributesAnnotation(processor, rubyClass);
 
+        handlePositionalAttributesAnnotation(processor, rubyClass);
+
         handleContextsAnnotation(processor, rubyClass);
 
         handleFormatAnnotation(processor, rubyClass);
@@ -143,6 +146,21 @@ public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
             rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
                     rubyRuntime.newSymbol("default_attrs"),
                     defaultAttrs
+            });
+        }
+    }
+
+    private static void handlePositionalAttributesAnnotation(Class<? extends Processor> processor, RubyClass rubyClass) {
+        Ruby rubyRuntime = rubyClass.getRuntime();
+        if (processor.isAnnotationPresent(PositionalAttributes.class)) {
+            PositionalAttributes positionalAttributes = processor.getAnnotation(PositionalAttributes.class);
+            RubyArray positionalAttrs = RubyArray.newArray(rubyRuntime);
+            for (String positionalAttribute: positionalAttributes.value()) {
+                positionalAttrs.add(positionalAttribute);
+            }
+            rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                    rubyRuntime.newSymbol("pos_attrs"),
+                    positionalAttrs
             });
         }
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
@@ -1,12 +1,25 @@
 package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.ast.AbstractNodeImpl;
+import org.asciidoctor.extension.ContentModel;
+import org.asciidoctor.extension.Contexts;
+import org.asciidoctor.extension.DefaultAttribute;
+import org.asciidoctor.extension.DefaultAttributes;
+import org.asciidoctor.extension.Format;
+import org.asciidoctor.extension.FormatType;
+import org.asciidoctor.extension.Location;
+import org.asciidoctor.extension.Name;
 import org.asciidoctor.extension.Processor;
 import org.jruby.Ruby;
+import org.jruby.RubyArray;
 import org.jruby.RubyClass;
+import org.jruby.RubyHash;
 import org.jruby.RubyObject;
+import org.jruby.RubyRegexp;
+import org.jruby.RubySymbol;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.RegexpOptions;
 
 public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
 
@@ -53,6 +66,122 @@ public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
         } else {
             return JavaEmbedUtils.javaToRuby(getRuntime(), o);
         }
+    }
+
+    protected static void applyAnnotations(Class<? extends Processor> processor, RubyClass rubyClass) {
+        handleLocationAnnotation(processor, rubyClass);
+
+        handleNameAnnotation(processor, rubyClass);
+
+        handleContentModelAnnotation(processor, rubyClass);
+
+        handleDefaultAttributeAnnotation(processor, rubyClass);
+
+        handleDefaultAttributesAnnotation(processor, rubyClass);
+
+        handleContextsAnnotation(processor, rubyClass);
+
+        handleFormatAnnotation(processor, rubyClass);
+    }
+
+    private static void handleFormatAnnotation(Class<? extends Processor> processor, RubyClass rubyClass) {
+        Ruby rubyRuntime = rubyClass.getRuntime();
+        if (processor.isAnnotationPresent(Format.class)) {
+            Format format = processor.getAnnotation(Format.class);
+            switch (format.value()) {
+                case CUSTOM:
+                    rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                            rubyRuntime.newSymbol("regexp"),
+                            convertRegexp(rubyRuntime, format.regexp())
+                    });
+                default:
+                    rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                            rubyRuntime.newSymbol("format"),
+                            rubyRuntime.newSymbol(format.value().optionValue().substring(1))
+                    });
+            }
+        }
+    }
+
+    private static void handleContextsAnnotation(Class<? extends Processor> processor, RubyClass rubyClass) {
+        Ruby rubyRuntime = rubyClass.getRuntime();
+        if (processor.isAnnotationPresent(Contexts.class)) {
+            Contexts contexts = processor.getAnnotation(Contexts.class);
+            RubyArray contextList = rubyRuntime.newArray();
+            for (String value: contexts.value()) {
+                contextList.add(rubyRuntime.newSymbol(value.substring(1)));
+            }
+            rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                    rubyRuntime.newSymbol("contexts"),
+                    contextList
+            });
+
+        }
+    }
+
+    private static void handleDefaultAttributesAnnotation(Class<? extends Processor> processor, RubyClass rubyClass) {
+        Ruby rubyRuntime = rubyClass.getRuntime();
+        if (processor.isAnnotationPresent(DefaultAttributes.class)) {
+            DefaultAttributes defaultAttributes = processor.getAnnotation(DefaultAttributes.class);
+            RubyHash defaultAttrs = RubyHash.newHash(rubyRuntime);
+            for (DefaultAttribute defaultAttribute: defaultAttributes.value()) {
+                defaultAttrs.put(defaultAttribute.key(), defaultAttribute.value());
+            }
+            rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                    rubyRuntime.newSymbol("default_attrs"),
+                    defaultAttrs
+            });
+        }
+    }
+
+    private static void handleDefaultAttributeAnnotation(Class<? extends Processor> processor, RubyClass rubyClass) {
+        Ruby rubyRuntime = rubyClass.getRuntime();
+        if (processor.isAnnotationPresent(DefaultAttribute.class)) {
+            DefaultAttribute defaultAttribute = processor.getAnnotation(DefaultAttribute.class);
+            RubyHash defaultAttrs = RubyHash.newHash(rubyRuntime);
+            defaultAttrs.put(defaultAttribute.key(), defaultAttribute.value());
+            rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                    rubyRuntime.newSymbol("default_attrs"),
+                    defaultAttrs
+            });
+        }
+    }
+
+    private static void handleContentModelAnnotation(Class<? extends Processor> processor, RubyClass rubyClass) {
+        Ruby rubyRuntime = rubyClass.getRuntime();
+        if (processor.isAnnotationPresent(ContentModel.class)) {
+            ContentModel contentModel = processor.getAnnotation(ContentModel.class);
+            rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                    rubyRuntime.newSymbol("content_model"),
+                    rubyRuntime.newSymbol(contentModel.value().substring(1))
+            });
+        }
+    }
+
+    private static void handleNameAnnotation(Class<? extends Processor> processor, RubyClass rubyClass) {
+        Ruby rubyRuntime = rubyClass.getRuntime();
+        if (processor.isAnnotationPresent(Name.class)) {
+            Name name = processor.getAnnotation(Name.class);
+            rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                    rubyRuntime.newSymbol("name"),
+                    rubyRuntime.newString(name.value())
+            });
+        }
+    }
+
+    private static void handleLocationAnnotation(Class<? extends Processor> processor, RubyClass rubyClass) {
+        Ruby rubyRuntime = rubyClass.getRuntime();
+        if (processor.isAnnotationPresent(Location.class)) {
+            Location location = processor.getAnnotation(Location.class);
+            rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[] {
+                    rubyRuntime.newSymbol("location"),
+                    rubyRuntime.newSymbol(location.value().optionValue().substring(1))
+            });
+        }
+    }
+
+    protected static RubyRegexp convertRegexp(Ruby runtime, CharSequence regexp) {
+        return RubyRegexp.newRegexp(runtime, regexp.toString(), RegexpOptions.NULL_OPTIONS);
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
@@ -32,16 +32,6 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
         super(runtime, metaClass, blockMacroProcessor);
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final String blockMacroProcessorClassName) {
-
-        try {
-            Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessorClassName);
-            return register(rubyRuntime, blockMacroProcessorClass);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static RubyClass register(final Ruby rubyRuntime, final Class<? extends BlockMacroProcessor> blockMacroProcessor) {
         RubyClass rubyClass = ProcessorProxyUtil.defineProcessorClass(rubyRuntime, "BlockMacroProcessor", new ObjectAllocator() {
             @Override
@@ -49,6 +39,9 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
                 return new BlockMacroProcessorProxy(runtime, klazz, blockMacroProcessor);
             }
         });
+
+        applyAnnotations(blockMacroProcessor, rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, BlockMacroProcessorProxy.class);
         return rubyClass;
     }
@@ -60,6 +53,9 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
                 return new BlockMacroProcessorProxy(runtime, klazz, blockMacroProcessor);
             }
         });
+
+        applyAnnotations(blockMacroProcessor.getClass(), rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, BlockMacroProcessorProxy.class);
         return rubyClass;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -32,16 +32,6 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
         super(runtime, metaClass, blockProcessor);
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final String blockProcessorClassName) {
-
-        try {
-            Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessorClassName);
-            return register(rubyRuntime, blockProcessorClass);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static RubyClass register(final Ruby rubyRuntime, final Class<? extends BlockProcessor> blockProcessor) {
         RubyClass rubyClass = ProcessorProxyUtil.defineProcessorClass(rubyRuntime, "BlockProcessor", new ObjectAllocator() {
             @Override
@@ -49,6 +39,9 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
                 return new BlockProcessorProxy(runtime, klazz, blockProcessor);
             }
         });
+
+        applyAnnotations(blockProcessor, rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, BlockProcessorProxy.class);
         return rubyClass;
     }
@@ -60,6 +53,9 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
                 return new BlockProcessorProxy(runtime, klazz, blockProcessor);
             }
         });
+
+        applyAnnotations(blockProcessor.getClass(), rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, BlockProcessorProxy.class);
         return rubyClass;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
@@ -1,12 +1,10 @@
 package org.asciidoctor.extension.processorproxies;
 
-import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentRuby;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.DocinfoProcessor;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
-import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
@@ -30,16 +28,6 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
         super(runtime, metaClass, docinfoProcessor);
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final String docinfoProcessorClassName) {
-
-        try {
-            Class<? extends DocinfoProcessor>  docinfoProcessorClass = (Class<? extends DocinfoProcessor>) Class.forName(docinfoProcessorClassName);
-            return register(rubyRuntime, docinfoProcessorClass);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static RubyClass register(final Ruby rubyRuntime, final Class<? extends DocinfoProcessor> docinfoProcessor) {
         RubyClass rubyClass = ProcessorProxyUtil.defineProcessorClass(rubyRuntime, "DocinfoProcessor", new ObjectAllocator() {
             @Override
@@ -47,6 +35,9 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
                 return new DocinfoProcessorProxy(runtime, klazz, docinfoProcessor);
             }
         });
+
+        applyAnnotations(docinfoProcessor, rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, DocinfoProcessorProxy.class);
         return rubyClass;
     }
@@ -58,6 +49,9 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
                 return new DocinfoProcessorProxy(runtime, klazz, docinfoProcessor);
             }
         });
+
+        applyAnnotations(docinfoProcessor.getClass(), rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, DocinfoProcessorProxy.class);
         return rubyClass;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
@@ -32,16 +32,6 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
         super(runtime, metaClass, includeProcessor);
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final String includeProcessorClassName) {
-
-        try {
-            Class<? extends IncludeProcessor>  includeProcessorClass = (Class<? extends IncludeProcessor>) Class.forName(includeProcessorClassName);
-            return register(rubyRuntime, includeProcessorClass);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static RubyClass register(final Ruby rubyRuntime, final Class<? extends IncludeProcessor> includeProcessor) {
         RubyClass rubyClass = ProcessorProxyUtil.defineProcessorClass(rubyRuntime, "IncludeProcessor", new ObjectAllocator() {
             @Override
@@ -49,6 +39,9 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
                 return new IncludeProcessorProxy(runtime, klazz, includeProcessor);
             }
         });
+
+        applyAnnotations(includeProcessor, rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, IncludeProcessorProxy.class);
         return rubyClass;
     }
@@ -60,6 +53,9 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
                 return new IncludeProcessorProxy(runtime, klazz, includeProcessor);
             }
         });
+
+        applyAnnotations(includeProcessor.getClass(), rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, IncludeProcessorProxy.class);
         return rubyClass;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
@@ -31,16 +31,6 @@ public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
         super(runtime, metaClass, postprocessor);
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final String postprocessorClassName) {
-
-        try {
-            Class<? extends Postprocessor>  postprocessorClass = (Class<? extends Postprocessor>) Class.forName(postprocessorClassName);
-            return register(rubyRuntime, postprocessorClass);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static RubyClass register(final Ruby rubyRuntime, final Class<? extends Postprocessor> postprocessor) {
         RubyClass rubyClass = ProcessorProxyUtil.defineProcessorClass(rubyRuntime, "Postprocessor", new ObjectAllocator() {
             @Override
@@ -48,6 +38,9 @@ public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
                 return new PostprocessorProxy(runtime, klazz, postprocessor);
             }
         });
+
+        applyAnnotations(postprocessor, rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, PostprocessorProxy.class);
         return rubyClass;
     }
@@ -59,6 +52,9 @@ public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
                 return new PostprocessorProxy(runtime, klazz, postprocessor);
             }
         });
+
+        applyAnnotations(postprocessor.getClass(), rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, PostprocessorProxy.class);
         return rubyClass;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
@@ -32,16 +32,6 @@ public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
         super(runtime, metaClass, preprocessor);
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final String preprocessorClassName) {
-
-        try {
-            Class<? extends Preprocessor>  preprocessorClass = (Class<? extends Preprocessor>) Class.forName(preprocessorClassName);
-            return register(rubyRuntime, preprocessorClass);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static RubyClass register(final Ruby rubyRuntime, final Class<? extends Preprocessor> preprocessor) {
         RubyClass rubyClass = ProcessorProxyUtil.defineProcessorClass(rubyRuntime, "Preprocessor", new ObjectAllocator() {
             @Override
@@ -49,6 +39,9 @@ public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
                 return new PreprocessorProxy(runtime, klazz, preprocessor);
             }
         });
+
+        applyAnnotations(preprocessor, rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, PreprocessorProxy.class);
         return rubyClass;
     }
@@ -60,6 +53,9 @@ public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
                 return new PreprocessorProxy(runtime, klazz, preprocessor);
             }
         });
+
+        applyAnnotations(preprocessor.getClass(), rubyClass);
+
         ProcessorProxyUtil.defineAnnotatedMethods(rubyClass, PreprocessorProxy.class);
         return rubyClass;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
@@ -30,16 +30,6 @@ public class TreeprocessorProxy extends AbstractProcessorProxy<Treeprocessor> {
         super(runtime, metaClass, treeProcessor);
     }
 
-    public static RubyClass register(final Ruby rubyRuntime, final String treeProcessorClassName) {
-
-        try {
-            Class<? extends Treeprocessor> treeProcessorClass = (Class<? extends Treeprocessor>) Class.forName(treeProcessorClassName);
-            return register(rubyRuntime, treeProcessorClass);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static RubyClass register(final Ruby rubyRuntime, final Class<? extends Treeprocessor> treeProcessor) {
         RubyClass rubyClass = ProcessorProxyUtil.defineProcessorClass(rubyRuntime, "Treeprocessor", new ObjectAllocator() {
             @Override
@@ -47,6 +37,9 @@ public class TreeprocessorProxy extends AbstractProcessorProxy<Treeprocessor> {
                 return new TreeprocessorProxy(runtime, klazz, treeProcessor);
             }
         });
+
+        applyAnnotations(treeProcessor, rubyClass);
+
         rubyClass.defineAnnotatedMethods(TreeprocessorProxy.class);
         return rubyClass;
     }
@@ -58,6 +51,9 @@ public class TreeprocessorProxy extends AbstractProcessorProxy<Treeprocessor> {
                 return new TreeprocessorProxy(runtime, klazz, treeProcessor);
             }
         });
+
+        applyAnnotations(treeProcessor.getClass(), rubyClass);
+
         rubyClass.defineAnnotatedMethods(TreeprocessorProxy.class);
         return rubyClass;
     }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockMacroProcessor.groovy
@@ -1,0 +1,21 @@
+package org.asciidoctor.extension
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.ast.AbstractBlock
+
+@CompileStatic
+@Name('testmacro')
+class AnnotatedBlockMacroProcessor extends BlockMacroProcessor {
+
+    public static final String RESULT = 'This content is added by this macro!'
+
+    AnnotatedBlockMacroProcessor(String macroName) {
+        super(macroName)
+        assert macroName == 'testmacro'
+    }
+
+    @Override
+    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+        createBlock(parent, 'paragraph', RESULT)
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockProcessor.groovy
@@ -1,0 +1,27 @@
+package org.asciidoctor.extension
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.ast.AbstractBlock
+
+@CompileStatic
+@Name('yell')
+@Contexts([Contexts.CONTEXT_LISTING, Contexts.CONTEXT_OPEN])
+@ContentModel(ContentModel.SIMPLE)
+@DefaultAttributes([
+    @DefaultAttribute(key = 'key', value = 'value')
+])
+class AnnotatedBlockProcessor extends BlockProcessor {
+
+    AnnotatedBlockProcessor(String blockName) {
+        super(blockName)
+    }
+
+    @Override
+    Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+        assert attributes['key'] == 'value'
+        List<String> lines = reader.readLines()
+        List<String> newLines = lines*.toUpperCase()
+
+        createBlock(parent, 'paragraph', newLines)
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedDocinfoProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedDocinfoProcessor.groovy
@@ -1,0 +1,22 @@
+package org.asciidoctor.extension
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.ast.DocumentRuby
+
+@CompileStatic
+@Location(LocationType.FOOTER)
+class AnnotatedDocinfoProcessor extends DocinfoProcessor {
+
+    public static final String META_TAG = '<meta name="robots" content="index, follow"/>'
+
+    AnnotatedDocinfoProcessor() {}
+
+    AnnotatedDocinfoProcessor(LocationType location) {
+        config['location'] = ":${location.name().toLowerCase()}"
+    }
+
+    @Override
+    String process(DocumentRuby document) {
+        META_TAG
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
@@ -1,0 +1,24 @@
+package org.asciidoctor.extension
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.ast.AbstractBlock
+
+@CompileStatic
+@Name('man')
+@Format(FormatType.LONG)
+class AnnotatedLongInlineMacroProcessor extends InlineMacroProcessor {
+
+    public static final String RESULT = 'This content is added by this macro!'
+
+    AnnotatedLongInlineMacroProcessor(String macroName) {
+        super(macroName)
+    }
+
+    @Override
+    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+        Map<String, Object> options = new HashMap<String, Object>()
+        options['type'] = ':link'
+        options['target'] = "${target}.html"
+        createInline(parent, 'anchor', target, attributes, options).convert()
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
@@ -6,9 +6,12 @@ import org.asciidoctor.ast.AbstractBlock
 @CompileStatic
 @Name('man')
 @Format(FormatType.LONG)
+@PositionalAttributes(['section', 'subsection'])
 class AnnotatedLongInlineMacroProcessor extends InlineMacroProcessor {
 
     public static final String RESULT = 'This content is added by this macro!'
+    public static final String SUBSECTION = 'subsection'
+    public static final String SECTION = 'section'
 
     AnnotatedLongInlineMacroProcessor(String macroName) {
         super(macroName)
@@ -16,6 +19,9 @@ class AnnotatedLongInlineMacroProcessor extends InlineMacroProcessor {
 
     @Override
     Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+
+        assert attributes[SECTION] == '7' || ( attributes[SECTION] == '8' || attributes[SUBSECTION] == '1')
+
         Map<String, Object> options = new HashMap<String, Object>()
         options['type'] = ':link'
         options['target'] = "${target}.html"

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
@@ -1,0 +1,24 @@
+package org.asciidoctor.extension
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.ast.AbstractBlock
+
+@CompileStatic
+@Name('man')
+@Format(regexp = 'manpage:(.*?)\\[(.*?)\\]')
+class AnnotatedRegexpInlineMacroProcessor extends InlineMacroProcessor {
+
+    public static final String RESULT = 'This content is added by this macro!'
+
+    AnnotatedRegexpInlineMacroProcessor(String macroName) {
+        super(macroName)
+    }
+
+    @Override
+    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+        Map<String, Object> options = new HashMap<String, Object>()
+        options['type'] = ':link'
+        options['target'] = "${target}.html"
+        createInline(parent, 'anchor', target, attributes, options).convert()
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
@@ -1,0 +1,194 @@
+package org.asciidoctor.extension
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.SafeMode
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.junit.runner.RunWith
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue('https://github.com/asciidoctor/asciidoctorj/issues/196')
+@RunWith(ArquillianSputnik)
+class WhenAJavaExtensionIsRegisteredWithAnnotations extends Specification {
+
+    public static final String UTF8 = 'UTF-8'
+    public static final String TAG_HEAD = 'head'
+    public static final String ELEMENTID_FOOTER = 'footer'
+    public static final String ATTR_KEY_NAME = 'name'
+    public static final String ATTR_VALUE_ROBOTS = 'robots'
+    public static final String DO_NOT_TOUCH_THIS = 'Do not touch this'
+    public static final String THIS_SHOULD_BE_UPPERCASE = 'This should be uppercase'
+    public static final String THIS_SHOULD_ALSO_BE_UPPERCASE = 'This should also be uppercase'
+    public static final String HREF = 'href'
+    public static final String ANCHOR_TAG = 'a'
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    private static final String DOCUMENT = '''= Test document
+'''
+
+    private static final String BLOCK_MACRO_DOCUMENT = '''= Test document
+
+testmacro::target[]
+
+'''
+
+    private static final String BLOCK_DOCUMENT = '''= Test document
+
+[yell]
+Do not touch this
+
+[yell]
+----
+This should be uppercase
+----
+
+[yell]
+--
+This should also be uppercase
+--
+
+'''
+
+    private static final String BLOCK_DOCUMENT_2 = '''= Test document
+
+[yell2]
+Do not touch this
+
+[yell2]
+----
+This should be uppercase
+----
+
+[yell2]
+--
+This should also be uppercase
+--
+
+'''
+
+    private static final String INLINE_MACRO_DOCUMENT = '''= Test document
+
+You can find infos on man:gittutorial[7].
+
+'''
+
+    private static final String INLINE_MACRO_REGEXP_DOCUMENT = '''= Test document
+
+You can find infos on man:gittutorial[7].
+
+And even more infos on manpage:git[7].
+
+'''
+
+
+    def "a docinfoprocessor should be configurable via the Location annotation"() {
+        when:
+        asciidoctor.javaExtensionRegistry().docinfoProcessor(AnnotatedDocinfoProcessor)
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element footer = doc.getElementById(ELEMENTID_FOOTER)
+        !footer.getElementsByAttributeValueContaining(ATTR_KEY_NAME, ATTR_VALUE_ROBOTS).empty
+    }
+
+    def "a docinfoprocessor instance should be configurable via the Location annotation"() {
+        when:
+        asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor())
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element footer = doc.getElementById(ELEMENTID_FOOTER)
+        !footer.getElementsByAttributeValueContaining(ATTR_KEY_NAME, ATTR_VALUE_ROBOTS).empty
+    }
+
+    def "a docinfoprocessor instance can override the annotation from footer to header"() {
+        when:
+        asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.HEADER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        !doc.getElementsByTag(TAG_HEAD)[0].getElementsByAttributeValueContaining(ATTR_KEY_NAME, ATTR_VALUE_ROBOTS).empty
+    }
+
+    def "a docinfoprocessor instance can override the annotation from footer to footer"() {
+        when:
+        asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.FOOTER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element footer = doc.getElementById(ELEMENTID_FOOTER)
+        !footer.getElementsByAttributeValueContaining(ATTR_KEY_NAME, ATTR_VALUE_ROBOTS).empty
+    }
+
+    def "when registering a BlockMacroProcessor class it should be configurable via annotations"() {
+
+        when:
+        asciidoctor.javaExtensionRegistry().blockMacro(AnnotatedBlockMacroProcessor)
+        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        result.contains(AnnotatedBlockMacroProcessor.RESULT)
+    }
+
+    // TODO: What about the macro name when passing an instance? Do we really need BlockMacroProcessor.getName()?
+
+    def "when registering a BlockProcessor class it should be configurable via annotations"() {
+
+        when:
+        asciidoctor.javaExtensionRegistry().block(AnnotatedBlockProcessor)
+        String result = asciidoctor.convert(BLOCK_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        result.contains(DO_NOT_TOUCH_THIS)
+        result.contains(THIS_SHOULD_BE_UPPERCASE.toUpperCase())
+        result.contains(THIS_SHOULD_ALSO_BE_UPPERCASE.toUpperCase())
+    }
+
+    // TODO: What about the block name when passing an instance? Do we really need BlockMacroProcessor.getName()?
+
+    def "when registering a BlockProcessor instance it should be configurable via annotations"() {
+
+        when:
+        asciidoctor.javaExtensionRegistry().block(new AnnotatedBlockProcessor('yell2'))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        result.contains(DO_NOT_TOUCH_THIS)
+        result.contains(THIS_SHOULD_BE_UPPERCASE.toUpperCase())
+        result.contains(THIS_SHOULD_ALSO_BE_UPPERCASE.toUpperCase())
+    }
+
+    def "when registering an InlineMacroProcessor class with long format it should be configurable via annotations"() {
+        when:
+        asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedLongInlineMacroProcessor)
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element link = doc.getElementsByTag(ANCHOR_TAG).first()
+        link.attr(HREF) == 'gittutorial.html'
+    }
+
+    def "when registering an InlineMacroProcessor class with regexp it should be configurable via annotations"() {
+        when:
+        asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedRegexpInlineMacroProcessor)
+        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element link = doc.getElementsByTag(ANCHOR_TAG).first()
+        link.attr(HREF) == 'git.html'
+    }
+
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
@@ -75,7 +75,7 @@ This should also be uppercase
 
     private static final String INLINE_MACRO_DOCUMENT = '''= Test document
 
-You can find infos on man:gittutorial[7].
+You can find infos on man:gittutorial[7] or man:git[8, 1].
 
 '''
 


### PR DESCRIPTION
This should implement #196 

It is now possible to add these annotations:
- `@Name` to define block or macro names for BlockProcessors, BlockMacro- and InlineMacroProcessors
- `@ContentModel` to define the content model of a BlockProcessor
- `@Contexts` to define the contexts of a BlockProcessor
- `@DefaultAttribute` to define default attributes to pass to the process method of a processor
- `@DefaultAttributes` to define multiple `@DefaultAttribute`s on one type
- `@Location` to define where content generated by a DocinfoProcessor is to be placed.

`@PositionalAttributes` are missing yet because I am not aware what they should do.

In general the implementation adds options to the processors *class* object that serve as a default configuration for the instances. (see https://github.com/asciidoctor/asciidoctor/blob/master/lib/asciidoctor/extensions.rb#L84)

If this is a way to pursue docs and javadocs should be enhanced.
Also the javadocs of the new annotations should be extended with examples.




