### PR TITLE
Update asciidoctor diagram from version 1.3.0.preview.1 to 1.3.0

### DIFF
--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,3 +1,3 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=1.3.0.preview.1
+version=1.3.0


### PR DESCRIPTION
As there is a new release of asciidoctor-diagram, let's use this version instead of the previous preview one.