### PR TITLE
WIP: Publish Snapshot builds

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1835,6 +1835,27 @@ Here's how to use a pre-release version in Maven:
 </repositories>
 ----
 
+== Using a snapshot version
+
+Snapshot versions will be published to https://oss.jfrog.org.
+To use a snapshot version of the the AsciidoctorJ library add this repository to your project:
+
+[source,xml]
+----
+<repositories>
+  <repository>
+    <id>oss-jfrog-artifactory</id>
+    <name>oss-jfrog-artifactory-releases</name>
+    <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+</repositories>
+----
+
+You can also download a snapshot version of the distribution from here: https://oss.jfrog.org/oss-snapshot-local/org/asciidoctor/asciidoctorj-distribution
+
 == Development
 
 AsciidoctorJ is built using {uri-gradle}[Gradle].
@@ -1984,6 +2005,14 @@ NOTE: The `-x pMNPTML` is necessary to work around a bug in the publishing plugi
 IMPORTANT: Bintray does not allow you to publish snapshots.
 You have to first update the version in [path]_gradle.properties_ to a release (or pre-release) version number.
 Currently, Gradle is not configured to automatically tag a release, so *you have to create the git tag manually*.
+
+=== Publish snapshot versions
+
+To publish a snapshot version simply run:
+
+ $ ./gradlew artifactoryPublish
+
+This will publish the all artifacts that have a snapshot version number to https://oss.jfrog.org.
 
 == Resources
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     if (JavaVersion.current().isJava7Compatible()) {
       classpath 'com.netflix.nebula:nebula-publishing-plugin:2.2.2'
     }
+    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1'
   }
 }
 
@@ -177,7 +178,11 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
 subprojects {
   if (JavaVersion.current().isJava7Compatible()) {
     apply from: rootProject.file('gradle/sign.gradle')
-    apply from: rootProject.file('gradle/deploy.gradle')
+    if (statusIsRelease) {
+      apply from: rootProject.file('gradle/deploy.gradle')
+    } else if (it.version.endsWith('SNAPSHOT')) {
+      apply from: rootProject.file('gradle/deploySnapshot.gradle')
+    }
   }
 }
 

--- a/gradle/deploySnapshot.gradle
+++ b/gradle/deploySnapshot.gradle
@@ -1,0 +1,38 @@
+if (project.name.endsWith('-distribution')) {
+    // artifactory-upload is for publishing configurations
+    apply plugin: 'com.jfrog.artifactory-upload'
+} else {
+    // artifactory is for publishing publications
+    apply plugin: 'com.jfrog.artifactory'
+}
+
+artifactory {
+    contextUrl = 'https://oss.jfrog.org/artifactory'   //The base Artifactory URL if not overridden by the publisher/resolver
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = System.env['BINTRAY_USER'] ?: (project.hasProperty('bintrayUsername') ? project.bintrayUsername : '')
+            password = System.env['BINTRAY_KEY'] ?: (project.hasProperty('bintrayApiKey') ? project.bintrayApiKey : '')
+            maven = true
+        }
+        defaults {
+
+            if (project.name.endsWith('-distribution')) {
+                // NOTE ignore warning that install task does not exist; the plugin is looking for the wrong task!!
+                publishConfigs('archives')
+            }
+            else {
+                publications('mavenNebula')
+            }
+
+            def dryRun = project.hasProperty('dryRun') && project.dryRun.toBoolean()
+            publishBuildInfo = !dryRun  //Publish build-info to Artifactory (true by default)
+            publishArtifacts = !dryRun   //Publish artifacts to Artifactory (true by default)
+            publishPom = !dryRun && !project.name.endsWith('-distribution')  //Publish generated POM files to Artifactory (true by default).
+            publishIvy = false   //Publish generated Ivy descriptor files to Artifactory (true by default).
+
+        }
+    }
+}
+
+artifactoryPublish.dependsOn preparePublish

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -67,14 +67,11 @@ afterEvaluate {
     //artifacts.clear()
     //from components.java
 
-    // NOTE only build sources and javadoc jars when releasing
-    if (project.statusIsRelease) {
-      if (project.tasks.withType(Jar).findByName('sourcesJar')) {
-        artifact sourcesJar
-      }
-      if (project.tasks.withType(Jar).findByName('javadocJar')) {
-        artifact javadocJar
-      }
+    if (project.tasks.withType(Jar).findByName('sourcesJar')) {
+      artifact sourcesJar
+    }
+    if (project.tasks.withType(Jar).findByName('javadocJar')) {
+      artifact javadocJar
     }
 
     pom.withXml {


### PR DESCRIPTION
I managed to upload a snapshot version of the asciidoctorj.jar with this via `./gradlew :asciidoctorj:artifactoryPublish`.
But it fails for other projects like the EPUB converter or the test-support project if I want to publish everything with a HTTP 409 (Conflict).

I don't really understand how it is all connected, gradle publishing, the nebula publishing plugin and now the artifactory plugin.
But I thought I already open a PR so that somebody could possibly help bringing this forward.

(And I just don't understand why the binary plugin and the artifactory plugin have to be so different, I mean it's the same company...)