### PR TITLE
WIP: Fixes #404. Add AST types for definition lists.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DescriptionList.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DescriptionList.java
@@ -1,0 +1,14 @@
+package org.asciidoctor.ast;
+
+public interface DescriptionList extends StructuralNode {
+
+    java.util.List<DescriptionListEntry> getItems();
+
+    boolean hasItems();
+
+    @Deprecated
+    public String render();
+
+    public String convert();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DescriptionListEntry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DescriptionListEntry.java
@@ -1,0 +1,9 @@
+package org.asciidoctor.ast;
+
+public interface DescriptionListEntry {
+
+    java.util.List<ListItem> getTerms();
+
+    ListItem getDescription();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DescriptionListEntryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DescriptionListEntryImpl.java
@@ -1,0 +1,31 @@
+package org.asciidoctor.ast.impl;
+
+import org.asciidoctor.ast.DescriptionListEntry;
+import org.asciidoctor.ast.ListItem;
+import org.asciidoctor.ast.NodeConverter;
+import org.asciidoctor.internal.RubyBlockListDecorator;
+import org.jruby.RubyArray;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.List;
+
+public class DescriptionListEntryImpl extends StructuralNodeImpl implements DescriptionListEntry {
+
+    public DescriptionListEntryImpl(IRubyObject listDelegate) {
+        super(listDelegate);
+    }
+
+    @Override
+    public List<ListItem> getTerms() {
+        return new RubyBlockListDecorator<ListItem>((RubyArray) getAt(0));
+    }
+
+    @Override
+    public ListItem getDescription() {
+        return (ListItem) NodeConverter.createASTNode(getAt(1));
+    }
+
+    private Object getAt(int i) {
+        return ((RubyArray) getRubyObject()).get(i);
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DescriptionListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DescriptionListImpl.java
@@ -1,22 +1,24 @@
 package org.asciidoctor.ast.impl;
 
-import org.asciidoctor.ast.List;
+import org.asciidoctor.ast.DescriptionList;
+import org.asciidoctor.ast.DescriptionListEntry;
 import org.asciidoctor.ast.StructuralNode;
-import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.asciidoctor.internal.RubyBlockListDecorator;
 import org.jruby.RubyArray;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class ListImpl extends StructuralNodeImpl implements List {
+import java.util.List;
 
-    public ListImpl(IRubyObject delegate) {
+public class DescriptionListImpl extends StructuralNodeImpl implements DescriptionList {
+
+    public DescriptionListImpl(IRubyObject delegate) {
         super(delegate);
     }
 
     @Override
-    public java.util.List getItems() {
+    public java.util.List<DescriptionListEntry> getItems() {
         RubyArray rubyBlocks = (RubyArray) getRubyProperty("items");
-        return new RubyBlockListDecorator<StructuralNode>(rubyBlocks);
+        return new RubyBlockListDecorator<DescriptionListEntry>(rubyBlocks);
     }
 
     @Override
@@ -35,7 +37,7 @@ public class ListImpl extends StructuralNodeImpl implements List {
     }
 
     @Override
-    public java.util.List<StructuralNode> getBlocks() {
+    public List<StructuralNode> getBlocks() {
         return null;
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -445,7 +445,7 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
         try {
             Object object = this.asciidoctorModule.convert(content, rubyHash);
-            if (object instanceof IRubyObject && ((IRubyObject) object).getMetaClass() == NodeConverter.NodeType.DOCUMENT_CLASS.getRubyClass(getRubyRuntime())) {
+            if (object instanceof IRubyObject && NodeConverter.NodeType.DOCUMENT_CLASS.isInstance((IRubyObject) object)) {
                 // If a document is rendered to a file Asciidoctor returns the document, we return null
                 return null;
             }
@@ -518,7 +518,7 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
         try {
             Object object = this.asciidoctorModule.convertFile(filename.getAbsolutePath(), rubyHash);
-            if (object instanceof IRubyObject && ((IRubyObject) object).getMetaClass() == NodeConverter.NodeType.DOCUMENT_CLASS.getRubyClass(getRubyRuntime())) {
+            if (object instanceof IRubyObject && NodeConverter.NodeType.DOCUMENT_CLASS.isInstance((IRubyObject) object)) {
                 // If a document is rendered to a file Asciidoctor returns the document, we return null
                 return null;
             }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyBlockListDecorator.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyBlockListDecorator.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 
-public class RubyBlockListDecorator<T extends ContentNode> extends AbstractList<T> {
+public class RubyBlockListDecorator<T> extends AbstractList<T> {
 
     private final RubyArray rubyBlockList;
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyObjectWrapper.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyObjectWrapper.java
@@ -33,7 +33,7 @@ public class RubyObjectWrapper {
         return runtime;
     }
 
-    protected String getString(String propertyName, Object... args) {
+    public String getString(String propertyName, Object... args) {
         IRubyObject result = getRubyProperty(propertyName, args);
 
         if (result instanceof RubyNil) {
@@ -45,7 +45,7 @@ public class RubyObjectWrapper {
         }
     }
 
-    protected void setString(String propertyName, String value) {
+    public void setString(String propertyName, String value) {
         if (value == null) {
             setRubyProperty(propertyName, runtime.getNil());
         } else {
@@ -53,7 +53,7 @@ public class RubyObjectWrapper {
         }
     }
 
-    protected String getSymbol(String propertyName, Object... args) {
+    public String getSymbol(String propertyName, Object... args) {
         IRubyObject result = getRubyProperty(propertyName, args);
 
         if (result instanceof RubyNil) {
@@ -62,7 +62,7 @@ public class RubyObjectWrapper {
         return ((RubySymbol) result).asJavaString();
     }
 
-    protected void setSymbol(String propertyName, String value) {
+    public void setSymbol(String propertyName, String value) {
         if (value == null) {
             setRubyProperty(propertyName, runtime.getNil());
         } else {
@@ -70,7 +70,7 @@ public class RubyObjectWrapper {
         }
     }
 
-    protected boolean getBoolean(String propertyName, Object... args) {
+    public boolean getBoolean(String propertyName, Object... args) {
         IRubyObject result = getRubyProperty(propertyName, args);
         if (result instanceof RubyNil) {
             return false;
@@ -79,7 +79,7 @@ public class RubyObjectWrapper {
         }
     }
 
-    protected int getInt(String propertyName, Object... args) {
+    public int getInt(String propertyName, Object... args) {
         IRubyObject result = getRubyProperty(propertyName, args);
         if (result instanceof RubyNil) {
             return 0;
@@ -88,7 +88,7 @@ public class RubyObjectWrapper {
         }
     }
 
-    protected <T> List<T> getList(String propertyName, Class<T> elementClass, Object... args) {
+    public <T> List<T> getList(String propertyName, Class<T> elementClass, Object... args) {
         IRubyObject result = getRubyProperty(propertyName, args);
         if (result instanceof RubyNil) {
             return null;
@@ -103,7 +103,7 @@ public class RubyObjectWrapper {
     }
 
 
-    protected IRubyObject getRubyProperty(String propertyName, Object... args) {
+    public IRubyObject getRubyProperty(String propertyName, Object... args) {
         ThreadContext threadContext = runtime.getThreadService().getCurrentContext();
 
         IRubyObject result = null;
@@ -130,7 +130,7 @@ public class RubyObjectWrapper {
         return result;
     }
 
-    protected void setRubyProperty(String propertyName, IRubyObject arg) {
+    public void setRubyProperty(String propertyName, IRubyObject arg) {
         ThreadContext threadContext = runtime.getThreadService().getCurrentContext();
 
         IRubyObject result = null;
@@ -145,15 +145,15 @@ public class RubyObjectWrapper {
         }
     }
 
-    protected Object getProperty(String propertyName, Object... args) {
+    public Object getProperty(String propertyName, Object... args) {
         return toJava(getRubyProperty(propertyName, args));
     }
 
-    protected Object toJava(IRubyObject rubyObject) {
+    public Object toJava(IRubyObject rubyObject) {
         return JavaEmbedUtils.rubyToJava(rubyObject);
     }
 
-    protected <T> T toJava(IRubyObject rubyObject, Class<T> targetClass) {
+    public <T> T toJava(IRubyObject rubyObject, Class<T> targetClass) {
         return (T) JavaEmbedUtils.rubyToJava(runtime, rubyObject, targetClass);
     }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentContainsADefinitionList.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentContainsADefinitionList.groovy
@@ -1,0 +1,58 @@
+package org.asciidoctor
+
+import org.asciidoctor.ast.DescriptionList
+import org.asciidoctor.ast.DescriptionListEntry
+import org.asciidoctor.ast.Document
+import org.asciidoctor.ast.ListItem
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+@RunWith(ArquillianSputnik)
+class WhenADocumentContainsADefinitionList extends Specification {
+
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    def "the definition list should be loaded"() {
+
+        given:
+        String document = '''= Test document
+
+Item A::
+Item B:: A description
+
+Item C:: Another description
+'''
+
+        when:
+        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().headerFooter(false).asMap())
+
+        then:
+        DescriptionList list = documentNode.blocks[0]
+
+        list.items != null || list.items.size() == 2
+
+        list.items[0] instanceof DescriptionListEntry
+
+        list.items[0].terms[0].text == 'Item A'
+        list.items[0].terms[0] instanceof ListItem
+
+        list.items[0].terms[1].text == 'Item B'
+        list.items[0].terms[1] instanceof ListItem
+
+        list.items[0].description instanceof ListItem
+        list.items[0].description.hasText()
+        list.items[0].description.text == 'A description'
+
+        list.items[1] instanceof DescriptionListEntry
+
+        list.items[1].terms[0].text == 'Item C'
+
+        list.items[1].description instanceof ListItem
+        list.items[1].description.hasText()
+        list.items[1].description.text == 'Another description'
+    }
+}

--- a/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
+++ b/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
@@ -566,11 +566,19 @@ The AST is built from the following types:
   .. `pass``
 
 `org.asciidoctor.ast.List`::
-  The list node is the container for all lists supported by Asciidoctor.
-  The type of list is available in the field `context`, with the content `ulist` for unordered lists, `olist` for ordered lists and `dlist` for definition lists.
+  The list node is the container for ordered and unordered lists.
+  The type of list is available in the field `context`, with the content `ulist` for unordered lists, `olist` for ordered lists.
 
 `org.asciidoctor.ast.ListItem`::
   A list item represents a single item of a list.
+
+`org.asciidoctor.ast.DescriptionList`::
+  The description list node is the container for description lists.
+  The context of the node is `dlist`.
+
+`org.asciidoctor.ast.DescriptionListEntry`::
+  A list entry represents a single item of a description list.
+  It has multiple terms that are again instances of `org.asciidoctor.ast.ListItem` and a description that is also an instance of `org.asciidoctor.ast.ListItem`.
 
 `org.asciidoctor.ast.Table`::
   This represents a table and is probably the most complex node type.

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ASTExtractorTreeprocessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ASTExtractorTreeprocessor.java
@@ -1,5 +1,8 @@
 package org.asciidoctor.integrationguide.extension;
 
+import org.asciidoctor.ast.DescriptionList;
+import org.asciidoctor.ast.DescriptionListEntry;
+import org.asciidoctor.ast.List;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.Block;
@@ -69,7 +72,13 @@ public class ASTExtractorTreeprocessor extends Treeprocessor {
         }
         result.append("\n");
 
-        if (node instanceof StructuralNode) {
+        if (node instanceof List) {
+            for (StructuralNode child: ((List) node).getItems()) {
+                processNode(level + 1, child);
+            }
+        } else if (node instanceof DescriptionList) {
+            // Ignore it, we don't showcase description lists.
+        } else if (node instanceof StructuralNode) {
             for (StructuralNode child: ((StructuralNode) node).getBlocks()) {
                 processNode(level + 1, child);
             }

--- a/docs/integrator-guide.adoc
+++ b/docs/integrator-guide.adoc
@@ -685,11 +685,19 @@ The AST is built from the following types:
   .. `pass``
 
 `org.asciidoctor.ast.List`::
-  The list node is the container for all lists supported by Asciidoctor.
-  The type of list is available in the field `context`, with the content `ulist` for unordered lists, `olist` for ordered lists and `dlist` for definition lists.
+  The list node is the container for ordered and unordered lists.
+  The type of list is available in the field `context`, with the content `ulist` for unordered lists, `olist` for ordered lists.
 
 `org.asciidoctor.ast.ListItem`::
   A list item represents a single item of a list.
+
+`org.asciidoctor.ast.DescriptionList`::
+  The description list node is the container for description lists.
+  The context of the node is `dlist`.
+
+`org.asciidoctor.ast.DescriptionListEntry`::
+  A list entry represents a single item of a description list.
+  It has multiple terms that are again instances of `org.asciidoctor.ast.ListItem` and a description that is also an instance of `org.asciidoctor.ast.ListItem`.
 
 `org.asciidoctor.ast.Table`::
   This represents a table and is probably the most complex node type.


### PR DESCRIPTION
I created two new classes in the AST package:

`DefinitionList` is a `StructuralNode` and contains `DefinitionListItem`s.

`DefinitionListItem` has a list of `definitionTerm`s, that are `ListItem`s, and a `definition`, that is also a `ListItem`.
But a `DefinitionListItem` is not a `ContentNode`.
And that's maybe not so nice, because `DefinitionList.getBlocks()` returns a list of `StructuralNode`s per its signature.
In fact the members are `DefinitionListItem`s and therefore no `StructuralNode`s.