### PR TITLE
add fix to upstream test script for OSX

### DIFF
--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -19,8 +19,8 @@ unzip -q $SRC_DIR.zip
 cp ../../asciidoctor-gem-installer.pom $SRC_DIR/pom.xml
 cd $SRC_DIR
 ASCIIDOCTOR_VERSION=`grep 'VERSION' ./lib/asciidoctor/version.rb | sed "s/.*'\(.*\)'.*/\1/"`
-sed -i "s;<version></version>;<version>$ASCIIDOCTOR_VERSION</version>;" pom.xml
-sed -i "s;^ *s\.files \+.*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor.gemspec
+sed "s;<version></version>;<version>$ASCIIDOCTOR_VERSION</version>;" pom.xml > pom.xml.sedtmp && mv -f pom.xml.sedtmp pom.xml
+sed "s;^ *s\.files *.*$;s.files = Dir['*.gemspec', '*.adoc', '{bin,data,lib}/*', '{bin,data,lib}/**/*'];" asciidoctor.gemspec > asciidoctor.gemspec.sedtmp && mv -f asciidoctor.gemspec.sedtmp asciidoctor.gemspec
 mvn install -Dgemspec=asciidoctor.gemspec
 cd ../..
 #rm -rf maven


### PR DESCRIPTION
Add a blank extension value to the `-i` flag when invoking `sed` so that it works on OSX. This should work in theory, but I haven't tested it yet on an OSX box.

The same patch should be applied to the master branch.