### PR TITLE
Removed default setting of any JRuby options

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -132,9 +132,6 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
     private static RubyInstanceConfig createOptimizedConfiguration() {
         RubyInstanceConfig config = new RubyInstanceConfig();
-        config.setCompatVersion(CompatVersion.RUBY2_0);
-        config.setCompileMode(CompileMode.OFF);
-
         return config;
     }
 

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -23,8 +23,7 @@ startScripts {
   mainClassName = 'org.asciidoctor.cli.AsciidoctorInvoker'
   defaultJvmOpts = [
     '-client', '-Xmn128m', '-Xms256m', '-Xmx256m',
-    '-Xverify:none', '-XX:+UseFastAccessorMethods', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC',
-    '-Djruby.compile.mode=OFF', '-Djruby.compat.version=RUBY2_0'
+    '-Xverify:none', '-XX:+UseFastAccessorMethods', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC'
   ]
 }
 


### PR DESCRIPTION
This is to make a start for #296 
This PR removes any setting of the ruby compat version or compile mode.
AsciidoctorJ will still run with the defaults and a user can now override the defaults if required.
