### PR TITLE
#296: Add support for overriding Ruby properties

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
@@ -28,6 +28,7 @@ public class AsciidoctorCliOptions {
     public static final String TEMPLATE_ENGINE = "-E";
     public static final String COMPACT = "-C";
     public static final String ERUBY = "-e";
+    public static final String RUBY_OPTION = "-R";
     public static final String SECTION_NUMBERS = "-n";
     public static final String NO_HEADER_FOOTER = "-s";
     public static final String SAFE = "-S";
@@ -68,6 +69,9 @@ public class AsciidoctorCliOptions {
 
     @Parameter(names = { ERUBY, "--eruby" }, description = "specify eRuby implementation to render built-in templates: [erb, erubis] (default: erb)")
     private String eruby = "erb";
+
+    @Parameter(names = { RUBY_OPTION }, description = "specify JRuby options like -R compat.version=1.9")
+    private List<String> rubyOptions = new ArrayList<String>();
 
     @Parameter(names = { COMPACT, "--compact" }, description = "compact the output by removing blank lines (default: false)")
     private boolean compact = false;
@@ -178,6 +182,10 @@ public class AsciidoctorCliOptions {
 
     public String getEruby() {
         return this.eruby;
+    }
+
+    public List<String> getRubyOptions() {
+        return rubyOptions;
     }
 
     public boolean isCompact() {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
@@ -100,7 +100,14 @@ public class AsciidoctorInvoker {
         }
     }
 
-    private JRubyAsciidoctor buildAsciidoctorJInstance(AsciidoctorCliOptions asciidoctorCliOptions) {
+    JRubyAsciidoctor buildAsciidoctorJInstance(AsciidoctorCliOptions asciidoctorCliOptions) {
+
+        for (String rubyOption: asciidoctorCliOptions.getRubyOptions()) {
+            String key = rubyOption.substring(0, rubyOption.indexOf('='));
+            String value = rubyOption.substring(rubyOption.indexOf('=') + 1);
+            System.setProperty("jruby." + key, value);
+        }
+
         ClassLoader oldTccl = Thread.currentThread().getContextClassLoader();
         try {
             if (asciidoctorCliOptions.isClassPaths()) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -132,8 +132,12 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
     private static RubyInstanceConfig createOptimizedConfiguration() {
         RubyInstanceConfig config = new RubyInstanceConfig();
-        config.setCompatVersion(CompatVersion.RUBY2_0);
-        config.setCompileMode(CompileMode.OFF);
+        if (System.getProperty("jruby.compat.version") == null) {
+            config.setCompatVersion(CompatVersion.RUBY2_0);
+        }
+        if (System.getProperty("jruby.compile.mode") == null) {
+            config.setCompileMode(CompileMode.OFF);
+        }
 
         return config;
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenJRubyOptionsArePassed.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenJRubyOptionsArePassed.java
@@ -1,0 +1,56 @@
+package org.asciidoctor.cli;
+
+import com.beust.jcommander.JCommander;
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+public class WhenJRubyOptionsArePassed {
+
+    @ArquillianResource
+    private ClasspathResources classpath;
+
+    @ArquillianResource
+    public TemporaryFolder temporaryFolder;
+
+    public String pwd = new File("").getAbsolutePath();
+
+    @Test
+    public void shouldUseRubyVersion20ByDefault() {
+        // Given
+        AsciidoctorInvoker invoker = new AsciidoctorInvoker();
+        AsciidoctorCliOptions asciidoctorCliOptions = new AsciidoctorCliOptions();
+        JCommander jCommander = new JCommander(asciidoctorCliOptions);
+
+        // When
+        JRubyAsciidoctor asciidoctor = invoker.buildAsciidoctorJInstance(asciidoctorCliOptions);
+
+        // Then
+        assertThat(asciidoctor.getRubyRuntime().evalScriptlet("RUBY_VERSION").asJavaString(), is("2.0.0"));
+
+    }
+
+    @Test
+    public void shouldUseRubyVersion193WhenConfigured() {
+        // Given
+        AsciidoctorInvoker invoker = new AsciidoctorInvoker();
+        AsciidoctorCliOptions asciidoctorCliOptions = new AsciidoctorCliOptions();
+        JCommander jCommander = new JCommander(asciidoctorCliOptions, "-R", "compile.mode=OFF", "-R", "compat.version=1.9");
+
+        // When
+        JRubyAsciidoctor asciidoctor = invoker.buildAsciidoctorJInstance(asciidoctorCliOptions);
+
+        // Then
+        assertThat(asciidoctor.getRubyRuntime().evalScriptlet("RUBY_VERSION").asJavaString(), is("1.9.3"));
+
+    }
+
+}


### PR DESCRIPTION
This PR is a simple way to solve #296 
If the system property jruby.compat.version is set, AsciidoctorJ will not override this with the default value 2_0.
If such a system property is not set, the default 2_0 will be applied.

The CLI options are also extended to accept options like `-R compat.version=1.9` which result in setting the system property `jruby.compat.version=1.9`.