### PR TITLE
Fixes #368: Bundles rouge 1.9.1 with asciidoctorj-pdf excluding the d…

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     exclude module: 'prawn'
   }
   gems "rubygems:prawn:$prawnGemVersion"
+  gems "rubygems:rouge:$rougeGemVersion"
 }
 
 def gemFiles = fileTree(jruby.gemInstallDir) {
@@ -25,6 +26,8 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   include "gems/prawn-icon-*/fonts/*/*"
   // Include required data file from the addressable gem
   include "gems/addressable-*/data/*.data"
+
+  exclude 'gems/rouge-*/lib/rouge/demos/**'
 }
 
 jrubyPrepareGems << {

--- a/asciidoctorj-pdf/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
+++ b/asciidoctorj-pdf/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
@@ -24,7 +24,7 @@ public class WhenBackendIsPdf {
         File inputFile = classpath.getResource("sample.adoc");
         File outputFile1 = new File(inputFile.getParentFile(), "sample.pdf");
         File outputFile2 = new File(inputFile.getParentFile(), "sample.pdfmarks");
-        asciidoctor.convertFile(inputFile, options().backend("pdf").get());
+        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).get());
         assertThat(outputFile1.exists(), is(true));
         assertThat(outputFile2.exists(), is(true));
         outputFile1.delete();

--- a/asciidoctorj-pdf/src/test/resources/sample.adoc
+++ b/asciidoctorj-pdf/src/test/resources/sample.adoc
@@ -1,9 +1,15 @@
 = Document Title
-:source-highlighter: coderay
+:source-highlighter: rouge
+
+== Section
 
 Content.
 
 [source,java]
 ----
-puts "Hello, World!"
+public class Test {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}
 ----

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ subprojects {
     hamlGemVersion = '4.0.5'
     openUriCachedGemVersion = '0.0.5'
     prawnGemVersion = '1.3.0'
+    rougeGemVersion = '1.9.1'
     slimGemVersion = '2.0.3'
     threadSafeGemVersion = '0.3.4'
     tiltGemVersion = '2.0.1'


### PR DESCRIPTION
…emo files.

Works in general.
Seeing two warnings though from the shell lexer:
```
/Users/robertpanzer/dev/asciidoctorj/asciidoctorj-pdf/build/resources/main/gems/rouge-1.9.1/lib/rouge/lexers/shell.rb:20 warning: already initialized constant KEYWORDS
/Users/robertpanzer/dev/asciidoctorj/asciidoctorj-pdf/build/resources/main/gems/rouge-1.9.1/lib/rouge/lexers/shell.rb:25 warning: already initialized constant BUILTINS
```