### PR TITLE
Renamed AST classes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -781,7 +781,7 @@ assertThat(document.doctitle(), is("Document Title")); // <2>
 
 But also all blocks that conforms the document can be retrieved.
 Currently there are support for three kinds of blocks.
-`Blocks` itself, `Section` for sections of the document and `AbstractBlock` which is the base type where all kind of blocks (including those not mapped as Java class) are mapped.
+`Blocks` itself, `Section` for sections of the document and `StructuralNode` which is the base type where all kind of blocks (including those not mapped as Java class) are mapped.
 
 [source]
 ----
@@ -809,7 +809,7 @@ Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
 Map<Object, Object> selector = new HashMap<Object, Object>(); // <1>
 selector.put("context", ":image"); // <2>
 
-List<AbstractBlock> findBy = document.findBy(selector);
+List<StructuralNode> findBy = document.findBy(selector);
 assertThat(findBy, hasSize(2)); //<3>
 ----
 <1> To make queries you need to use a `map` approach. Currently this is because of the Asciidoctor API but it will change in near future.
@@ -932,10 +932,10 @@ public class TerminalCommandTreeprocessor extends Treeprocessor { // <1>
 
     this.document = document;
 
-    final List<AbstractBlock> blocks = this.document.blocks(); // <2>
+    final List<StructuralNode> blocks = this.document.blocks(); // <2>
 
     for (int i = 0; i < blocks.size(); i++) {
-        final AbstractBlock currentBlock = blocks.get(i);
+        final StructuralNode currentBlock = blocks.get(i);
         if(currentBlock instanceof Block) {
             Block block = (Block)currentBlock;
             List<String> lines = block.lines(); // <3>
@@ -1122,7 +1122,7 @@ public class YellBlock extends BlockProcessor { // <1>
   }
 
   @Override
-  public Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) { // <3>
+  public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) { // <3>
       List<String> lines = reader.readLines();
       String upperLines = null;
       for (String line : lines) {
@@ -1181,7 +1181,7 @@ public class GistMacro extends BlockMacroProcessor { // <1>
   }
 
   @Override
-  public Block process(AbstractBlock parent, String target,
+  public Block process(StructuralNode parent, String target,
                         Map<String, Object> attributes) { // <3>
 
     String content = "<div class=\"content\">\n" +
@@ -1236,12 +1236,12 @@ public class ManpageMacro extends InlineMacroProcessor { //<1>
   }
 
   @Override
-  protected String process(AbstractBlock parent, String target, Map<String, Object> attributes) { // <3>
+  protected String process(StructuralNode parent, String target, Map<String, Object> attributes) { // <3>
 
       Map<String, Object> options = new HashMap<String, Object>();
       options.put("type", ":link");
       options.put("target", target + ".html");
-      return createInline(parent, "anchor", target, attributes, options).convert(); // <4>
+      return createPhraseNode(parent, "anchor", target, attributes, options).convert(); // <4>
   }
 
 }
@@ -1537,7 +1537,7 @@ public class TextConverter extends StringConverter {
     
     @Override
     public String convert(
-            AbstractNode node, String transform, Map<Object, Object> o) {    // <2>
+            ContentNode node, String transform, Map<Object, Object> o) {     // <2>
 
         if (transform == null) {                                             // <3>
             transform = node.getNodeName();
@@ -1553,7 +1553,7 @@ public class TextConverter extends StringConverter {
                     .append(LINE_SEPARATOR).append(LINE_SEPARATOR)
                     .append(section.getContent()).toString();                // <4>
         } else if (transform.equals("paragraph")) {
-            AbstractBlock block = (AbstractBlock) node;
+            StructuralNode block = (StructuralNode) node;
             String content = (String) block.content();                       // <4>
             return new StringBuilder(content.replaceAll(LINE_SEPARATOR, " "))
                             .append(LINE_SEPARATOR).toString();
@@ -1853,7 +1853,7 @@ To use a snapshot version of the the AsciidoctorJ library add this repository to
 </repositories>
 ----
 
-If you build your project using {uri-gradle}[Gradle] add the repository like this to our build:
+If you build your project using {uri-gradle}[Gradle] add the repository like this to your build:
 
 [source,groovy]
 ----

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Block.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Block.java
@@ -2,7 +2,7 @@ package org.asciidoctor.ast;
 
 import java.util.List;
 
-public interface Block extends AbstractBlock {
+public interface Block extends StructuralNode {
     /**
      * @deprecated Please use {@link #getLines}
      * @return The original content of this block

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.ast;
 
-public interface Cell extends AbstractNode {
+public interface Cell extends ContentNode {
 
     Column getColumn();
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Column.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Column.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.ast;
 
-public interface Column extends AbstractNode {
+public interface Column extends ContentNode {
 
     /**
      * Returns the style of this column.

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ContentNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ContentNode.java
@@ -3,7 +3,7 @@ package org.asciidoctor.ast;
 import java.util.List;
 import java.util.Map;
 
-public interface AbstractNode {
+public interface ContentNode {
 
     /**
      * @deprecated Please use {@link #getId()}
@@ -22,8 +22,8 @@ public interface AbstractNode {
     /**
      * @deprecated Use {@linkplain #getParent()}  instead.
      */
-    AbstractNode parent();
-    AbstractNode getParent();
+    ContentNode parent();
+    ContentNode getParent();
     /**
      * @deprecated Use {@linkplain #getContext()}  instead.
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
@@ -3,7 +3,7 @@ package org.asciidoctor.ast;
 import java.util.List;
 import java.util.Map;
 
-public interface Document extends AbstractBlock {
+public interface Document extends StructuralNode {
 
     /**
      * @return The Title structure for this document.
@@ -51,7 +51,7 @@ public interface Document extends AbstractBlock {
      *
      * @return blocks contained within current Document.
      */
-    List<AbstractBlock> blocks();
+    List<StructuralNode> blocks();
 
     /**
      *

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/List.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/List.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.ast;
 
-public interface ListNode extends AbstractBlock {
+public interface List extends StructuralNode {
 
-    java.util.List<AbstractBlock> getItems();
+    java.util.List<StructuralNode> getItems();
 
     boolean hasItems();
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItem.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItem.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.ast;
 
-public interface ListItem extends AbstractBlock {
+public interface ListItem extends StructuralNode {
 
     public String getMarker();
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeCache.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeCache.java
@@ -34,12 +34,12 @@ public class NodeCache {
         this.runtime = cache.getRuntime();
     }
 
-    public AbstractNode getASTNode() {
-        AbstractNode astNode = (AbstractNode) cache.get(getRuntime().newSymbol(KEY_AST_NODE));
+    public ContentNode getASTNode() {
+        ContentNode astNode = (ContentNode) cache.get(getRuntime().newSymbol(KEY_AST_NODE));
         return astNode;
     }
 
-    public void setASTNode(AbstractNode astNode) {
+    public void setASTNode(ContentNode astNode) {
         cache.put(getRuntime().newSymbol(KEY_AST_NODE), astNode);
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
@@ -1,5 +1,14 @@
 package org.asciidoctor.ast;
 
+import org.asciidoctor.ast.impl.BlockImpl;
+import org.asciidoctor.ast.impl.CellImpl;
+import org.asciidoctor.ast.impl.ColumnImpl;
+import org.asciidoctor.ast.impl.DocumentImpl;
+import org.asciidoctor.ast.impl.ListImpl;
+import org.asciidoctor.ast.impl.ListItemImpl;
+import org.asciidoctor.ast.impl.PhraseNodeImpl;
+import org.asciidoctor.ast.impl.SectionImpl;
+import org.asciidoctor.ast.impl.TableImpl;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
@@ -64,18 +73,18 @@ public final class NodeConverter {
 
     private NodeConverter() {}
 
-    public static AbstractNode createASTNode(Ruby runtime, NodeType nodeType, IRubyObject... args) {
+    public static ContentNode createASTNode(Ruby runtime, NodeType nodeType, IRubyObject... args) {
         IRubyObject node = nodeType.getRubyClass(runtime).callMethod(runtime.getCurrentContext(), "new", args);
         return createASTNode(node);
     }
 
 
-    public static AbstractNode createASTNode(Object object) {
+    public static ContentNode createASTNode(Object object) {
 
         if (object instanceof IRubyObject || object instanceof RubyObjectHolderProxy) {
             IRubyObject rubyObject = asRubyObject(object);
             NodeCache nodeCache = NodeCache.get(rubyObject);
-            AbstractNode cachedNode = nodeCache.getASTNode();
+            ContentNode cachedNode = nodeCache.getASTNode();
             if (cachedNode != null) {
                 return cachedNode;
             }
@@ -83,7 +92,7 @@ public final class NodeConverter {
             Ruby runtime = rubyObject.getRuntime();
 
             RubyClass rubyClass = rubyObject.getMetaClass().getRealClass();
-            AbstractNode ret = null;
+            ContentNode ret = null;
 
             switch (NodeType.getNodeType(rubyClass)) {
                 case BLOCK_CLASS:
@@ -96,7 +105,7 @@ public final class NodeConverter {
                     ret = new DocumentImpl(rubyObject);
                     break;
                 case INLINE_CLASS:
-                    ret = new InlineImpl(rubyObject);
+                    ret = new PhraseNodeImpl(rubyObject);
                     break;
                 case LIST_CLASS:
                     ret = new ListImpl(rubyObject);
@@ -120,9 +129,9 @@ public final class NodeConverter {
             nodeCache.setASTNode(ret);
 
             return ret;
-        } else if (object instanceof AbstractNode) {
+        } else if (object instanceof ContentNode) {
 
-            return (AbstractNode) object;
+            return (ContentNode) object;
 
         } else {
             throw new IllegalArgumentException(object != null ? object.toString() : "null");

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/PhraseNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/PhraseNode.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.ast;
 
-public interface Inline extends AbstractNode {
+public interface PhraseNode extends ContentNode {
 
     @Deprecated
     public String render();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Section.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Section.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.ast;
 
-public interface Section extends AbstractBlock {
+public interface Section extends StructuralNode {
 
     /**
      * @deprecated Please use {@link #getIndex()}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/StructuralNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/StructuralNode.java
@@ -3,7 +3,7 @@ package org.asciidoctor.ast;
 import java.util.List;
 import java.util.Map;
 
-public interface AbstractBlock extends AbstractNode {
+public interface StructuralNode extends ContentNode {
 
     /**
      * @deprecated Please use {@linkplain #getTitle()} instead
@@ -21,18 +21,18 @@ public interface AbstractBlock extends AbstractNode {
      * @return The list of child blocks of this block
      * @deprecated Please use {@linkplain #getBlocks()} instead
      */
-    List<AbstractBlock> blocks();
+    List<StructuralNode> blocks();
 
     /**
      * @return The list of child blocks of this block
      */
-    List<AbstractBlock> getBlocks();
+    List<StructuralNode> getBlocks();
 
     /**
      * Appends a new child block as the last block to this block.
      * @param block The new child block added as last child to this block.
      */
-    void append(AbstractBlock block);
+    void append(StructuralNode block);
 
     /**
      * @deprecated Please use {@linkplain #getContent()} instead
@@ -40,7 +40,7 @@ public interface AbstractBlock extends AbstractNode {
     Object content();
     Object getContent();
     String convert();
-    List<AbstractBlock> findBy(Map<Object, Object> selector);
+    List<StructuralNode> findBy(Map<Object, Object> selector);
     int getLevel();
 
     /**

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Table.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Table.java
@@ -2,7 +2,7 @@ package org.asciidoctor.ast;
 
 import java.util.List;
 
-public interface Table extends AbstractBlock {
+public interface Table extends StructuralNode {
 
     public static enum HorizontalAlignment {
         LEFT, CENTER, RIGHT

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/BlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/BlockImpl.java
@@ -1,10 +1,12 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
 import java.util.List;
 
+import org.asciidoctor.ast.Block;
+import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class BlockImpl extends AbstractBlockImpl implements Block {
+public class BlockImpl extends StructuralNodeImpl implements Block {
 
     public BlockImpl(IRubyObject blockDelegate) {
         super(blockDelegate);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
@@ -1,8 +1,13 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.Cell;
+import org.asciidoctor.ast.Column;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.NodeConverter;
+import org.asciidoctor.ast.Table;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class CellImpl extends AbstractNodeImpl implements Cell {
+public class CellImpl extends ContentNodeImpl implements Cell {
 
     public CellImpl(IRubyObject rubyNode) {
         super(rubyNode);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ColumnImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ColumnImpl.java
@@ -1,8 +1,10 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.Column;
+import org.asciidoctor.ast.Table;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class ColumnImpl extends AbstractNodeImpl implements Column {
+public class ColumnImpl extends ContentNodeImpl implements Column {
 
     public ColumnImpl(IRubyObject rubyNode) {
         super(rubyNode);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ContentNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ContentNodeImpl.java
@@ -1,5 +1,8 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.internal.RubyAttributesMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyObjectWrapper;
@@ -11,9 +14,9 @@ import org.jruby.javasupport.JavaEmbedUtils;
 import java.util.List;
 import java.util.Map;
 
-public abstract class AbstractNodeImpl extends RubyObjectWrapper implements AbstractNode {
+public abstract class ContentNodeImpl extends RubyObjectWrapper implements ContentNode {
 
-    public AbstractNodeImpl(IRubyObject rubyNode) {
+    public ContentNodeImpl(IRubyObject rubyNode) {
         super(rubyNode);
     }
 
@@ -43,12 +46,12 @@ public abstract class AbstractNodeImpl extends RubyObjectWrapper implements Abst
     }
 
     @Override
-    public AbstractNode parent() {
+    public ContentNode parent() {
         return getParent();
     }
 
     @Override
-    public AbstractNode getParent() {
+    public ContentNode getParent() {
         return NodeConverter.createASTNode(getRubyProperty("parent"));
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CursorImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CursorImpl.java
@@ -1,5 +1,6 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.Cursor;
 import org.asciidoctor.internal.RubyObjectWrapper;
 import org.jruby.runtime.builtin.IRubyObject;
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DocumentImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DocumentImpl.java
@@ -1,7 +1,10 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
 import java.util.Map;
 
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.Title;
+import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
@@ -9,7 +12,7 @@ import org.jruby.RubyHash;
 import org.jruby.RubySymbol;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class DocumentImpl extends AbstractBlockImpl implements Document {
+public class DocumentImpl extends StructuralNodeImpl implements Document {
 
     public DocumentImpl(IRubyObject document) {
         super(document);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListImpl.java
@@ -1,17 +1,17 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.List;
+import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import java.util.List;
-
-public class ListImpl extends AbstractBlockImpl implements ListNode {
+public class ListImpl extends StructuralNodeImpl implements List {
 
     public ListImpl(IRubyObject delegate) {
         super(delegate);
     }
 
     @Override
-    public List<AbstractBlock> getItems() {
+    public java.util.List getItems() {
         return getBlocks();
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListItemImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListItemImpl.java
@@ -1,8 +1,10 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.ListItem;
+import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class ListItemImpl extends AbstractBlockImpl implements ListItem {
+public class ListItemImpl extends StructuralNodeImpl implements ListItem {
 
     public ListItemImpl(IRubyObject listDelegate) {
         super(listDelegate);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/PhraseNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/PhraseNodeImpl.java
@@ -1,11 +1,11 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
-import org.jruby.Ruby;
+import org.asciidoctor.ast.PhraseNode;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class InlineImpl extends AbstractNodeImpl implements Inline  {
+public class PhraseNodeImpl extends ContentNodeImpl implements PhraseNode {
 
-    public InlineImpl(IRubyObject delegate) {
+    public PhraseNodeImpl(IRubyObject delegate) {
         super(delegate);
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/RowImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/RowImpl.java
@@ -1,5 +1,7 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.Cell;
+import org.asciidoctor.ast.Row;
 import org.asciidoctor.internal.RubyBlockListDecorator;
 import org.asciidoctor.internal.RubyObjectWrapper;
 import org.jruby.RubyArray;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/SectionImpl.java
@@ -1,8 +1,10 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.Section;
+import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class SectionImpl extends AbstractBlockImpl implements Section {
+public class SectionImpl extends StructuralNodeImpl implements Section {
 
     public SectionImpl(IRubyObject blockDelegate) {
         super(blockDelegate);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/StructuralNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/StructuralNodeImpl.java
@@ -1,5 +1,7 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.Cursor;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.internal.RubyBlockListDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.jruby.RubyArray;
@@ -8,12 +10,12 @@ import org.jruby.runtime.builtin.IRubyObject;
 import java.util.List;
 import java.util.Map;
 
-public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock {
+public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNode {
 
     private static final String BLOCK_CLASS = "Block";
     private static final String SECTION_CLASS = "Section";
     
-    public AbstractBlockImpl(IRubyObject blockDelegate) {
+    public StructuralNodeImpl(IRubyObject blockDelegate) {
         super(blockDelegate);
     }
 
@@ -43,20 +45,20 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     }
 
     @Override
-    public List<AbstractBlock> blocks() {
+    public List<StructuralNode> blocks() {
         return getBlocks();
     }
 
     @Override
-    public List<AbstractBlock> getBlocks() {
+    public List<StructuralNode> getBlocks() {
         RubyArray rubyBlocks = (RubyArray) getRubyProperty("blocks");
-        return new RubyBlockListDecorator<AbstractBlock>(rubyBlocks);
+        return new RubyBlockListDecorator<StructuralNode>(rubyBlocks);
     }
 
     @Override
-    public void append(AbstractBlock block) {
+    public void append(StructuralNode block) {
 
-        getRubyObject().callMethod(runtime.getCurrentContext(), "<<", ((AbstractBlockImpl) block).getRubyObject());
+        getRubyObject().callMethod(runtime.getCurrentContext(), "<<", ((StructuralNodeImpl) block).getRubyObject());
     }
 
     @Override
@@ -89,7 +91,7 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     }
 
     @Override
-    public List<AbstractBlock> findBy(Map<Object, Object> selector) {
+    public List<StructuralNode> findBy(Map<Object, Object> selector) {
 
         RubyArray rubyBlocks = (RubyArray) getRubyProperty("find_by", RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,
                 selector));

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/TableImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/TableImpl.java
@@ -1,5 +1,8 @@
-package org.asciidoctor.ast;
+package org.asciidoctor.ast.impl;
 
+import org.asciidoctor.ast.Column;
+import org.asciidoctor.ast.Row;
+import org.asciidoctor.ast.Table;
 import org.asciidoctor.internal.RubyBlockListDecorator;
 import org.asciidoctor.internal.RubyObjectWrapper;
 import org.jruby.RubyArray;
@@ -10,7 +13,7 @@ import java.util.AbstractList;
 import java.util.Collection;
 import java.util.List;
 
-public class TableImpl extends AbstractBlockImpl implements Table {
+public class TableImpl extends StructuralNodeImpl implements Table {
 
     private static final String FRAME_ATTR = "frame";
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/converter/Converter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/converter/Converter.java
@@ -1,22 +1,22 @@
 package org.asciidoctor.converter;
 
-import org.asciidoctor.ast.AbstractNode;
+import org.asciidoctor.ast.ContentNode;
 
 import java.util.Map;
 
 public interface Converter<T> {
 
     /**
-     * Converts an {@link org.asciidoctor.ast.AbstractNode} using the specified transform along
+     * Converts an {@link ContentNode} using the specified transform along
      * with additional options. If a transform is not specified, implementations
-     * typically derive one from the {@link org.asciidoctor.ast.AbstractNode#getNodeName()} property.
+     * typically derive one from the {@link ContentNode#getNodeName()} property.
      *
      * <p>Implementations are free to decide how to carry out the conversion. In
      * the case of the built-in converters, the tranform value is used to
      * dispatch to a handler method. The TemplateConverter uses the value of
      * the transform to select a template to render.
      *
-     * @param node The concrete instance of AbstractNode to convert
+     * @param node The concrete instance of FlowNode to convert
      * @param transform An optional String transform that hints at which transformation
      *             should be applied to this node. If a transform is not specified,
      *             the transform is typically derived from the value of the
@@ -25,7 +25,7 @@ public interface Converter<T> {
      *             how to convert the node. (optional, default: empty map)
      * @return the converted result
      */
-    T convert(AbstractNode node, String transform, Map<Object, Object> opts);
+    T convert(ContentNode node, String transform, Map<Object, Object> opts);
 
     Map<String, Object> getOptions();
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/converter/ConverterProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/converter/ConverterProxy.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.converter;
 
-import org.asciidoctor.ast.AbstractNode;
+import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
@@ -126,7 +126,7 @@ public class ConverterProxy<T> extends RubyObject {
 
     @JRubyMethod(required = 1, optional = 2)
     public IRubyObject convert(ThreadContext context, IRubyObject[] args) {
-        AbstractNode node = NodeConverter.createASTNode(args[0]);
+        ContentNode node = NodeConverter.createASTNode(args[0]);
 
         T ret = null;
         if (args.length == 1) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockProcessor.java
@@ -3,7 +3,7 @@ package org.asciidoctor.extension;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 
 public abstract class BlockProcessor extends Processor {
 
@@ -148,5 +148,5 @@ public abstract class BlockProcessor extends Processor {
         this.name = name;
     }
     
-    public abstract Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes);
+    public abstract Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes);
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Contexts.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Contexts.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
  *         super(blockName);
  *     }
  *
- *     public Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+ *     public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
  *         List<String> lines = reader.readLines();
  *         List<String> newLines = new ArrayList<>();
  *         for (String line: lines) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/MacroProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/MacroProcessor.java
@@ -3,7 +3,7 @@ package org.asciidoctor.extension;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 
 public abstract class MacroProcessor extends Processor {
 
@@ -30,6 +30,6 @@ public abstract class MacroProcessor extends Processor {
         return new HashMap<Object, Object>();
     }
     
-    public abstract Object process(AbstractBlock parent, String target, Map<String, Object> attributes);
+    public abstract Object process(StructuralNode parent, String target, Map<String, Object> attributes);
     
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PositionalAttributes.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PositionalAttributes.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
  *         super(macroName)
  *     }
  *
- *     public Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+ *     public Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
  *         assertEquals(attributes.get("section"), "7")
  *     }
  * }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
@@ -2,8 +2,11 @@ package org.asciidoctor.extension;
 
 import org.asciidoctor.Options;
 import org.asciidoctor.ast.*;
+import org.asciidoctor.ast.impl.ColumnImpl;
+import org.asciidoctor.ast.impl.DocumentImpl;
+import org.asciidoctor.ast.impl.RowImpl;
+import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.asciidoctor.internal.JRubyRuntimeContext;
-import org.asciidoctor.extension.ReaderImpl;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyObjectWrapper;
 import org.asciidoctor.internal.RubyUtils;
@@ -11,7 +14,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyHash;
-import org.jruby.java.proxies.RubyObjectHolderProxy;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.HashMap;
@@ -112,18 +114,18 @@ public class Processor {
     }
 
 
-    public Table createTable(AbstractBlock parent) {
+    public Table createTable(StructuralNode parent) {
         return createTable(parent, new HashMap<String, Object>());
     }
 
-    public Table createTable(AbstractBlock parent, Map<String, Object> attributes) {
+    public Table createTable(StructuralNode parent, Map<String, Object> attributes) {
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
 
         RubyHash rubyAttributes = RubyHash.newHash(rubyRuntime);
         rubyAttributes.putAll(attributes);
 
         IRubyObject[] parameters = {
-                ((AbstractBlockImpl) parent).getRubyObject(),
+                ((StructuralNodeImpl) parent).getRubyObject(),
                 rubyAttributes};
         Table ret = (Table) NodeConverter.createASTNode(rubyRuntime, TABLE_CLASS, parameters);
         ret.setAttr("rowcount", 0, false);
@@ -148,7 +150,7 @@ public class Processor {
         rubyAttributes.putAll(attributes);
 
         IRubyObject[] parameters = {
-                ((AbstractBlockImpl) parent).getRubyObject(),
+                ((StructuralNodeImpl) parent).getRubyObject(),
                 RubyFixnum.newFixnum(rubyRuntime, index),
                 rubyAttributes}; // No cursor parameter yet
 
@@ -184,15 +186,15 @@ public class Processor {
         return (Cell) NodeConverter.createASTNode(rubyRuntime, TABLE_CELL_CLASS, parameters);
     }
 
-    public Block createBlock(AbstractBlock parent, String context, String content) {
+    public Block createBlock(StructuralNode parent, String context, String content) {
         return createBlock(parent, context, content, new HashMap<String, Object>(), new HashMap<Object, Object>());
     }
 
-    public Block createBlock(AbstractBlock parent, String context, String content, Map<String, Object> attributes) {
+    public Block createBlock(StructuralNode parent, String context, String content, Map<String, Object> attributes) {
         return createBlock(parent, context, content, attributes, new HashMap<Object, Object>());
     }
 
-    public Block createBlock(AbstractBlock parent, String context, String content, Map<String, Object> attributes,
+    public Block createBlock(StructuralNode parent, String context, String content, Map<String, Object> attributes,
             Map<Object, Object> options) {
 
         options.put(Options.SOURCE, content);
@@ -201,15 +203,15 @@ public class Processor {
         return createBlock(parent, context, options);
     }
 
-    public Block createBlock(AbstractBlock parent, String context, List<String> content) {
+    public Block createBlock(StructuralNode parent, String context, List<String> content) {
         return createBlock(parent, context, content, new HashMap<String, Object>(), new HashMap<Object, Object>());
     }
 
-    public Block createBlock(AbstractBlock parent, String context, List<String> content, Map<String, Object> attributes) {
+    public Block createBlock(StructuralNode parent, String context, List<String> content, Map<String, Object> attributes) {
         return createBlock(parent, context, content, attributes, new HashMap<Object, Object>());
     }
 
-    public Block createBlock(AbstractBlock parent, String context, List<String> content, Map<String, Object> attributes,
+    public Block createBlock(StructuralNode parent, String context, List<String> content, Map<String, Object> attributes,
             Map<Object, Object> options) {
 
         options.put(Options.SOURCE, content);
@@ -218,31 +220,31 @@ public class Processor {
         return createBlock(parent, context, options);
     }
 
-    public Section createSection(AbstractBlock parent) {
+    public Section createSection(StructuralNode parent) {
         return createSection(parent, null, true, new HashMap<Object, Object>());
     }
 
-    public Section createSection(AbstractBlock parent, Map<Object, Object> options) {
+    public Section createSection(StructuralNode parent, Map<Object, Object> options) {
         return createSection(parent, null, true, options);
     }
 
-    public Section createSection(AbstractBlock parent, boolean numbered, Map<Object, Object> options) {
+    public Section createSection(StructuralNode parent, boolean numbered, Map<Object, Object> options) {
         return createSection(parent, null, numbered, options);
     }
 
-    public Section createSection(AbstractBlock parent, int level, boolean numbered, Map<Object, Object> options) {
+    public Section createSection(StructuralNode parent, int level, boolean numbered, Map<Object, Object> options) {
         return createSection(parent, Integer.valueOf(level), numbered, options);
     }
 
-    public Inline createInline(AbstractBlock parent, String context, List<String> text) {
-        return createInline(parent, context, text, new HashMap<String, Object>());
+    public PhraseNode createPhraseNode(StructuralNode parent, String context, List<String> text) {
+        return createPhraseNode(parent, context, text, new HashMap<String, Object>());
     }
 
-    public Inline createInline(AbstractBlock parent, String context, List<String> text, Map<String, Object> attributes) {
-        return createInline(parent, context, text, attributes, new HashMap<Object, Object>());
+    public PhraseNode createPhraseNode(StructuralNode parent, String context, List<String> text, Map<String, Object> attributes) {
+        return createPhraseNode(parent, context, text, attributes, new HashMap<Object, Object>());
     }
 
-    public Inline createInline(AbstractBlock parent, String context, List<String> text, Map<String, Object> attributes, Map<Object, Object> options) {
+    public PhraseNode createPhraseNode(StructuralNode parent, String context, List<String> text, Map<String, Object> attributes, Map<Object, Object> options) {
 
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
 
@@ -255,22 +257,22 @@ public class Processor {
         rubyText.addAll(text);
 
         IRubyObject[] parameters = {
-                ((AbstractBlockImpl) parent).getRubyObject(),
+                ((StructuralNodeImpl) parent).getRubyObject(),
                 RubyUtils.toSymbol(rubyRuntime, context),
                 rubyText,
                 convertMapToRubyHashWithSymbols };
-        return (Inline) NodeConverter.createASTNode(rubyRuntime, INLINE_CLASS, parameters);
+        return (PhraseNode) NodeConverter.createASTNode(rubyRuntime, INLINE_CLASS, parameters);
     }
 
-    public Inline createInline(AbstractBlock parent, String context, String text) {
-        return createInline(parent, context, text, new HashMap<String, Object>());
+    public PhraseNode createPhraseNode(StructuralNode parent, String context, String text) {
+        return createPhraseNode(parent, context, text, new HashMap<String, Object>());
     }
 
-    public Inline createInline(AbstractBlock parent, String context, String text, Map<String, Object> attributes) {
-        return createInline(parent, context, text, attributes, new HashMap<String, Object>());
+    public PhraseNode createPhraseNode(StructuralNode parent, String context, String text, Map<String, Object> attributes) {
+        return createPhraseNode(parent, context, text, attributes, new HashMap<String, Object>());
     }
 
-    public Inline createInline(AbstractBlock parent, String context, String text, Map<String, Object> attributes, Map<String, Object> options) {
+    public PhraseNode createPhraseNode(StructuralNode parent, String context, String text, Map<String, Object> attributes, Map<String, Object> options) {
         
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
 
@@ -279,14 +281,14 @@ public class Processor {
         RubyHash convertedOptions = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
 
         IRubyObject[] parameters = {
-                ((AbstractBlockImpl) parent).getRubyObject(),
+                ((StructuralNodeImpl) parent).getRubyObject(),
                 RubyUtils.toSymbol(rubyRuntime, context),
                 text == null ? rubyRuntime.getNil() : rubyRuntime.newString(text),
                 convertedOptions };
-        return (Inline) NodeConverter.createASTNode(rubyRuntime, INLINE_CLASS, parameters);
+        return (PhraseNode) NodeConverter.createASTNode(rubyRuntime, INLINE_CLASS, parameters);
     }
     
-    private Block createBlock(AbstractBlock parent, String context,
+    private Block createBlock(StructuralNode parent, String context,
             Map<Object, Object> options) {
 
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
@@ -295,13 +297,13 @@ public class Processor {
                 options);
 
         IRubyObject[] parameters = {
-                ((AbstractBlockImpl) parent).getRubyObject(),
+                ((StructuralNodeImpl) parent).getRubyObject(),
                 RubyUtils.toSymbol(rubyRuntime, context),
                 convertMapToRubyHashWithSymbols };
         return (Block) NodeConverter.createASTNode(rubyRuntime, BLOCK_CLASS, parameters);
     }
 
-    private Section createSection(AbstractBlock parent, Integer level, boolean numbered, Map<Object, Object> options) {
+    private Section createSection(StructuralNode parent, Integer level, boolean numbered, Map<Object, Object> options) {
 
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
 
@@ -309,7 +311,7 @@ public class Processor {
                 options);
 
         IRubyObject[] parameters = {
-                ((AbstractBlockImpl) parent).getRubyObject(),
+                ((StructuralNodeImpl) parent).getRubyObject(),
                 level == null ? rubyRuntime.getNil() : rubyRuntime.newFixnum(level),
                 rubyRuntime.newBoolean(numbered),
                 convertMapToRubyHashWithSymbols };
@@ -359,11 +361,11 @@ public class Processor {
      * @param parent The block to which the parsed content should be added as children.
      * @param lines Raw asciidoctor content
      */
-    public void parseContent(AbstractBlock parent, List<String> lines) {
+    public void parseContent(StructuralNode parent, List<String> lines) {
         Ruby runtime = JRubyRuntimeContext.get(parent);
         Parser parser = new Parser(runtime, parent, ReaderImpl.createReader(runtime, lines));
 
-        AbstractBlock nextBlock = parser.nextBlock();
+        StructuralNode nextBlock = parser.nextBlock();
         while (nextBlock != null) {
             parent.append(nextBlock);
             nextBlock = parser.nextBlock();
@@ -373,24 +375,24 @@ public class Processor {
     private class Parser extends RubyObjectWrapper {
 
         private final Reader reader;
-        private final AbstractBlock parent;
+        private final StructuralNode parent;
 
-        public Parser(Ruby runtime, AbstractBlock parent, Reader reader) {
+        public Parser(Ruby runtime, StructuralNode parent, Reader reader) {
             super(runtime.getModule("Asciidoctor").getClass("Parser"));
 
             this.reader = reader;
             this.parent = parent;
         }
 
-        public AbstractBlock nextBlock() {
+        public StructuralNode nextBlock() {
             if (!reader.hasMoreLines()) {
                 return null;
             }
-            IRubyObject nextBlock = getRubyProperty("next_block", reader, ((AbstractBlockImpl)parent).getRubyObject());
+            IRubyObject nextBlock = getRubyProperty("next_block", reader, ((StructuralNodeImpl)parent).getRubyObject());
             if (nextBlock.isNil()) {
                 return null;
             } else {
-                return (AbstractBlock) NodeConverter.createASTNode(nextBlock);
+                return (StructuralNode) NodeConverter.createASTNode(nextBlock);
             }
         }
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.extension.processorproxies;
 
-import org.asciidoctor.ast.AbstractNodeImpl;
+import org.asciidoctor.ast.impl.ContentNodeImpl;
 import org.asciidoctor.extension.ContentModel;
 import org.asciidoctor.extension.Contexts;
 import org.asciidoctor.extension.DefaultAttribute;
@@ -111,8 +111,8 @@ public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
     }
 
     protected IRubyObject convertProcessorResult(Object o) {
-        if (o instanceof AbstractNodeImpl) {
-            return ((AbstractNodeImpl) o).getRubyObject();
+        if (o instanceof ContentNodeImpl) {
+            return ((ContentNodeImpl) o).getRubyObject();
         } else {
             return JavaEmbedUtils.javaToRuby(getRuntime(), o);
         }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
@@ -1,8 +1,6 @@
 package org.asciidoctor.extension.processorproxies;
 
-import org.asciidoctor.ast.AbstractBlock;
-import org.asciidoctor.ast.AbstractNode;
-import org.asciidoctor.ast.AbstractNodeImpl;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.BlockMacroProcessor;
 import org.asciidoctor.internal.RubyHashMapDecorator;
@@ -104,7 +102,7 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
     @JRubyMethod(name = "process", required = 3)
     public IRubyObject process(ThreadContext context, IRubyObject parent, IRubyObject target, IRubyObject attributes) {
         Object o = getProcessor().process(
-                (AbstractBlock) NodeConverter.createASTNode(parent),
+                (StructuralNode) NodeConverter.createASTNode(parent),
                 RubyUtils.rubyToJava(getRuntime(), target, String.class),
                 RubyUtils.rubyToJava(getRuntime(), attributes, Map.class));
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.extension.processorproxies;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.BlockProcessor;
 import org.asciidoctor.extension.ReaderImpl;
@@ -115,7 +115,7 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
     @JRubyMethod(name = "process", required = 3)
     public IRubyObject process(ThreadContext context, IRubyObject parent, IRubyObject reader, IRubyObject attributes) {
         Object o = getProcessor().process(
-                (AbstractBlock) NodeConverter.createASTNode(parent),
+                (StructuralNode) NodeConverter.createASTNode(parent),
                 new ReaderImpl(reader),
                 RubyUtils.rubyToJava(getRuntime(), attributes, Map.class));
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/InlineMacroProcessorProxy.java
@@ -1,7 +1,6 @@
 package org.asciidoctor.extension.processorproxies;
 
-import org.asciidoctor.ast.AbstractBlock;
-import org.asciidoctor.ast.AbstractNodeImpl;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.internal.RubyHashMapDecorator;
@@ -10,7 +9,6 @@ import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
-import org.jruby.RubyRegexp;
 import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaEmbedUtils;
@@ -19,7 +17,6 @@ import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.RegexpOptions;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
@@ -117,7 +114,7 @@ public class InlineMacroProcessorProxy extends AbstractMacroProcessorProxy<Inlin
     @JRubyMethod(name = "process", required = 3)
     public IRubyObject process(ThreadContext context, IRubyObject parent, IRubyObject target, IRubyObject attributes) {
         Object o = getProcessor().process(
-                (AbstractBlock) NodeConverter.createASTNode(parent),
+                (StructuralNode) NodeConverter.createASTNode(parent),
                 RubyUtils.rubyToJava(getRuntime(), target, String.class),
                 RubyUtils.rubyToJava(getRuntime(), attributes, Map.class));
         return convertProcessorResult(o);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.extension.processorproxies;
 
-import org.asciidoctor.ast.AbstractNodeImpl;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.extension.Preprocessor;
@@ -8,7 +7,6 @@ import org.asciidoctor.extension.PreprocessorReader;
 import org.asciidoctor.extension.PreprocessorReaderImpl;
 import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.asciidoctor.internal.RubyHashUtil;
-import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -5,7 +5,7 @@ import org.asciidoctor.Attributes;
 import org.asciidoctor.DirectoryWalker;
 import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.ContentPart;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentHeader;
@@ -141,7 +141,7 @@ public class JRubyAsciidoctor implements Asciidoctor {
         return StructuredDocument.createStructuredDocument(toDocumentHeader(documentImpl), contentParts);
     }
 
-    private List<ContentPart> getContents(List<AbstractBlock> blocks, int level, int maxDeepLevel) {
+    private List<ContentPart> getContents(List<StructuralNode> blocks, int level, int maxDeepLevel) {
         // finish getting childs if max structure level was riched
         if (level > maxDeepLevel) {
             return null;
@@ -155,13 +155,13 @@ public class JRubyAsciidoctor implements Asciidoctor {
          */
         // add next level of contentParts
         List<ContentPart> parts = new ArrayList<ContentPart>();
-        for (AbstractBlock block : blocks) {
+        for (StructuralNode block : blocks) {
             parts.add(getContentPartFromBlock(block, level, maxDeepLevel));
         }
         return parts;
     }
 
-    private ContentPart getContentPartFromBlock(AbstractBlock child, int level, int maxDeepLevel) {
+    private ContentPart getContentPartFromBlock(StructuralNode child, int level, int maxDeepLevel) {
         Object content = child.content();
         String textContent;
         if (content instanceof String) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyRuntimeContext.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyRuntimeContext.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.internal;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.ast.AbstractNode;
-import org.asciidoctor.ast.AbstractNodeImpl;
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.impl.ContentNodeImpl;
 import org.jruby.Ruby;
 import org.jruby.java.proxies.RubyObjectHolderProxy;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -27,13 +27,13 @@ public class JRubyRuntimeContext {
         return ((JRubyAsciidoctor) asciidoctor).getRubyRuntime();
     }
 
-    public static Ruby get(AbstractNode node) {
+    public static Ruby get(ContentNode node) {
         if (node instanceof IRubyObject) {
             return ((IRubyObject) node).getRuntime();
         } else if (node instanceof RubyObjectHolderProxy) {
             return ((RubyObjectHolderProxy) node).__ruby_object().getRuntime();
-        } else if (node instanceof AbstractNodeImpl) {
-            IRubyObject nodeDelegate = ((AbstractNodeImpl) node).getRubyObject();
+        } else if (node instanceof ContentNodeImpl) {
+            IRubyObject nodeDelegate = ((ContentNodeImpl) node).getRubyObject();
             return nodeDelegate.getRuntime();
         } else {
             throw new IllegalArgumentException("Don't know what to with a " + node);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyBlockListDecorator.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyBlockListDecorator.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.internal;
 
-import org.asciidoctor.ast.AbstractNode;
-import org.asciidoctor.ast.AbstractNodeImpl;
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.impl.ContentNodeImpl;
 import org.asciidoctor.ast.NodeConverter;
 import org.jruby.RubyArray;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -9,13 +9,9 @@ import org.jruby.runtime.builtin.IRubyObject;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
 
 
-
-public class RubyBlockListDecorator<T extends AbstractNode> extends AbstractList<T> {
+public class RubyBlockListDecorator<T extends ContentNode> extends AbstractList<T> {
 
     private final RubyArray rubyBlockList;
 
@@ -30,15 +26,15 @@ public class RubyBlockListDecorator<T extends AbstractNode> extends AbstractList
 
     @Override
     public boolean contains(Object o) {
-        if (!(o instanceof AbstractNodeImpl)) {
+        if (!(o instanceof ContentNodeImpl)) {
             return false;
         }
-        return rubyBlockList.contains(((AbstractNodeImpl) o).getRubyObject());
+        return rubyBlockList.contains(((ContentNodeImpl) o).getRubyObject());
     }
 
     @Override
     public boolean add(T abstractBlock) {
-        return rubyBlockList.add(((AbstractNodeImpl) abstractBlock).getRubyObject());
+        return rubyBlockList.add(((ContentNodeImpl) abstractBlock).getRubyObject());
     }
 
     @Override
@@ -46,17 +42,17 @@ public class RubyBlockListDecorator<T extends AbstractNode> extends AbstractList
         if (o instanceof IRubyObject) {
             return rubyBlockList.remove(o);
         }
-        if (!(o instanceof AbstractNodeImpl)) {
+        if (!(o instanceof ContentNodeImpl)) {
             return false;
         }
-        return rubyBlockList.remove(((AbstractNodeImpl) o).getRubyObject());
+        return rubyBlockList.remove(((ContentNodeImpl) o).getRubyObject());
     }
 
     private Collection<Object> getDelegateCollection(Collection<?> c) {
         Collection<Object> delegateList = new ArrayList<Object>(c.size());
         for (Object o: c) {
-            if (o instanceof AbstractNodeImpl) {
-                delegateList.add(((AbstractNodeImpl) o).getRubyObject());
+            if (o instanceof ContentNodeImpl) {
+                delegateList.add(((ContentNodeImpl) o).getRubyObject());
             } else {
                 delegateList.add(o);
             }
@@ -94,7 +90,7 @@ public class RubyBlockListDecorator<T extends AbstractNode> extends AbstractList
         if (element instanceof IRubyObject) {
             oldObject = rubyBlockList.set(index, element);
         } else {
-            oldObject = rubyBlockList.set(index, ((AbstractNodeImpl) element).getRubyObject());
+            oldObject = rubyBlockList.set(index, ((ContentNodeImpl) element).getRubyObject());
         }
         return (T) NodeConverter.createASTNode(oldObject);
     }
@@ -104,7 +100,7 @@ public class RubyBlockListDecorator<T extends AbstractNode> extends AbstractList
         if (element instanceof IRubyObject) {
             rubyBlockList.set(index, element);
         } else {
-            rubyBlockList.add(index, ((AbstractNodeImpl) element).getRubyObject());
+            rubyBlockList.add(index, ((ContentNodeImpl) element).getRubyObject());
         }
     }
 
@@ -122,8 +118,8 @@ public class RubyBlockListDecorator<T extends AbstractNode> extends AbstractList
     public int indexOf(Object o) {
         if (o instanceof IRubyObject) {
             return rubyBlockList.indexOf(o);
-        } else if (o instanceof AbstractNodeImpl) {
-            return rubyBlockList.indexOf(((AbstractNodeImpl) o).getRubyObject());
+        } else if (o instanceof ContentNodeImpl) {
+            return rubyBlockList.indexOf(((ContentNodeImpl) o).getRubyObject());
         } else {
             return -1;
         }
@@ -133,8 +129,8 @@ public class RubyBlockListDecorator<T extends AbstractNode> extends AbstractList
     public int lastIndexOf(Object o) {
         if (o instanceof IRubyObject) {
             return rubyBlockList.lastIndexOf(o);
-        } else if (o instanceof AbstractNodeImpl) {
-            return rubyBlockList.lastIndexOf(((AbstractNodeImpl) o).getRubyObject());
+        } else if (o instanceof ContentNodeImpl) {
+            return rubyBlockList.lastIndexOf(((ContentNodeImpl) o).getRubyObject());
         } else {
             return -1;
         }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/ObjectConverter.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/ObjectConverter.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.converter
 
 import groovy.transform.CompileStatic
-import org.asciidoctor.ast.AbstractNode
+import org.asciidoctor.ast.ContentNode
 
 @CompileStatic
 @ConverterFor(format = '42')
@@ -14,7 +14,7 @@ class ObjectConverter extends AbstractConverter<ObjectConverterResult> implement
     }
 
     @Override
-    ObjectConverterResult convert(AbstractNode node, String transform, Map<Object, Object> opts) {
+    ObjectConverterResult convert(ContentNode node, String transform, Map<Object, Object> opts) {
         new ObjectConverterResult(x: FIXED_RESULT)
     }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableTestConverter.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableTestConverter.groovy
@@ -1,6 +1,6 @@
 package org.asciidoctor.converter
 
-import org.asciidoctor.ast.AbstractNode
+import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.Cell
 import org.asciidoctor.ast.Document
 import org.asciidoctor.ast.Section
@@ -18,7 +18,7 @@ class TableTestConverter extends StringConverter {
     }
 
     @Override
-    String convert(AbstractNode node, String transform, Map<Object, Object> opts) {
+    String convert(ContentNode node, String transform, Map<Object, Object> opts) {
         if (transform == null) {
             transform = node.nodeName
         }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockMacroProcessor.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 
 @CompileStatic
 @Name('testmacro')
@@ -10,7 +10,7 @@ class AnnotatedBlockMacroProcessor extends BlockMacroProcessor {
     public static final String RESULT = 'This content is added by this macro!'
 
     @Override
-    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
         createBlock(parent, 'paragraph', RESULT)
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockProcessor.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 
 @CompileStatic
 @Name('yell')
@@ -21,7 +21,7 @@ class AnnotatedBlockProcessor extends BlockProcessor {
     }
 
     @Override
-    Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
         assert attributes['key'] == 'value'
         List<String> lines = reader.readLines()
         List<String> newLines = lines*.toUpperCase()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 
 @CompileStatic
 @Name('man')
@@ -13,13 +13,13 @@ class AnnotatedLongInlineMacroProcessor extends InlineMacroProcessor {
     public static final String SECTION = 'section'
 
     @Override
-    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
 
         assert attributes[SECTION] == '7' || ( attributes[SECTION] == '8' || attributes[SUBSECTION] == '1')
 
         Map<String, Object> options = new HashMap<String, Object>()
         options['type'] = ':link'
         options['target'] = "${target}.html"
-        createInline(parent, 'anchor', target, attributes, options).convert()
+        createPhraseNode(parent, 'anchor', target, attributes, options).convert()
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 
 @CompileStatic
 @Name('man')
@@ -13,10 +13,10 @@ class AnnotatedRegexpInlineMacroProcessor extends InlineMacroProcessor {
     }
 
     @Override
-    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
         Map<String, Object> options = new HashMap<String, Object>()
         options['type'] = ':link'
         options['target'] = "${target}.html"
-        createInline(parent, 'anchor', target, attributes, options).convert()
+        createPhraseNode(parent, 'anchor', target, attributes, options).convert()
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/ConfigModifyingBlockProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/ConfigModifyingBlockProcessor.groovy
@@ -1,6 +1,6 @@
 package org.asciidoctor.extension
 
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 
 class ConfigModifyingBlockProcessor extends BlockProcessor {
 
@@ -18,7 +18,7 @@ class ConfigModifyingBlockProcessor extends BlockProcessor {
     }
 
     @Override
-    Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
         setConfig([:])
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import groovy.json.JsonSlurper
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.ast.Cell
 import org.asciidoctor.ast.Column
 import org.asciidoctor.ast.Document
@@ -18,7 +18,7 @@ class GithubContributorsBlockMacro extends BlockMacroProcessor {
     }
 
     @Override
-    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
         URL url = new URL("http://api.github.com/repos/${target}/contributors")
         URLConnection connection = url.openConnection(new Proxy(Proxy.Type.HTTP, new InetSocketAddress('localhost', TestHttpServer.instance.localPort)))
         String content = connection.inputStream.text

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/SectionCreatorBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/SectionCreatorBlockMacro.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
-import org.asciidoctor.ast.AbstractBlock
 import org.asciidoctor.ast.Section
+import org.asciidoctor.ast.StructuralNode
 
 @Name('section')
 class SectionCreatorBlockMacro extends BlockMacroProcessor {
@@ -9,7 +9,7 @@ class SectionCreatorBlockMacro extends BlockMacroProcessor {
     public static final String CONTENT = 'This is just some text'
 
     @Override
-    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
         Section section = createSection(parent)
         section.title = target
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnExtensionAppendsChildBlocks.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnExtensionAppendsChildBlocks.groovy
@@ -2,7 +2,7 @@ package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
 import org.asciidoctor.OptionsBuilder
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.ast.Block
 import org.asciidoctor.ast.Document
 import org.asciidoctor.ast.Section
@@ -123,7 +123,7 @@ testmacro::target[]
 
         asciidoctor.javaExtensionRegistry().blockMacro(new BlockMacroProcessor('testmacro'){
             @Override
-            Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+            Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
                 createBlock(parent, 'paragraph', expectedContent, [:])
             }
         })

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAstIsIterated.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAstIsIterated.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.ast.Document
 import spock.lang.Specification
 
@@ -31,7 +31,7 @@ A list with items
     def "getDocument should always return the same instance"() {
         when:
         Document document = asciidoctor.load(DOCUMENT, [:])
-        List<AbstractBlock>  allBlocks = document.findBy([:])
+        List<StructuralNode>  allBlocks = document.findBy([:])
 
         then:
         document.is(document.getDocument())

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.asciidoctor.arquillian.api.Unshared;
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Section;
 import org.asciidoctor.internal.IOUtils;
@@ -96,7 +96,7 @@ public class WhenAsciiDocIsRenderedToDocument {
         Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
         Map<Object, Object> selector = new HashMap<Object, Object>();
         selector.put("context", ":image");
-        List<AbstractBlock> findBy = document.findBy(selector);
+        List<StructuralNode> findBy = document.findBy(selector);
         assertThat(findBy, hasSize(2));
         
         assertThat((String)findBy.get(0).getAttributes().get("target"), is("tiger.png"));
@@ -146,7 +146,7 @@ public class WhenAsciiDocIsRenderedToDocument {
     @Test
     public void should_be_able_to_get_roles() {
         Document document = asciidoctor.load(ROLE, new HashMap<String, Object>());
-        AbstractBlock abstractBlock = document.blocks().get(0);
+        StructuralNode abstractBlock = document.blocks().get(0);
         assertThat(abstractBlock.getRole(), is("famous"));
         assertThat(abstractBlock.hasRole("famous"), is(true));
         assertThat(abstractBlock.isRole(), is(true));
@@ -156,7 +156,7 @@ public class WhenAsciiDocIsRenderedToDocument {
     @Test
     public void should_be_able_to_get_reftext() {
         Document document = asciidoctor.load(REFTEXT, new HashMap<String, Object>());
-        AbstractBlock abstractBlock = document.blocks().get(0);
+        StructuralNode abstractBlock = document.blocks().get(0);
         assertThat(abstractBlock.getReftext(), is("the first section"));
         assertThat(abstractBlock.isReftext(), is(true));
     }
@@ -241,17 +241,17 @@ public class WhenAsciiDocIsRenderedToDocument {
         Document document = asciidoctor.loadFile(file, OptionsBuilder.options().option("sourcemap", "true").docType("book").asMap());
         Map<Object, Object> selector = new HashMap<Object, Object>();
         selector.put("context", ":paragraph");
-        List<AbstractBlock> findBy = document.findBy(selector);
-        AbstractBlock block = findBy.get(0);
+        List<StructuralNode> findBy = document.findBy(selector);
+        StructuralNode block = findBy.get(0);
 
         // Then
-        AbstractBlock block1 = findBy.get(0);
+        StructuralNode block1 = findBy.get(0);
         assertThat(block1.getSourceLocation().getLineNumber(), is(3));
         assertThat(block1.getSourceLocation().getPath(), is(file.getName()));
         assertThat(block1.getSourceLocation().getFile(), is(file.getName()));
         assertThat(block1.getSourceLocation().getDir(), is(file.getParent().replaceAll("\\\\", "/")));
 
-        AbstractBlock block2 = findBy.get(1);
+        StructuralNode block2 = findBy.get(1);
         assertThat(block2.getSourceLocation().getLineNumber(), is(8));
         assertThat(block2.getSourceLocation().getPath(), is(file.getName()));
         assertThat(block2.getSourceLocation().getFile(), is(file.getName()));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenTwoAsciidoctorInstancesAreCreated.groovy
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenTwoAsciidoctorInstancesAreCreated.groovy
@@ -1,6 +1,6 @@
 package org.asciidoctor
 
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.extension.BlockMacroProcessor
 import spock.lang.Specification
 
@@ -36,7 +36,7 @@ testmacro::Test[]
         }
 
         @Override
-        Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+        Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
             createBlock(parent, PARAGRAPH, TEST_STRING)
         }
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/DummyConverter.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/DummyConverter.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.converter;
 
-import org.asciidoctor.ast.AbstractNode;
+import org.asciidoctor.ast.ContentNode;
 
 import java.util.Map;
 
@@ -11,7 +11,7 @@ public class DummyConverter extends StringConverter {
     }
     
     @Override
-    public String convert(AbstractNode node, String transform, Map<Object, Object> o) {
+    public String convert(ContentNode node, String transform, Map<Object, Object> o) {
         return "Dummy";
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.converter;
 
-import org.asciidoctor.ast.AbstractBlock;
-import org.asciidoctor.ast.AbstractNode;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.ListItem;
-import org.asciidoctor.ast.ListNode;
+import org.asciidoctor.ast.List;
 import org.asciidoctor.ast.Section;
 
 import java.util.Map;
@@ -21,7 +21,7 @@ public class TextConverter extends StringConverter {
     }
     
     @Override
-    public String convert(AbstractNode node, String transform, Map<Object, Object> o) {
+    public String convert(ContentNode node, String transform, Map<Object, Object> o) {
 
         if (transform == null) {
             transform = node.getNodeName();
@@ -37,19 +37,19 @@ public class TextConverter extends StringConverter {
                     .append(LINE_SEPARATOR).append(LINE_SEPARATOR)
                     .append(section.getContent()).toString();
         } else if (transform.equals("paragraph")) {
-            AbstractBlock block = (AbstractBlock) node;
+            StructuralNode block = (StructuralNode) node;
             String content = (String) block.content();
             return new StringBuilder(content.replaceAll(LINE_SEPARATOR, " ")).append(LINE_SEPARATOR).toString();
-        } else if (node instanceof ListNode) {
+        } else if (node instanceof List) {
             StringBuilder sb = new StringBuilder();
-            for (AbstractBlock listItem: ((ListNode) node).getItems()) {
+            for (StructuralNode listItem: ((List) node).getItems()) {
                 sb.append(listItem.convert()).append(LINE_SEPARATOR);
             }
             return sb.toString();
         } else if (node instanceof ListItem) {
             return "-> " + ((ListItem) node).getText();
-        } else if (node instanceof AbstractBlock) {
-            AbstractBlock block = (AbstractBlock) node;
+        } else if (node instanceof StructuralNode) {
+            StructuralNode block = (StructuralNode) node;
             return block.getContent().toString();
         }
         return null;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ArrowsAndBoxesBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ArrowsAndBoxesBlock.java
@@ -3,7 +3,7 @@ package org.asciidoctor.extension;
 import java.util.List;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.Document;
 
 public class ArrowsAndBoxesBlock extends BlockProcessor {
@@ -19,7 +19,7 @@ public class ArrowsAndBoxesBlock extends BlockProcessor {
     }
 
     @Override
-    public Object process(AbstractBlock parent, Reader reader,
+    public Object process(StructuralNode parent, Reader reader,
             Map<String, Object> attributes) {
 
         List<String> lines = reader.lines();

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/GistMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/GistMacro.java
@@ -3,7 +3,7 @@ package org.asciidoctor.extension;
 import java.util.Arrays;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.Block;
 
 public class GistMacro extends BlockMacroProcessor {
@@ -17,7 +17,7 @@ public class GistMacro extends BlockMacroProcessor {
     }
     
     @Override
-    public Block process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    public Block process(StructuralNode parent, String target, Map<String, Object> attributes) {
        
        String content = "<div class=\"content\">\n" + 
        		"<script src=\"https://gist.github.com/"+target+".js\"></script>\n" + 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,12 +16,12 @@ public class ManpageMacro extends InlineMacroProcessor {
     }
 
     @Override
-    public String process(AbstractBlock parent, String target,
+    public String process(StructuralNode parent, String target,
             Map<String, Object> attributes) {
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("type", ":link");
         options.put("target", target + ".html");
-        return createInline(parent, "anchor", target, attributes, options).convert();
+        return createPhraseNode(parent, "anchor", target, attributes, options).convert();
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.Document;
 
@@ -22,17 +22,17 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {
     @Override
     public Document process(Document document) {
         this.document = document;
-        processBlock((AbstractBlock) this.document);
+        processBlock((StructuralNode) this.document);
         return this.document;
     }
 
-    private void processBlock(AbstractBlock block) {
+    private void processBlock(StructuralNode block) {
 
-        List<AbstractBlock> blocks = block.getBlocks();
+        List<StructuralNode> blocks = block.getBlocks();
 
         for (int i = 0; i < blocks.size(); i++) {
-            final AbstractBlock currentBlock = blocks.get(i);
-            if(currentBlock instanceof AbstractBlock) {
+            final StructuralNode currentBlock = blocks.get(i);
+            if(currentBlock instanceof StructuralNode) {
                 if ("paragraph".equals(currentBlock.getContext())) {
                     List<String> lines = ((Block) currentBlock).lines();
                     if (lines.size() > 0 && lines.get(0).startsWith("$")) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellBlock.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 
 public class YellBlock extends BlockProcessor {
 
@@ -14,7 +14,7 @@ public class YellBlock extends BlockProcessor {
     }
 
     @Override
-    public Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+    public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
         List<String> lines = reader.readLines();
         String upperLines = null;
         for (String line : lines) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticBlock.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 
 public class YellStaticBlock extends BlockProcessor {
 
@@ -23,7 +23,7 @@ public class YellStaticBlock extends BlockProcessor {
     }
 
     @Override
-    public Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+    public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
         List<String> lines = reader.readLines();
         String upperLines = null;
         for (String line : lines) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticListingBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticListingBlock.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.StructuralNode;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -23,7 +23,7 @@ public class YellStaticListingBlock extends BlockProcessor {
     }
 
     @Override
-    public Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+    public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
         List<String> lines = reader.readLines();
         String upperLines = null;
         for (String line : lines) {


### PR DESCRIPTION
Implements the renaming of the AST classes as discussed at http://discuss.asciidoctor.org/dev-Reorganization-of-the-AsciidoctorJ-AST-data-structures-td2991.html#a3606

That is the new AST hierarchy is:

```
FlowNode
 +- StructuralNode
 | +- Block
 | +- Section
 | +- Document
 | +- List
 | +- ListItem
 | +- Table
 +- PhrasingNode
```

Also moved all implementations to the package `org.asciidoctor.ast.impl` to reduce the size of the last package.