### PR TITLE
#296 Load JRuby properties from ./.jrubyrc and ~/.jrubyrc

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
@@ -40,8 +40,8 @@ public class AsciidoctorInvoker {
             
             if (asciidoctorCliOptions.isVersion()) {
                 System.out.println("Asciidoctor " + asciidoctor.asciidoctorVersion() + " [http://asciidoctor.org]");
-                System.out.println("JRuby : " + JRubyRuntimeContext.get(asciidoctor).evalScriptlet("JRUBY_VERSION"));
-                System.out.println("Ruby compat version: " + JRubyRuntimeContext.get(asciidoctor).evalScriptlet("RUBY_VERSION"));
+                Object rubyVersionString = JRubyRuntimeContext.get(asciidoctor).evalScriptlet("\"#{JRUBY_VERSION} (#{RUBY_VERSION})\"");
+                System.out.println("Runtime Environment: jruby " + rubyVersionString);
                 return;
             }
             

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
@@ -14,10 +14,12 @@ import org.asciidoctor.DirectoryWalker;
 import org.asciidoctor.GlobDirectoryWalker;
 import org.asciidoctor.Options;
 import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.internal.JRubyRuntimeContext;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 
 import com.beust.jcommander.JCommander;
+import org.jruby.Main;
 
 public class AsciidoctorInvoker {
 
@@ -38,6 +40,8 @@ public class AsciidoctorInvoker {
             
             if (asciidoctorCliOptions.isVersion()) {
                 System.out.println("Asciidoctor " + asciidoctor.asciidoctorVersion() + " [http://asciidoctor.org]");
+                System.out.println("JRuby : " + JRubyRuntimeContext.get(asciidoctor).evalScriptlet("JRUBY_VERSION"));
+                System.out.println("Ruby compat version: " + JRubyRuntimeContext.get(asciidoctor).evalScriptlet("RUBY_VERSION"));
                 return;
             }
             
@@ -205,6 +209,10 @@ public class AsciidoctorInvoker {
     }
 
     public static void main(String args[]) {
+
+        // Process .jrubyrc file
+        Main.processDotfile();
+
         new AsciidoctorInvoker().invoke(args);
     }
 


### PR DESCRIPTION
One step further:
This PR parses the files `./.jrubyrc` and `~/.jrubyrc` when asciidoctorj is started via the CLI.
(IMO integrators should set these properties themselves, either use the same method or define own properties.)

Fortunately JRuby already provides a public static method to do this in `org.jruby.Main` that is simply used to accomplish this.

Additionally extended the version output (-V) to show the JRuby version and RUBY_VERSION.
