### PR TITLE
Bump version of Asciidoctor to 1.5.3 and fixes #393.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ContentNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ContentNode.java
@@ -53,6 +53,11 @@ public interface ContentNode {
      */
     String role();
     List<String> getRoles();
+
+    void addRole(String role);
+
+    void removeRole(String role);
+
     boolean isReftext();
     String getReftext();
     String iconUri(String name);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ContentNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ContentNodeImpl.java
@@ -142,7 +142,17 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
 
     @Override
     public boolean hasRole(String role) {
-        return getBoolean("role?", role);
+        return getBoolean("has_role?", role);
+    }
+
+    @Override
+    public void addRole(String role) {
+        getRubyProperty("add_role", role);
+    }
+
+    @Override
+    public void removeRole(String role) {
+        getRubyProperty("remove_role", role);
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/LocationType.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/LocationType.java
@@ -5,7 +5,7 @@ package org.asciidoctor.extension;
  */
 public enum LocationType {
 
-    HEADER(":header"),
+    HEADER(":head"),
     FOOTER(":footer");
 
     private final String optionValue;

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
@@ -96,8 +96,7 @@ And even more infos on manpage:git[7].
         then:
         Document doc = Jsoup.parse(result, UTF8)
         Element footer = doc.getElementById(ELEMENTID_FOOTER)
-        // 1. test Asciidoctor 1.5.2, 2. test Asciidoctor 1.5.3.dev
-        !footer.getElementsByAttributeValueContaining(ATTR_KEY_NAME, ATTR_VALUE_ROBOTS).empty || footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
+        footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
     }
 
     def "a docinfoprocessor instance should be configurable via the Location annotation"() {
@@ -108,8 +107,7 @@ And even more infos on manpage:git[7].
         then:
         Document doc = Jsoup.parse(result, UTF8)
         Element footer = doc.getElementById(ELEMENTID_FOOTER)
-        // 1. test Asciidoctor 1.5.2, 2. test Asciidoctor 1.5.3.dev
-        !footer.getElementsByAttributeValueContaining(ATTR_KEY_NAME, ATTR_VALUE_ROBOTS).empty || footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
+        footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
     }
 
     @spock.lang.Ignore('Option for docinfo in header changed from :header to :head in AsciidoctorJ. Ignore as long as these tests have to run on both Asciidoctor 1.5.2 as well as 1.5.3.dev')
@@ -131,8 +129,7 @@ And even more infos on manpage:git[7].
         then:
         Document doc = Jsoup.parse(result, UTF8)
         Element footer = doc.getElementById(ELEMENTID_FOOTER)
-        // 1. test Asciidoctor 1.5.2, 2. test Asciidoctor 1.5.3.dev
-        !footer.getElementsByAttributeValueContaining(ATTR_KEY_NAME, ATTR_VALUE_ROBOTS).empty || footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
+        footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
     }
 
     def "when registering a BlockMacroProcessor class it should be configurable via annotations"() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -154,6 +154,26 @@ public class WhenAsciiDocIsRenderedToDocument {
     }
 
     @Test
+    public void should_be_able_to_add_role() {
+        final String tmpRole = "tmpRole";
+        Document document = asciidoctor.load(ROLE, new HashMap<String, Object>());
+        StructuralNode abstractBlock = document.blocks().get(0);
+        assertThat(abstractBlock.hasRole(tmpRole), is(false));
+        abstractBlock.addRole(tmpRole);
+        assertThat(abstractBlock.hasRole(tmpRole), is(true));
+    }
+
+    @Test
+    public void should_be_able_to_remove_role() {
+        final String famousRole = "famous";
+        Document document = asciidoctor.load(ROLE, new HashMap<String, Object>());
+        StructuralNode abstractBlock = document.blocks().get(0);
+        assertThat(abstractBlock.hasRole(famousRole), is(true));
+        abstractBlock.removeRole(famousRole);
+        assertThat(abstractBlock.hasRole(famousRole), is(false));
+    }
+
+    @Test
     public void should_be_able_to_get_reftext() {
         Document document = asciidoctor.load(REFTEXT, new HashMap<String, Object>());
         StructuralNode abstractBlock = document.blocks().get(0);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -1,7 +1,6 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.arquillian.api.Unshared;
@@ -220,9 +219,8 @@ public class WhenJavaExtensionIsRegistered {
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
         Element footer = doc.getElementById("footer");
-        Element metaRobots = footer.getElementsByAttributeValueContaining("name", "robots").first();
-        // 1.5.2 || 1.5.3.dev
-        assertTrue(metaRobots != null || "robots".equals(footer.nextElementSibling().attr("name")));
+        // Since Asciidoctor 1.5.3 the docinfo in the footer is a sibling to the footer element
+        assertTrue("robots".equals(footer.nextElementSibling().attr("name")));
     }
 
     @Test

--- a/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
+++ b/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
@@ -974,7 +974,7 @@ include::src/test/java/org/asciidoctor/integrationguide/extension/TerminalComman
     The context of the new block has to be `listing` to get a source block.
     The content can be simply taken from the original block.
     We add the option 'subs' with the value ':specialcharacters' so that special characters are substituted, i.e. `>` and `<` will be replaced with `\&gt;` and `\&lt;` respectively.
-<5> Finally we set the role of the node to `terminal`, which will result in the div containing the listing having the class `terminal`.
+<5> Finally we add the role of the node to `terminal`, which will result in the div containing the listing having the class `terminal`.
 
 After that we can simply use that Treeprocessor by registering it at the `JavaExtensionRegistry`.
 

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessor.java
@@ -52,7 +52,7 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {    // <1>
                 originalBlock.getAttributes(),
                 options);
 
-        block.setAttr("role", "terminal", true);                     // <5>
+        block.addRole("terminal");                                   // <5>
         return block;
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
   pdfboxVersion = '1.8.10'
 
   // gem versions
-  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.2'
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.3'
   asciidoctorEpub3GemVersion = project(':asciidoctorj-epub3').version.replace('-', '.')
   asciidoctorPdfGemVersion = project.hasProperty('asciidoctorPdfGemVersion') ? project.asciidoctorPdfGemVersion : project(':asciidoctorj-pdf').version.replace('-', '.')
   asciidoctorDiagramGemVersion = project(':asciidoctorj-diagram').version.replace('-', '.')

--- a/docs/integrator-guide.adoc
+++ b/docs/integrator-guide.adoc
@@ -1436,7 +1436,7 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {    // <1>
                 originalBlock.getAttributes(),
                 options);
 
-        block.setAttr("role", "terminal", true);                     // <5>
+        block.addRole("terminal");                                   // <5>
         return block;
     }
 }
