### PR TITLE
Readded support for processor constructors with a trailing map parameter

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
@@ -20,6 +20,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockMacroProcessor> {
@@ -79,7 +80,7 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
         } else {
             // First create only the instance passing in the name
             String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
-            setProcessor(instantiateProcessor(macroName));
+            setProcessor(instantiateProcessor(macroName, new HashMap<String, Object>()));
 
             if (getProcessor().getName() == null) {
                 getProcessor().setName(macroName);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -20,6 +20,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> {
@@ -80,7 +81,7 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
 
             String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
             // First create only the instance passing in the block name
-            setProcessor(instantiateProcessor(macroName));
+            setProcessor(instantiateProcessor(macroName, new HashMap<String, Object>()));
 
             if (getProcessor().getName() == null) {
                 getProcessor().setName(macroName);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/DocinfoProcessorProxy.java
@@ -17,6 +17,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 
 public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcessor> {
 
@@ -74,7 +75,7 @@ public class DocinfoProcessorProxy extends AbstractProcessorProxy<DocinfoProcess
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(instantiateProcessor());
+            setProcessor(instantiateProcessor(new HashMap<String, Object>()));
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
@@ -20,6 +20,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcessor> {
@@ -78,7 +79,7 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(instantiateProcessor());
+            setProcessor(instantiateProcessor(new HashMap<String, Object>()));
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PostprocessorProxy.java
@@ -20,6 +20,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 
 public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
 
@@ -76,7 +77,7 @@ public class PostprocessorProxy extends AbstractProcessorProxy<Postprocessor> {
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(instantiateProcessor());
+            setProcessor(instantiateProcessor(new HashMap<String, Object>()));
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
@@ -21,6 +21,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 
 public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
 
@@ -74,7 +75,7 @@ public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
                     Block.NULL_BLOCK);
         } else {
             // First create only the instance passing in the block name
-            setProcessor(instantiateProcessor());
+            setProcessor(instantiateProcessor(new HashMap<String, Object>()));
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/TreeprocessorProxy.java
@@ -19,6 +19,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 
 public class TreeprocessorProxy extends AbstractProcessorProxy<Treeprocessor> {
 
@@ -75,7 +76,7 @@ public class TreeprocessorProxy extends AbstractProcessorProxy<Treeprocessor> {
             getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(instantiateProcessor());
+            setProcessor(instantiateProcessor(new HashMap<String, Object>()));
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ChangeAttributeValuePreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ChangeAttributeValuePreprocessor.java
@@ -6,8 +6,6 @@ import java.util.Map;
 
 public class ChangeAttributeValuePreprocessor extends Preprocessor {
 
-	public ChangeAttributeValuePreprocessor() {}
-
 	public ChangeAttributeValuePreprocessor(Map<String, Object> config) {
 		super(config);
 	}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/CustomFooterPostProcessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/CustomFooterPostProcessor.java
@@ -8,8 +8,6 @@ import java.util.Map;
 
 public class CustomFooterPostProcessor extends Postprocessor {
 
-    public CustomFooterPostProcessor() {}
-
     public CustomFooterPostProcessor(Map<String, Object> config) {
         super(config);
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/HasMoreLinesPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/HasMoreLinesPreprocessor.java
@@ -9,8 +9,6 @@ import static org.junit.Assert.assertThat;
 
 public class HasMoreLinesPreprocessor extends Preprocessor {
 
-	public HasMoreLinesPreprocessor() {}
-
 	public HasMoreLinesPreprocessor(Map<String, Object> config) {
 		super(config);
 	}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/MetaRobotsDocinfoProcessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/MetaRobotsDocinfoProcessor.java
@@ -6,10 +6,6 @@ import java.util.Map;
 
 public class MetaRobotsDocinfoProcessor extends DocinfoProcessor {
 
-    public MetaRobotsDocinfoProcessor() {
-        super();
-    }
-
     public MetaRobotsDocinfoProcessor(Map<String, Object> config) {
         super(config);
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NextLineEmptyPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NextLineEmptyPreprocessor.java
@@ -9,8 +9,6 @@ import static org.junit.Assert.assertThat;
 
 public class NextLineEmptyPreprocessor extends Preprocessor {
 
-	public NextLineEmptyPreprocessor() {}
-
 	public NextLineEmptyPreprocessor(Map<String, Object> config) {
 		super(config);
 	}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NumberLinesPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NumberLinesPreprocessor.java
@@ -11,10 +11,6 @@ public class NumberLinesPreprocessor extends Preprocessor {
 
 	public NumberLinesPreprocessor() {}
 
-	public NumberLinesPreprocessor(Map<String, Object> config) {
-		super(config);
-	}
-
 	@Override
 	public PreprocessorReader process(DocumentRuby document,
 			PreprocessorReader reader) {


### PR DESCRIPTION
With changing the way processor classes get instantiated by AsciidoctorJ I removed the last map argument to the constructor call because there was simply no value in it.
AsciidoctorJ could only pass an empty map.

But removing this parameter would make existing processors incompatible.

So I readded the trailing map parameter again, always passing in an empty HashMap.

For a BlockProcessor registered as a class AsciidoctorJ will now call the constructors in this order:
1. String macroName, Map config
2. String macroName
3. no args

The first constructor that exists will be called.

The same mechanism applies for all other extensions.