### PR TITLE
Bump slim to 3.0.6

### DIFF
--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenSlimTemplatesAreUsed.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenSlimTemplatesAreUsed.java
@@ -1,0 +1,33 @@
+package org.asciidoctor;
+
+import org.asciidoctor.util.ClasspathResources;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class WhenSlimTemplatesAreUsed {
+
+    @Rule
+    public ClasspathResources classpath = new ClasspathResources();
+
+    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+    @Test
+    public void the_slim_paragraph_template_should_be_used_when_rendering_a_document_inline() throws Exception {
+
+        Options options = OptionsBuilder.options().templateDir(classpath.getResource("src/custom-backends/slim")).toFile(false).headerFooter(false).get();
+
+        String sourceDocument = "= Hello World\n" +
+                "\n" +
+                "This will be replaced by static content from the template";
+
+        String renderContent = asciidoctor.render(sourceDocument, options);
+
+        Element doc = Jsoup.parse(renderContent, "UTF-8");
+        Element paragraph = doc.select("p").first();
+        assertEquals("This is static content", paragraph.text());
+    }
+}

--- a/asciidoctorj-core/src/test/resources/src/custom-backends/slim/block_paragraph.html.slim
+++ b/asciidoctorj-core/src/test/resources/src/custom-backends/slim/block_paragraph.html.slim
@@ -1,0 +1,1 @@
+p This is static content

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
   openUriCachedGemVersion = '0.0.5'
   prawnGemVersion = '1.3.0'
   rougeGemVersion = '1.9.1'
-  slimGemVersion = '2.0.3'
+  slimGemVersion = '3.0.6'
   threadSafeGemVersion = '0.3.5'
   tiltGemVersion = '2.0.1'
   ttfunkGemVersion = '1.2.2'


### PR DESCRIPTION
We already went to slim 3.0.3 on the 1.6.0 branch.
This should upgrade the slim dependency to the most recent version 3.0.6 on the master branch to prepare a 1.5.3 release.