@@ -1450,7 +1450,7 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {    // <1>
     The context of the new block has to be `listing` to get a source block.
     The content can be simply taken from the original block.
     We add the option 'subs' with the value ':specialcharacters' so that special characters are substituted, i.e. `>` and `<` will be replaced with `\&gt;` and `\&lt;` respectively.
-<5> Finally we set the role of the node to `terminal`, which will result in the div containing the listing having the class `terminal`.
+<5> Finally we add the role of the node to `terminal`, which will result in the div containing the listing having the class `terminal`.
 
 After that we can simply use that Treeprocessor by registering it at the `JavaExtensionRegistry`.
 
@@ -1515,10 +1515,10 @@ To make AsciidoctorJ use our processor it also has to be registered at the `Java
                         .toFile(false));
 
         org.jsoup.nodes.Document document = Jsoup.parse(result); // <4>
-        Element metaElement = document.head().children().last();
-        assertThat(metaElement.tagName(), is("meta"));
-        assertThat(metaElement.attr("name"), is("robots"));
-        assertThat(metaElement.attr("content"), is("index,follow"));
+        Elements metaElements = document.head().getElementsByAttributeValue("name", "robots");
+        assertThat(metaElements, hasSize(1));
+        assertThat(metaElements.get(0).attr("name"), is("robots"));
+        assertThat(metaElements.get(0).attr("content"), is("index,follow"));
 ----
 <1> The Docinfo Processor implementation is registered at the `JavaExtensionRegistry` of the Asciidoctor instance.
 <2> We render our document with header and footer instead of an embeddable document.


### PR DESCRIPTION
Also added new methods addRole() and removeRole() that became part of Asciidoctor 1.5.3.
Adapted to change of DocinfoProcessor option for adding Docinfo to the header (:header -> :head).

When this PR is merged I'd like to cut an Asciidoctor 1.6.0-alpha release.
Then we do not only make a difference internally to 1.5.2 but also by the numbers:
Asciidoctor 1.5.2 -> 1.5.3
JRuby 1.7.x -> 9.0.3.0
Java 6 -> 7 