### PR TITLE
Support for creating tables with asciidoc style in extensions

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
@@ -61,4 +61,16 @@ public interface Cell extends AbstractNode {
      */
     void setVerticalAlignment(Table.VerticalAlignment valign);
 
+    /**
+     * If the style of a cell is {@code asciidoc} the content of the cell is an inner document.
+     * This method returns this inner document.
+     * @return The inner document if the cell style is {@code asciidoc}
+     */
+    DocumentRuby getInnerDocument();
+
+    /**
+     * @see {@link #getInnerDocument()}
+     */
+    void setInnerDocument(DocumentRuby document);
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/CellImpl.java
@@ -63,4 +63,14 @@ public class CellImpl extends AbstractNodeImpl implements Cell {
         setAttr("valign", valign.name().toLowerCase(), true);
     }
 
+    @Override
+    public DocumentRuby getInnerDocument() {
+        return (DocumentRuby) NodeConverter.createASTNode(getRubyProperty("inner_document"));
+    }
+
+    @Override
+    public void setInnerDocument(DocumentRuby document) {
+        setRubyProperty("@inner_document", ((Document) document).getRubyObject());
+    }
+
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableTestConverter.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableTestConverter.groovy
@@ -48,7 +48,7 @@ class TableTestConverter extends AbstractConverter {
 
         Closure cellFormatter = { Cell cell ->
             if (cell.style == 'asciidoc') {
-                cell.content.toString().padRight(COLWIDTH)
+                cell.innerDocument.convert().padRight(COLWIDTH)
             } else {
                 switch (cell.column.horizontalAlignment) {
                     case Table.HorizontalAlignment.LEFT:

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
@@ -2,12 +2,16 @@ package org.asciidoctor.extension
 
 import groovy.json.JsonSlurper
 import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.Cell
 import org.asciidoctor.ast.Column
+import org.asciidoctor.ast.DocumentRuby
 import org.asciidoctor.ast.Row
 import org.asciidoctor.ast.Table
 import org.asciidoctor.util.TestHttpServer
 
 class GithubContributorsBlockMacro extends BlockMacroProcessor {
+
+    private static final String IMAGE = 'image'
 
     GithubContributorsBlockMacro(String macroName) {
         super(macroName)
@@ -26,12 +30,14 @@ class GithubContributorsBlockMacro extends BlockMacroProcessor {
         table.title = "Github contributors of $target"
 
         // Create the columns 'Login' and 'Contributions'
-        Column loginColumn = createTableColumn(table, 0)
-        Column contributionsColumn = createTableColumn(table, 1)
+        Column avatarColumn = createTableColumn(table, 0)
+        Column loginColumn = createTableColumn(table, 1)
+        Column contributionsColumn = createTableColumn(table, 2)
         contributionsColumn.setHorizontalAlignment(Table.HorizontalAlignment.CENTER)
 
         // Create the single header row with the column titles
         Row headerRow = createTableRow(table)
+        headerRow.cells << createTableCell(avatarColumn, 'Avatar')
         headerRow.cells << createTableCell(loginColumn, 'Login')
         headerRow.cells << createTableCell(loginColumn, 'Contributions')
         table.header << headerRow
@@ -39,6 +45,11 @@ class GithubContributorsBlockMacro extends BlockMacroProcessor {
         // for each contributor create a cell with the login and the number of contributions
         contributors.each { contributor ->
             Row row = createTableRow(table)
+
+            DocumentRuby document = createDocument(parent.getDocument())
+            document.blocks << createBlock(document, IMAGE, null, ['type': IMAGE, 'target': contributor.avatar_url])
+            Cell avatarCell = createTableCell(loginColumn, document)
+            row.cells << avatarCell
             row.cells << createTableCell(loginColumn, contributor.login)
             row.cells << createTableCell(contributionsColumn, contributor.contributions as String)
             table.body << row

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesATable.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesATable.groovy
@@ -16,11 +16,15 @@ import spock.lang.Specification
 @RunWith(ArquillianSputnik)
 class WhenABlockMacroProcessorCreatesATable extends Specification {
 
-    public static final String FIRST_TD = 'td:first-child'
+    public static final String FIRST_TD  = 'td:first-child'
     public static final String SECOND_TD = 'td:nth-child(2)'
+    public static final String THIRD_TD  = 'td:nth-child(3)'
+    public static final String IMG_ELEMENT  = 'img'
     public static final String CONTRIBUTOR = 'bob'
     public static final String BLOCKMACRO_NAME = 'githubcontributors'
-    public static final String ALIGN_ATTRIBUTE = '@align'
+
+    public static final String AVATAR_URL_REGEXP = /https:\/\/avatars.githubusercontent.com\/u\/.*/
+
     @ArquillianResource
     private Asciidoctor asciidoctor
 
@@ -60,13 +64,16 @@ githubcontributors::asciidoctor/asciidoctorj[]
 
         htmlDocument.select('table').hasClass('grid-rows')
 
-        htmlDocument.select(FIRST_TD).size() == htmlDocument.select(SECOND_TD) != 0
-        htmlDocument.select(FIRST_TD).size() != 0
+        htmlDocument.select(FIRST_TD).every { tdElement -> tdElement.select(IMG_ELEMENT).size() == 1 }
+        htmlDocument.select(FIRST_TD).every { tdElement -> tdElement.select(IMG_ELEMENT)[0].attr('src') =~ AVATAR_URL_REGEXP }
 
-        htmlDocument.select(FIRST_TD).every { tdElement -> tdElement.hasClass('halign-left')}
-        htmlDocument.select(SECOND_TD).every { tdElement -> tdElement.hasClass('halign-center')}
+        htmlDocument.select(SECOND_TD).size() == htmlDocument.select(SECOND_TD) != 0
+        htmlDocument.select(SECOND_TD).size() != 0
 
-        htmlDocument.select(FIRST_TD).find { tdElement -> tdElement.text() == CONTRIBUTOR } != null
+        htmlDocument.select(SECOND_TD).every { tdElement -> tdElement.hasClass('halign-left')}
+        htmlDocument.select(THIRD_TD).every { tdElement -> tdElement.hasClass('halign-center')}
+
+        htmlDocument.select(SECOND_TD).find { tdElement -> tdElement.text() == CONTRIBUTOR } != null
     }
 
     def "the table should be rendered to docbook"() {
@@ -80,7 +87,7 @@ githubcontributors::asciidoctor/asciidoctorj[]
         when:
         asciidoctor.convert(DOCUMENT,
                 OptionsBuilder.options()
-                        .backend('docbook')
+                        .backend('docbook5')
                         .safe(SafeMode.SAFE)
                         .inPlace(false)
                         .baseDir(tmp.getRoot())
@@ -90,11 +97,14 @@ githubcontributors::asciidoctor/asciidoctorj[]
         then:
         def rootNode = new XmlSlurper().parse(resultFile)
         rootNode.table.tgroup.tbody.'*'.find { row ->
-            row.entry[0].text() == CONTRIBUTOR
+            row.entry[1].text() == CONTRIBUTOR
         }
         rootNode.table.tgroup.tbody.'*'.size() > 0
-        rootNode.table.tgroup.tbody.'*'.every {row -> row.entry[0][ALIGN_ATTRIBUTE] == 'left'}
-        rootNode.table.tgroup.tbody.'*'.every {row -> row.entry[1][ALIGN_ATTRIBUTE] == 'center'}
+        rootNode.table.tgroup.tbody.'*'.every {row ->
+            row.entry[0].informalfigure.mediaobject.imageobject.imagedata.@fileref =~ AVATAR_URL_REGEXP
+        }
+        rootNode.table.tgroup.tbody.'*'.every {row -> row.entry[1].@align == 'left'}
+        rootNode.table.tgroup.tbody.'*'.every {row -> row.entry[2].@align == 'center'}
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -138,9 +138,9 @@ public class WhenAsciiDocIsRenderedToDocument {
                                                     .attributes(AttributesBuilder.attributes().dataUri(true))
                                                     .compact(true).asMap();
         Document document = asciidoctor.load(DOCUMENT, options);
-        assertThat(document.getAttributes(), hasKey("encoding"));
-        assertThat(document.isAttr("encoding", "UTF-8", false), is(true));
-        assertThat(document.getAttr("encoding", "", false).toString(), is("UTF-8"));
+        assertThat(document.getAttributes(), hasKey("toc-placement"));
+        assertThat(document.isAttr("toc-placement", "auto", false), is(true));
+        assertThat(document.getAttr("toc-placement", "", false).toString(), is("auto"));
     }
 
     @Test

--- a/asciidoctorj-core/src/test/resources/githubcontributors.json
+++ b/asciidoctorj-core/src/test/resources/githubcontributors.json
@@ -2,7 +2,7 @@
   {
     "login": "alice",
     "id": 1,
-    "avatar_url": "https://avatars.githubusercontent.com/u/1517153?v=3",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1?v=3",
     "gravatar_id": "",
     "url": "https://api.github.com/users/alice",
     "html_url": "https://github.com/alice",
@@ -22,7 +22,7 @@
   {
     "login": "bob",
     "id": 2,
-    "avatar_url": "https://avatars.githubusercontent.com/u/79351?v=3",
+    "avatar_url": "https://avatars.githubusercontent.com/u/2?v=3",
     "gravatar_id": "",
     "url": "https://api.github.com/users/bob",
     "html_url": "https://github.com/bob",
@@ -42,7 +42,7 @@
   {
     "login": "charlie",
     "id": 3,
-    "avatar_url": "https://avatars.githubusercontent.com/u/1163662?v=3",
+    "avatar_url": "https://avatars.githubusercontent.com/u/3?v=3",
     "gravatar_id": "",
     "url": "https://api.github.com/users/charlie",
     "html_url": "https://github.com/charlie",


### PR DESCRIPTION
This PR adds support to create table cells with the asciidoc style.
These cells do not have content lines but have a nested document instead.

Therefore I
- added `Processor.createDocument(DocumentRuby parentDoc)` to create a nested document
- added `Processor.createTableCell(Column, DocumentRuby)` to create a cell with a nested document instead of content.

This is for example required to have images in tables.