### PR TITLE
Support block and macro processors with no arg constructors if name i…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockMacroProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockMacroProcessor.java
@@ -5,6 +5,10 @@ import java.util.Map;
 
 public abstract class BlockMacroProcessor extends MacroProcessor {
 
+    public BlockMacroProcessor() {
+        this(null, new HashMap<String, Object>());
+    }
+
     public BlockMacroProcessor(String macroName) {
         this(macroName, new HashMap<String, Object>());
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockProcessor.java
@@ -126,7 +126,11 @@ public abstract class BlockProcessor extends Processor {
     public static final String CONTEXT_PARAGRAPH = ":paragraph";
 
     protected String name;
-    
+
+    public BlockProcessor() {
+        this(null);
+    }
+
     public BlockProcessor(String name) {
         this(name, new HashMap<String, Object>());
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
@@ -25,6 +25,10 @@ public abstract class InlineMacroProcessor extends MacroProcessor {
      */
     public static final String REGEXP = "regexp";
 
+    public InlineMacroProcessor() {
+        this(null);
+    }
+
     public InlineMacroProcessor(String macroName) {
         this(macroName, new HashMap<String, Object>());
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
@@ -78,11 +78,12 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash)getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the name
-            setProcessor(
-                    getProcessorClass()
-                            .getConstructor(String.class)
-                            .newInstance(
-                                    RubyUtils.rubyToJava(getRuntime(), args[0], String.class)));
+            String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
+            setProcessor(instantiateProcessor(macroName));
+
+            if (getProcessor().getName() == null) {
+                getProcessor().setName(macroName);
+            }
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -78,12 +78,13 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
 
+            String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
             // First create only the instance passing in the block name
-            setProcessor(
-                    getProcessorClass()
-                            .getConstructor(String.class)
-                            .newInstance(
-                                    RubyUtils.rubyToJava(getRuntime(), args[0], String.class)));
+            setProcessor(instantiateProcessor(macroName));
+
+            if (getProcessor().getName() == null) {
+                getProcessor().setName(macroName);
+            }
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
@@ -74,10 +74,7 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(
-                    getProcessorClass()
-                            .getConstructor()
-                            .newInstance());
+            setProcessor(instantiateProcessor());
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
@@ -78,10 +78,7 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(
-                    getProcessorClass()
-                            .getConstructor()
-                            .newInstance());
+            setProcessor(instantiateProcessor());
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
@@ -91,12 +91,13 @@ public class InlineMacroProcessorProxy extends AbstractMacroProcessorProxy<Inlin
             // because the accessor is routed to the Java Processor.config
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
+            String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
             // First create only the instance passing in the block name
-            setProcessor(
-                    getProcessorClass()
-                            .getConstructor(String.class)
-                            .newInstance(
-                                    RubyUtils.rubyToJava(getRuntime(), args[0], String.class)));
+            setProcessor(instantiateProcessor(macroName));
+
+            if (getProcessor().getName() == null) {
+                getProcessor().setName(macroName);
+            }
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
@@ -76,10 +76,7 @@ public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(
-                    getProcessorClass()
-                            .getConstructor()
-                            .newInstance());
+            setProcessor(instantiateProcessor());
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
@@ -74,10 +74,7 @@ public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
                     Block.NULL_BLOCK);
         } else {
             // First create only the instance passing in the block name
-            setProcessor(
-                    getProcessorClass()
-                            .getConstructor()
-                            .newInstance());
+            setProcessor(instantiateProcessor());
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
@@ -75,10 +75,7 @@ public class TreeprocessorProxy extends AbstractProcessorProxy<Treeprocessor> {
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(
-                    getProcessorClass()
-                            .getConstructor()
-                            .newInstance());
+            setProcessor(instantiateProcessor());
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockMacroProcessor.groovy
@@ -9,11 +9,6 @@ class AnnotatedBlockMacroProcessor extends BlockMacroProcessor {
 
     public static final String RESULT = 'This content is added by this macro!'
 
-    AnnotatedBlockMacroProcessor(String macroName) {
-        super(macroName)
-        assert macroName == 'testmacro'
-    }
-
     @Override
     Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
         createBlock(parent, 'paragraph', RESULT)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockProcessor.groovy
@@ -12,7 +12,11 @@ import org.asciidoctor.ast.AbstractBlock
 ])
 class AnnotatedBlockProcessor extends BlockProcessor {
 
-    AnnotatedBlockProcessor(String blockName) {
+    AnnotatedBlockProcessor() {}
+
+    // This constructor will not be called when registered as a a class
+    // because 2 Strings don't match any known signature.
+    AnnotatedBlockProcessor(String dummyValue, String blockName) {
         super(blockName)
     }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedDocinfoProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedDocinfoProcessor.groovy
@@ -12,7 +12,7 @@ class AnnotatedDocinfoProcessor extends DocinfoProcessor {
     AnnotatedDocinfoProcessor() {}
 
     AnnotatedDocinfoProcessor(LocationType location) {
-        config['location'] = ":${location.name().toLowerCase()}"
+        config['location'] = location.optionValue()
     }
 
     @Override

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
@@ -9,13 +9,8 @@ import org.asciidoctor.ast.AbstractBlock
 @PositionalAttributes(['section', 'subsection'])
 class AnnotatedLongInlineMacroProcessor extends InlineMacroProcessor {
 
-    public static final String RESULT = 'This content is added by this macro!'
     public static final String SUBSECTION = 'subsection'
     public static final String SECTION = 'section'
-
-    AnnotatedLongInlineMacroProcessor(String macroName) {
-        super(macroName)
-    }
 
     @Override
     Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
@@ -8,8 +8,6 @@ import org.asciidoctor.ast.AbstractBlock
 @Format(regexp = 'manpage:(.*?)\\[(.*?)\\]')
 class AnnotatedRegexpInlineMacroProcessor extends InlineMacroProcessor {
 
-    public static final String RESULT = 'This content is added by this macro!'
-
     AnnotatedRegexpInlineMacroProcessor(String macroName) {
         super(macroName)
     }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
@@ -160,7 +160,7 @@ And even more infos on manpage:git[7].
     def "when registering a BlockProcessor instance it should be configurable via annotations"() {
 
         when:
-        asciidoctor.javaExtensionRegistry().block(new AnnotatedBlockProcessor('yell2'))
+        asciidoctor.javaExtensionRegistry().block(new AnnotatedBlockProcessor('dummy', 'yell2'))
         String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().headerFooter(false))
 
         then:


### PR DESCRIPTION
…s defined via an annotation

As discussed in #196 this PR brings support for macro and block processors that only provide a no arg constructor if the name is defined via an annotation.

All processor proxies now use a more generic way to instantiate the processor by using the constructor with the most matching arguments, so this could also be used if we would support passing a configuration at processor registration time.
(JavaExtensionRegistry does not support passing a config yet, but I think Asciidoctor itself supports that.)