### PR TITLE
convince Asciidoctor PDF to use the thread_safe provided by AsciidoctorJ

### DIFF
--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -3,9 +3,7 @@ dependencies {
   gems("rubygems:asciidoctor-pdf:$asciidoctorPdfGemVersion") {
     // Exclude gems provided by AsciidoctorJ core
     exclude module: 'asciidoctor'
-    //Include thread_safe again (0.3.5) because AsciidoctorJ core delivers 0.3.4,
-    // which is incompatible since asciidoctor-pdf 1.5.0.alpha.9
-    //exclude module: 'thread_safe'
+    exclude module: 'thread_safe'
     // We must lock Prawn to 1.3.0 until AsciidoctorJ upgrades to JRuby 9.0.0.0
     exclude module: 'prawn'
   }
@@ -31,10 +29,10 @@ jrubyPrepareGems << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     eachFile {
-      if (it.path == 'gems/asciidoctor-pdf-1.5.0.alpha.8/lib/asciidoctor-pdf/prawn_ext/formatted_text/fragment.rb' ||
-          it.path == 'gems/asciidoctor-pdf-1.5.0.alpha.8/lib/asciidoctor-pdf/formatted_text/inline_image_arranger.rb') {
+      // convince Asciidoctor PDF to use the thread_safe 0.3.4 provided by AsciidoctorJ
+      if (it.path == 'specifications/asciidoctor-pdf-1.5.0.alpha.9.gemspec') {
         it.filter { line ->
-          line.replaceAll(/^( *)if ::RUBY_MIN_VERSION_2$/, "\$1if respond_to? :prepend")
+          line.replaceAll(/<thread_safe>, \["= 0.3.5"\]/, '<thread_safe>, ["= 0.3.4"]')
         }
       }
     }


### PR DESCRIPTION
- downgrade the thread_safe version to 0.3.4
- remove out of date hacks for Asciidoctor PDF 1.5.0.alpha.8