### PR TITLE
Updated description of options for the JRuby runtime

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1689,10 +1689,10 @@ Asciidoctor asciidoctor = Asciidoctor.Factory.create();
 When starting AsciidoctorJ via the CLI these options can be defined in the files `.jrubyrc` that are loaded from the current working directory and the home directory of the user.
 
 ----
-> cat ./.jrubyrc
+$ cat ./.jrubyrc
 compat.version=RUBY1_9
 compile.mode=OFF
-> ./asciidoctorj -V
+$ ./asciidoctorj -V
 AsciidoctorJ 1.5.2 [http://asciidoctor.org]
 Runtime Environment: jruby 1.7.20 (1.9.3)
 ----
@@ -1700,6 +1700,15 @@ Runtime Environment: jruby 1.7.20 (1.9.3)
 [NOTE]
 The properties in these `.jrubyrc` files do not contain the prefix `jruby.`. 
 The property values also must not have trailing blanks!
+
+Alternatively you can also set any system properties using the environment variable `ASCIIDOCTORJ_OPTS`:
+
+----
+$ export ASCIIDOCTORJ_OPTS=-Djruby.compat.version=RUBY1_9
+$ asciidoctorj -V
+AsciidoctorJ 1.5.2 [http://asciidoctor.org]
+Runtime Environment: jruby 1.7.20 (1.9.3)
+----
 
 The Java flags available for improving start time depend on whether your working on a 32- or 64-bit processor and your JDK version.
 Let's see a summary of these flags and in which environments they can be used.

--- a/README.adoc
+++ b/README.adoc
@@ -1677,10 +1677,31 @@ For small tasks such as converting an AsciiDoc document, two JRuby flags can dra
 |OFF
 |===
 
-Both flags are set by default inside AsciidoctorJ.
+When using AsciidoctorJ via the API these flags have to be set as system properties when creating the `org.asciidoctor.Asciidoctor` instance:
+
+[source,java]
+----
+System.setProperty("jruby.compat.version", "RUBY1_9");
+System.setProperty("jruby.compile.mode", "OFF");
+Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+----
+
+When starting AsciidoctorJ via the CLI these options can be defined in the files `.jrubyrc` that are loaded from the current working directory and the home directory of the user.
+
+----
+> cat ./.jrubyrc
+compat.version=RUBY1_9
+compile.mode=OFF
+> ./asciidoctorj -V
+AsciidoctorJ 1.5.2 [http://asciidoctor.org]
+Runtime Environment: jruby 1.7.20 (1.9.3)
+----
+
+[NOTE]
+The properties in these `.jrubyrc` files do not contain the prefix `jruby.`. 
+The property values also must not have trailing blanks!
 
 The Java flags available for improving start time depend on whether your working on a 32- or 64-bit processor and your JDK version.
-These flags are set by using the `JRUBY_OPTS` environment variable.
 Let's see a summary of these flags and in which environments they can be used.
 
 [cols="1m,2",width="75%"]
@@ -1704,9 +1725,8 @@ Let's see a summary of these flags and in which environments they can be used.
 [source,shell]
 .Setting flags for Java SE 6
 ----
-export JRUBY_OPTS="-J-Xverify:none -J-client" # <1>
+export JAVA_OPTS="-Xverify:none -client" 
 ----
-<1> Note that you should add `-J` before the flag.
 
 You can find a full explanation on how to improve the start time of JRuby applications in <<Optimization>>.
 


### PR DESCRIPTION
Describe that the JRuby runtime can be configured via `jruby.*` system properties or `.jrubyrc` files when launching via the shell script.