### PR TITLE
Changed dependency on JRuby to 9.0.3.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
-  - openjdk6
 before_script: unset GEM_PATH GEM_HOME JRUBY_OPTS
 install: ./gradlew assemble
 script: ./gradlew -S check && bash test-asciidoctor-upstream.sh

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'osgi'
 
 dependencies {
-  compile "org.jruby:jruby-complete:$jrubyVersion"
+  compile "org.jruby:jruby:$jrubyVersion"
   compile "com.beust:jcommander:$jcommanderVersion"
   gems "rubygems:asciidoctor:$asciidoctorGemVersion"
   gems "rubygems:coderay:$coderayGemVersion"
@@ -26,7 +26,7 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   include "gems/asciidoctor-${asciidoctorGemVersion}/data/**"
 }
 
-jrubyPrepareGems << {
+jrubyPrepare << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     into sourceSets.main.output.resourcesDir

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenClassloaderIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenClassloaderIsRequired.java
@@ -3,6 +3,7 @@ package org.asciidoctor.internal;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import org.asciidoctor.Asciidoctor;
+import org.junit.Ignore;
 import org.junit.Test;
 
  class AsciiDoctorJClassloaderTestRunnable implements Runnable {
@@ -41,6 +42,7 @@ public class WhenClassloaderIsRequired {
         inside the runnable to verify we have created the same error as happens inside sbt.
      */
     @Test
+    @Ignore("Behavior changed in JRuby 9000. It no longer only uses the TCCL by default")
     public void contentsOfJRubyCompleteShouldFailToLoadWithoutPassingClassloader() throws Exception{
         ClassLoader currentclassloader =  this.getClass().getClassLoader();
         ClassLoader rootclassloader =  currentclassloader.getParent();

--- a/asciidoctorj-diagram/build.gradle
+++ b/asciidoctorj-diagram/build.gradle
@@ -16,7 +16,7 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   include "gems/asciidoctor-diagram-${asciidoctorDiagramGemVersion}/data/**"
 }
 
-jrubyPrepareGems << {
+jrubyPrepare << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     into sourceSets.main.output.resourcesDir

--- a/asciidoctorj-epub3/build.gradle
+++ b/asciidoctorj-epub3/build.gradle
@@ -14,7 +14,7 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   include 'gems/*/data/**'
 }
 
-jrubyPrepareGems << {
+jrubyPrepare << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     into sourceSets.main.output.resourcesDir

--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -33,7 +33,7 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
   exclude 'gems/rouge-*/lib/rouge/demos/**'
 }
 
-jrubyPrepareGems << {
+jrubyPrepare << {
   copy { // bundles the gems inside this artifact
     from gemFiles
     eachFile {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 // modern plugins config
 plugins {
-  id 'com.github.jruby-gradle.base' version '0.1.17'
+  id 'com.github.jruby-gradle.base' version '1.1.4'
   // Adding the nebula-publishing plugin when using JDK6 causes the build to abort
   //id 'nebula.nebula-publishing' version '2.0.0'
   id 'com.jfrog.bintray' version '1.0'
@@ -35,7 +35,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '1.7.20'
+  jrubyVersion = '9.0.3.0'
   jsoupVersion = '1.8.1'
   junitVersion = '4.12'
   nettyVersion = '4.0.28.Final'
@@ -77,7 +77,7 @@ subprojects {
 
   // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle
   // Must redefine here to work around a bug in the Eclipse plugin
-  sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_6
+  sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_7
 
   repositories {
     if (project.hasProperty('useMavenLocal') && project.useMavenLocal.toBoolean()) {
@@ -171,7 +171,7 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
 
   // QUESTION is this the right place to insert this task dependency in the lifecycle?
   // IMPORTANT The TMP or TEMP environment variable must be set for the gem install command to work on Windows
-  processResources.dependsOn jrubyPrepareGems
+  processResources.dependsOn jrubyPrepare
 
   apply from: rootProject.file('gradle/eclipse.gradle')
   if (JavaVersion.current().isJava7Compatible() && !it.name.endsWith('-documentation')) {

--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'eclipse'
 
-tasks.eclipse.dependsOn jrubyPrepareGems
+tasks.eclipse.dependsOn jrubyPrepare
 eclipse {
   classpath {
     defaultOutputDir = file('build/eclipse')


### PR DESCRIPTION
Bumped JRuby version to 9.0.3.0.
As JRuby only works with Java >= 7 I also bumped the source and target version of AsciidoctorJ to 1.7.

Additionally changed the dependency from `ruby-complete` to `jruby` which fixes #230.
With this the lib directory of the distribution looks like this:

```
asciidoctorj-1.6.0-SNAPSHOT.jar
asciidoctorj-epub3-1.5.0-alpha.4.jar
asciidoctorj-pdf-1.5.0-alpha.9.jar
bytelist-1.0.13.jar
dirgra-0.3.jar
high-scale-lib-1.0.6.jar
invokebinder-1.5.jar
jcodings-1.0.13.jar
jcommander-1.35.jar
jffi-1.2.9-native.jar
jffi-1.2.9.jar
jnr-constants-0.9.0.jar
jnr-enxio-0.9.jar
jnr-netdb-1.1.4.jar
jnr-posix-3.0.19.jar
jnr-unixsocket-0.8.jar
jnr-x86asm-1.0.2.jar
joda-time-2.8.2.jar
joni-2.1.8.jar
jruby-9.0.3.0.jar
jruby-core-9.0.3.0.jar
jruby-stdlib-9.0.3.0.jar
jzlib-1.1.3.jar
nailgun-server-0.9.1.jar
options-1.1.jar
```