### PR TITLE
Fixes #383: Change return type of Preprocessor.process() to void

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -886,9 +886,8 @@ public class ChangeAttributeValuePreprocessor extends Preprocessor { // <1>
 	}
 
 	@Override
-	public PreprocessorReader process(Document document, PreprocessorReader reader) { // <3>
+	public void process(Document document, PreprocessorReader reader) { // <3>
 		document.getAttributes().put("content", "Alex");
-		return reader;
 	}
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Preprocessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Preprocessor.java
@@ -15,6 +15,6 @@ public abstract class Preprocessor extends Processor {
         super(config);
     }
 
-    public abstract PreprocessorReader process(Document document, PreprocessorReader reader);
+    public abstract void process(Document document, PreprocessorReader reader);
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/PreprocessorProxy.java
@@ -94,14 +94,10 @@ public class PreprocessorProxy extends AbstractProcessorProxy<Preprocessor> {
 
     @JRubyMethod(name = "process", required = 2)
     public IRubyObject process(ThreadContext context, IRubyObject document, IRubyObject preprocessorReader) {
-        PreprocessorReader result = getProcessor().process(
+        getProcessor().process(
                 (Document) NodeConverter.createASTNode(document),
                 new PreprocessorReaderImpl(preprocessorReader));
 
-        if (result instanceof PreprocessorReaderImpl) {
-            return ((PreprocessorReaderImpl) result).getRubyObject();
-        } else {
-            return JavaEmbedUtils.javaToRuby(getRuntime(), result);
-        }
+        return getRuntime().getNil();
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
@@ -32,7 +32,7 @@ $secondLine"""
 
         asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
             @Override
-            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+            void process(Document doc, PreprocessorReader reader) {
                 preprocessorCalled.set(true)
 
                 assert reader.peekLine() == firstLine
@@ -63,7 +63,7 @@ $secondLine"""
 
         asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
             @Override
-            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+            void process(Document doc, PreprocessorReader reader) {
                 preprocessorCalled.set(true)
 
                 assert reader.peekLines(ONE) == [firstLine]
@@ -95,7 +95,7 @@ $secondLine"""
 
         asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
             @Override
-            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+            void process(Document doc, PreprocessorReader reader) {
                 preprocessorCalled.set(true)
 
                 assert reader.readLine() == firstLine
@@ -120,7 +120,7 @@ $secondLine"""
 
         asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
             @Override
-            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+            void process(Document doc, PreprocessorReader reader) {
                 preprocessorCalled.set(true)
 
                 assert reader.peekLine() == firstLine
@@ -151,7 +151,7 @@ $secondLine"""
 
         asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
             @Override
-            PreprocessorReader process(Document doc, PreprocessorReader reader) {
+            void process(Document doc, PreprocessorReader reader) {
                 preprocessorCalled.set(true)
 
                 assert reader.peekLine() == firstLine

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ChangeAttributeValuePreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ChangeAttributeValuePreprocessor.java
@@ -11,12 +11,10 @@ public class ChangeAttributeValuePreprocessor extends Preprocessor {
 	}
 
 	@Override
-	public PreprocessorReader process(Document document,
+	public void process(Document document,
 			PreprocessorReader reader) {
 
 		document.getAttributes().put("content", "Alex");
-		
-		return reader;
 	}
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/HasMoreLinesPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/HasMoreLinesPreprocessor.java
@@ -14,12 +14,10 @@ public class HasMoreLinesPreprocessor extends Preprocessor {
 	}
 
 	@Override
-	public PreprocessorReader process(Document document,
+	public void process(Document document,
 			PreprocessorReader reader) {
 
 		assertThat(reader.hasMoreLines(), is(true));
-
-		return reader;
 	}
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NextLineEmptyPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NextLineEmptyPreprocessor.java
@@ -14,7 +14,7 @@ public class NextLineEmptyPreprocessor extends Preprocessor {
 	}
 
 	@Override
-	public PreprocessorReader process(Document document,
+	public void process(Document document,
 			PreprocessorReader reader) {
 
 		assertThat(reader.isNextLineEmpty(), is(false));
@@ -22,8 +22,6 @@ public class NextLineEmptyPreprocessor extends Preprocessor {
 		reader.advance();
 		
 		assertThat(reader.isNextLineEmpty(), is(true));
-		
-		return reader;
 	}
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NumberLinesPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NumberLinesPreprocessor.java
@@ -12,12 +12,11 @@ public class NumberLinesPreprocessor extends Preprocessor {
 	public NumberLinesPreprocessor() {}
 
 	@Override
-	public PreprocessorReader process(Document document,
+	public void process(Document document,
 			PreprocessorReader reader) {
 
 		assertThat(reader.getLineno(), is(1));
 
-		return reader;
 	}
 
 }


### PR DESCRIPTION
As discussed in #383 it doesn't make much sense at the moment to let `Preprocessor.process()` return anything useful as both `null` and the given `PreprocessorReader` have the same result. 
And with AsciidoctorJ it is atm impossible to create own Readers and it is generally not trivial to create them facing the state that they hold.

Therefore this PR changes the return type of `Preprocessor.process()` to `void`.

!!! This makes existing Preprocessors incompatible and requires a change when upgrading to 1.6.0!