### PR TITLE
Add own proxying for Reader and PreprocessorReader.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PreprocessorReader.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PreprocessorReader.java
@@ -8,6 +8,13 @@ public interface PreprocessorReader extends Reader {
 
     void push_include(String data, String file, String path, int lineNumber, Map<String, Object> attributes);
 
+    /**
+     *
+     * @return
+     * @deprecated Please use {@link #getDocument()}
+     */
     Document document();
-    
+
+    Document getDocument();
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PreprocessorReaderImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PreprocessorReaderImpl.java
@@ -1,0 +1,35 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.NodeConverter;
+import org.jruby.RubyHash;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.Map;
+
+public class PreprocessorReaderImpl extends ReaderImpl implements PreprocessorReader {
+
+    public PreprocessorReaderImpl(IRubyObject rubyNode) {
+        super(rubyNode);
+    }
+
+    @Override
+    public void push_include(String data, String file, String path, int lineNumber, Map<String, Object> attributes) {
+
+        RubyHash attributeHash = RubyHash.newHash(getRuntime());
+        attributeHash.putAll(attributes);
+
+        getRubyProperty("push_include", data, file, path, lineNumber, attributes);
+    }
+
+    @Override
+    public Document document() {
+        return getDocument();
+    }
+
+    @Override
+    public Document getDocument() {
+        return (Document) NodeConverter.createASTNode(getRubyProperty("document"));
+    }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Reader.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Reader.java
@@ -53,7 +53,48 @@ public interface Reader {
      */
     List<String> readLines();
 
+    /**
+     * Get the next line of source data. Consumes the line returned.
+     *
+     * @return the String of the next line of the source data if data is present or
+     * nulll if there is no more data.
+    */
+    String readLine();
+
     List<String> lines();
+
+    /**
+     * Push the String line onto the beginning of the Array of source data.
+     *
+     * Since this line was (assumed to be) previously retrieved through the
+     * reader, it is marked as seen.
+     */
+    void restoreLine(String line);
+
+    /**
+     * Push multiple lines onto the beginning of the Array of source data.
+     *
+     * Since this lines were (assumed to be) previously retrieved through the
+     * reader, they are marked as seen.
+     */
+    void restoreLines(List<String> line);
+
+    /**
+     * Peek at the next line of source data. Processes the line, if not
+     * already marked as processed, but does not consume it.
+     *
+     * This method will probe the reader for more lines.
+     */
+    String peekLine();
+
+    /**
+     * Peek at the next multiple lines of source data. Processes the lines, if not
+     * already marked as processed, but does not consume them.
+     *
+     * @param lineCount The Integer number of lines to peek.
+     * @return
+     */
+    List<String> peekLines(int lineCount);
 
     /**
      * Advance to the next line by discarding the line at the front of the stack

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Reader.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Reader.java
@@ -8,8 +8,16 @@ public interface Reader {
      * Get the 1-based offset of the current line.
      * 
      * @return 1-based offset.
+     * @deprecated Please use {@link #getLineNumber()}
      */
     int getLineno();
+
+    /**
+     * Get the 1-based offset of the current line.
+     *
+     * @return 1-based offset.
+     */
+    int getLineNumber();
 
     /**
      * Check whether there are any lines left to read. If a previous call to this method resulted in a value of false,

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ReaderImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ReaderImpl.java
@@ -42,8 +42,33 @@ public class ReaderImpl extends RubyObjectWrapper implements Reader {
     }
 
     @Override
+    public String readLine() {
+        return getString("read_line");
+    }
+
+    @Override
     public List<String> lines() {
         return getList("lines", String.class);
+    }
+
+    @Override
+    public void restoreLine(String line) {
+        getRubyProperty("unshift_line", line);
+    }
+
+    @Override
+    public void restoreLines(List<String> lines) {
+        getRubyProperty("unshift_lines", lines);
+    }
+
+    @Override
+    public String peekLine() {
+        return getString("peek_line");
+    }
+
+    @Override
+    public List<String> peekLines(int lineCount) {
+        return getList("peek_lines", String.class, lineCount);
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ReaderImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ReaderImpl.java
@@ -1,0 +1,59 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.internal.RubyObjectWrapper;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.List;
+
+public class ReaderImpl extends RubyObjectWrapper implements Reader {
+
+    public ReaderImpl(IRubyObject rubyNode) {
+        super(rubyNode);
+    }
+
+    @Override
+    public int getLineno() {
+        return getLineNumber();
+    }
+
+    @Override
+    public int getLineNumber() {
+        return getInt("lineno");
+    }
+
+    @Override
+    public boolean hasMoreLines() {
+        return getBoolean("has_more_lines?");
+    }
+
+    @Override
+    public boolean isNextLineEmpty() {
+        return getBoolean("next_line_empty?");
+    }
+
+    @Override
+    public String read() {
+        return getString("read");
+    }
+
+    @Override
+    public List<String> readLines() {
+        return getList("read_lines", String.class);
+    }
+
+    @Override
+    public List<String> lines() {
+        return getList("lines", String.class);
+    }
+
+    @Override
+    public boolean advance() {
+        return getBoolean("advance");
+    }
+
+    @Override
+    public void terminate() {
+        getRubyProperty("terminate");
+    }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -5,6 +5,7 @@ import org.asciidoctor.ast.AbstractNodeImpl;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.BlockProcessor;
 import org.asciidoctor.extension.Reader;
+import org.asciidoctor.extension.ReaderImpl;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
@@ -117,7 +118,7 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
     public IRubyObject process(ThreadContext context, IRubyObject parent, IRubyObject reader, IRubyObject attributes) {
         Object o = getProcessor().process(
                 (AbstractBlock) NodeConverter.createASTNode(parent),
-                RubyUtils.rubyToJava(getRuntime(), reader, Reader.class),
+                new ReaderImpl(reader),
                 RubyUtils.rubyToJava(getRuntime(), attributes, Map.class));
 
         return convertProcessorResult(o);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/IncludeProcessorProxy.java
@@ -4,6 +4,7 @@ import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.IncludeProcessor;
 import org.asciidoctor.extension.PreprocessorReader;
+import org.asciidoctor.extension.PreprocessorReaderImpl;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
@@ -105,7 +106,7 @@ public class IncludeProcessorProxy extends AbstractProcessorProxy<IncludeProcess
     @JRubyMethod(name = "process", required = 4)
     public IRubyObject process(ThreadContext context, IRubyObject[] args) {
         Document document = (Document) NodeConverter.createASTNode(args[0]);
-        PreprocessorReader reader = RubyUtils.rubyToJava(getRuntime(), args[1], PreprocessorReader.class);
+        PreprocessorReader reader = new PreprocessorReaderImpl(args[1]);
         String target = RubyUtils.rubyToJava(getRuntime(), args[2], String.class);
         Map<String, Object> attributes = RubyUtils.rubyToJava(getRuntime(), args[3], Map.class);
         getProcessor().process(document, reader, target, attributes);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
@@ -5,6 +5,7 @@ import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.Preprocessor;
 import org.asciidoctor.extension.PreprocessorReader;
+import org.asciidoctor.extension.PreprocessorReaderImpl;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
@@ -93,10 +94,14 @@ public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
 
     @JRubyMethod(name = "process", required = 2)
     public IRubyObject process(ThreadContext context, IRubyObject document, IRubyObject preprocessorReader) {
-        Object o = getProcessor().process(
+        PreprocessorReader result = getProcessor().process(
                 (Document) NodeConverter.createASTNode(document),
-                RubyUtils.rubyToJava(getRuntime(), preprocessorReader, PreprocessorReader.class));
+                new PreprocessorReaderImpl(preprocessorReader));
 
-        return convertProcessorResult(o);
+        if (result instanceof PreprocessorReaderImpl) {
+            return ((PreprocessorReaderImpl) result).getRubyObject();
+        } else {
+            return JavaEmbedUtils.javaToRuby(getRuntime(), result);
+        }
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
@@ -1,0 +1,177 @@
+package org.asciidoctor.extension
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.ast.Document
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+@RunWith(ArquillianSputnik)
+class WhenAPreprocessorIsRegistered extends Specification {
+    
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    public static final int ONE = 1
+    public static final int TWO = 2
+
+    private final String firstLine = 'First line'
+    private final String secondLine = 'Second line'
+
+    private final String document = """$firstLine
+$secondLine"""
+
+    def 'should be able to peek single lines from Reader'() {
+        given:
+
+        AtomicBoolean preprocessorCalled = new AtomicBoolean(false)
+
+        asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
+            @Override
+            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+                preprocessorCalled.set(true)
+
+                assert reader.peekLine() == firstLine
+                assert reader.peekLine() == firstLine
+
+                reader.advance()
+
+                assert reader.peekLine() == secondLine
+                assert reader.peekLine() == secondLine
+
+                reader.advance()
+
+                assert reader.peekLine() == null
+            }
+        })
+
+        when:
+        asciidoctor.convert(document, OptionsBuilder.options())
+
+        then:
+        preprocessorCalled.get()
+    }
+
+    def 'should be able to peek multiple lines from Reader'() {
+        given:
+
+        AtomicBoolean preprocessorCalled = new AtomicBoolean(false)
+
+        asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
+            @Override
+            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+                preprocessorCalled.set(true)
+
+                assert reader.peekLines(ONE) == [firstLine]
+                assert reader.peekLines(TWO) == [firstLine, secondLine]
+
+                reader.advance()
+
+                assert reader.peekLines(ONE) == [secondLine]
+                assert reader.peekLines(TWO) == [secondLine]
+
+                reader.advance()
+
+                assert reader.peekLines(ONE) == []
+                assert reader.peekLines(TWO) == []
+            }
+        })
+
+        when:
+        asciidoctor.convert(document, OptionsBuilder.options())
+
+        then:
+        preprocessorCalled.get()
+    }
+
+    def 'should be able to read line by line from Reader'() {
+        given:
+
+        AtomicBoolean preprocessorCalled = new AtomicBoolean(false)
+
+        asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
+            @Override
+            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+                preprocessorCalled.set(true)
+
+                assert reader.readLine() == firstLine
+                assert reader.readLine() == secondLine
+                assert reader.readLine() == null
+            }
+        })
+
+        when:
+        asciidoctor.convert(document, OptionsBuilder.options())
+
+        then:
+        preprocessorCalled.get()
+    }
+
+    def 'should be able to restore a line into the Reader'() {
+        given:
+
+        AtomicBoolean preprocessorCalled = new AtomicBoolean(false)
+
+        String anotherLine = 'Another line'
+
+        asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
+            @Override
+            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+                preprocessorCalled.set(true)
+
+                assert reader.peekLine() == firstLine
+
+                reader.restoreLine(anotherLine)
+
+                assert reader.peekLine() == anotherLine
+                assert reader.readLine() == anotherLine
+                assert reader.peekLine() == firstLine
+                assert reader.readLine() == firstLine
+            }
+        })
+
+        when:
+        asciidoctor.convert(document, OptionsBuilder.options())
+
+        then:
+        preprocessorCalled.get()
+    }
+
+    def 'should be able to restore multiple lines into the Reader'() {
+        given:
+
+        AtomicBoolean preprocessorCalled = new AtomicBoolean(false)
+
+        String anotherFirstLine = 'Another first line'
+        String anotherSecondLine = 'Another second line'
+
+        asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
+            @Override
+            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+                preprocessorCalled.set(true)
+
+                assert reader.peekLine() == firstLine
+
+                reader.restoreLines([anotherFirstLine, anotherSecondLine])
+
+                assert reader.peekLine() == anotherFirstLine
+                assert reader.readLine() == anotherFirstLine
+                assert reader.peekLine() == anotherSecondLine
+                assert reader.readLine() == anotherSecondLine
+                assert reader.peekLine() == firstLine
+                assert reader.readLine() == firstLine
+            }
+        })
+
+        when:
+        asciidoctor.convert(document, OptionsBuilder.options())
+
+        then:
+        preprocessorCalled.get()
+    }
+
+}


### PR DESCRIPTION
At the moment Reader and PreprocessorReader are still the "simple" Ruby wrapper objects with their drawbacks.
For example PreprocessorReader.document() will return a Ruby wrapper again instead of THE Document object that all other AST objects return.