### PR TITLE
Source location

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlock.java
@@ -29,4 +29,11 @@ public interface AbstractBlock extends AbstractNode {
     String convert();
     List<AbstractBlock> findBy(Map<Object, Object> selector);
     int getLevel();
+
+    /**
+     * Returns the source location of this block.
+     * This information is only available if the {@code sourcemap} option is enabled when loading or rendering the document.
+     * @return the source location of this block or {@code null} if the {@code sourcemap} option is not enabled when loading the document.
+     */
+    Cursor getSourceLocation();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -74,6 +74,15 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     }
 
     @Override
+    public Cursor getSourceLocation() {
+        IRubyObject object = getRubyProperty("source_location");
+        if (object == null || object.isNil()) {
+            return null;
+        }
+        return new CursorImpl(object);
+    }
+
+    @Override
     public List<AbstractBlock> findBy(Map<Object, Object> selector) {
 
         RubyArray rubyBlocks = (RubyArray) getRubyProperty("find_by", RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cursor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cursor.java
@@ -1,0 +1,16 @@
+package org.asciidoctor.ast;
+
+public interface Cursor {
+
+    /**
+     * @return The line number where the owning block begins.
+     */
+    int getLineNumber();
+
+    String getPath();
+
+    String getDir();
+
+    String getFile();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/CursorImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/CursorImpl.java
@@ -1,0 +1,32 @@
+package org.asciidoctor.ast;
+
+import org.asciidoctor.internal.RubyObjectWrapper;
+import org.jruby.runtime.builtin.IRubyObject;
+
+public class CursorImpl extends RubyObjectWrapper implements Cursor {
+
+    public CursorImpl(IRubyObject rubyNode) {
+        super(rubyNode);
+    }
+
+    @Override
+    public int getLineNumber() {
+        return getInt("lineno");
+    }
+
+    @Override
+    public String getPath() {
+        return getString("path");
+    }
+
+    @Override
+    public String getDir() {
+        return getString("dir");
+    }
+
+    @Override
+    public String getFile() {
+        return getString("file");
+    }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -18,12 +18,9 @@ import org.asciidoctor.converter.internal.ConverterRegistryExecutor;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.extension.internal.ExtensionRegistryExecutor;
-import org.jruby.CompatVersion;
 import org.jruby.Ruby;
 import org.jruby.RubyHash;
 import org.jruby.RubyInstanceConfig;
-import org.jruby.RubyInstanceConfig.CompileMode;
-import org.jruby.embed.ScriptingContainer;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaEmbedUtils;
 
@@ -567,7 +564,7 @@ public class JRubyAsciidoctor implements Asciidoctor {
     @Override
     public Document loadFile(File file, Map<String, Object> options) {
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
-        return (Document) NodeConverter.createASTNode(this.asciidoctorModule.load(file.getAbsolutePath(), rubyHash));
+        return (Document) NodeConverter.createASTNode(this.asciidoctorModule.load_file(file.getAbsolutePath(), rubyHash));
 
     }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -232,4 +232,30 @@ public class WhenAsciiDocIsRenderedToDocument {
         assertThat(document.getAttributes().get(attributeName), is(attributeValue));
     }
 
+    @Test
+    public void should_be_able_to_get_source_location() {
+        // Given
+        File file = classpath.getResource("sourcelocation.adoc");
+
+        // When
+        Document document = asciidoctor.loadFile(file, OptionsBuilder.options().option("sourcemap", "true").asMap());
+        Map<Object, Object> selector = new HashMap<Object, Object>();
+        selector.put("context", ":paragraph");
+        List<AbstractBlock> findBy = document.findBy(selector);
+        AbstractBlock block = findBy.get(0);
+
+        // Then
+        AbstractBlock block1 = findBy.get(0);
+        assertThat(block1.getSourceLocation().getLineNumber(), is(3));
+        assertThat(block1.getSourceLocation().getPath(), is(file.getName()));
+        assertThat(block1.getSourceLocation().getFile(), is(file.getName()));
+        assertThat(block1.getSourceLocation().getDir(), is(file.getParent().replaceAll("\\\\", "/")));
+
+        AbstractBlock block2 = findBy.get(1);
+        assertThat(block2.getSourceLocation().getLineNumber(), is(8));
+        assertThat(block2.getSourceLocation().getPath(), is(file.getName()));
+        assertThat(block2.getSourceLocation().getFile(), is(file.getName()));
+        assertThat(block2.getSourceLocation().getDir(), is(file.getParent().replaceAll("\\\\", "/")));
+    }
+
 }

--- a/asciidoctorj-core/src/test/resources/sourcelocation.adoc
+++ b/asciidoctorj-core/src/test/resources/sourcelocation.adoc
@@ -1,0 +1,10 @@
+= Test
+
+A paragraph
+that spans 2 lines
+
+== Section
+
+Another
+paragraph
+that spans 3 lines


### PR DESCRIPTION
This PR resolves #351 
I added a method `AbstractBlock.getSourceLocation()` that returns a `org.asciidoctor.ast.Cursor`.
