### PR TITLE
Upgrade jruby-gradle plugin to 1.0.2

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -26,7 +26,7 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   include "gems/asciidoctor-${asciidoctorGemVersion}/data/**"
 }
 
-jrubyPrepareGems << {
+jrubyPrepare << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     into sourceSets.main.output.resourcesDir

--- a/asciidoctorj-diagram/build.gradle
+++ b/asciidoctorj-diagram/build.gradle
@@ -16,7 +16,7 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   include "gems/asciidoctor-diagram-${asciidoctorDiagramGemVersion}/data/**"
 }
 
-jrubyPrepareGems << {
+jrubyPrepare << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     into sourceSets.main.output.resourcesDir

--- a/asciidoctorj-epub3/build.gradle
+++ b/asciidoctorj-epub3/build.gradle
@@ -14,7 +14,7 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   include 'gems/*/data/**'
 }
 
-jrubyPrepareGems << {
+jrubyPrepare << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     into sourceSets.main.output.resourcesDir

--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -33,7 +33,7 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   exclude 'gems/rouge-*/lib/rouge/demos/**'
 }
 
-jrubyPrepareGems << {
+jrubyPrepare << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     eachFile {

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,12 @@ buildscript {
       classpath 'com.netflix.nebula:nebula-publishing-plugin:2.2.2'
     }
     classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1'
+    classpath 'com.github.jruby-gradle:jruby-gradle-plugin:1.0.2'
   }
 }
 
 // modern plugins config
 plugins {
-  id 'com.github.jruby-gradle.base' version '0.1.17'
   // Adding the nebula-publishing plugin when using JDK6 causes the build to abort
   //id 'nebula.nebula-publishing' version '2.0.0'
   id 'com.jfrog.bintray' version '1.0'
@@ -170,7 +170,7 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
 
   // QUESTION is this the right place to insert this task dependency in the lifecycle?
   // IMPORTANT The TMP or TEMP environment variable must be set for the gem install command to work on Windows
-  processResources.dependsOn jrubyPrepareGems
+  processResources.dependsOn jrubyPrepare
 
   apply from: rootProject.file('gradle/eclipse.gradle')
   if (JavaVersion.current().isJava7Compatible()) {

--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'eclipse'
 
-tasks.eclipse.dependsOn jrubyPrepareGems
+tasks.eclipse.dependsOn jrubyPrepare
 eclipse {
   classpath {
     defaultOutputDir = file('build/eclipse')


### PR DESCRIPTION
This PR fixes #375 

As the jruby-gradle base plugin has not been upgraded on the Gradle Plugin Portal the plugin is now pulled again from the buildscript section.

Additionally the jruby-gradle-plugin is compiled to the Java 7 class file format, so the build will no longer run with Java 6.
(AsciidoctorJ should still run on Java6, though we won't be able to verify it.)
