### PR TITLE
Fixes #405. Adds integration tests to asciidoctorj-distribution.

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -2,6 +2,9 @@ dependencies {
   compile project(':asciidoctorj')
   compile project(':asciidoctorj-epub3')
   compile project(':asciidoctorj-pdf')
+  compile project(':asciidoctorj-diagram')
+
+  testCompile project(':asciidoctorj-arquillian-extension')
 }
 
 // we're creating a dist, not a jar, silly Gradle

--- a/asciidoctorj-distribution/src/test/groovy/org/asciidoctor/diagram/WhenDitaaDiagramIsRendered.groovy
+++ b/asciidoctorj-distribution/src/test/groovy/org/asciidoctor/diagram/WhenDitaaDiagramIsRendered.groovy
@@ -1,0 +1,46 @@
+package org.asciidoctor.diagram
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+@RunWith(ArquillianSputnik)
+class WhenDitaaDiagramIsRendered extends Specification {
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    def 'should render ditaa diagram'() throws Exception {
+
+        given:
+
+        String imageFileName = UUID.randomUUID()
+
+        String document = """= Document Title
+
+Hello World
+
+[ditaa,${imageFileName}]
+....
+
++---+
+| A |
++---+
+....
+
+"""
+
+        asciidoctor.requireLibrary('asciidoctor-diagram')
+
+        when:
+        String result = asciidoctor.convert(document, OptionsBuilder.options().toFile(false).attributes(['imagesoutdir': 'build']))
+
+        then:
+        result.contains("""src="${imageFileName}.png""")
+        new File("build/${imageFileName}.png").exists()
+        new File("build/${imageFileName}.png.cache").exists()
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '9.0.3.0'
+  jrubyVersion = '9.0.4.0'
   jsoupVersion = '1.8.1'
   junitVersion = '4.12'
   nettyVersion = '4.0.33.Final'
@@ -97,7 +97,7 @@ subprojects {
 }
 
 // apply Java and JRuby stuff for all subprojects except the distribution
-configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
+subprojects {
 
   plugins.withType(JavaPlugin) {
 
@@ -111,7 +111,7 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
       task.targetCompatibility = project.targetCompatibility
     }
   }
-  
+
   dependencies {
     testCompile "junit:junit:$junitVersion"
     testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
@@ -134,8 +134,7 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
     maxHeapSize = '1024m'
     if (JavaVersion.current().isJava8Compatible()) {
       jvmArgs '-XX:-UseGCOverheadLimit'
-    }
-    else {
+    } else {
       jvmArgs '-XX:MaxPermSize=256m', '-XX:-UseGCOverheadLimit'
     }
 
@@ -156,6 +155,9 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
       options.addStringOption('Xdoclint:none', '-quiet')
     }
   }
+}
+
+configure(subprojects.findAll { !it.name.endsWith('-distribution') }) {
 
   task sourcesJar(type: Jar, dependsOn: classes, group: 'Release') {
     description 'Assembles a jar archive containing the main source code.'


### PR DESCRIPTION
#401 has shown that JRuby behaves differently when loading gems from a jar or from an exploded directory.
The current test cases for diagram and pdf only refer to the exploded gems which does not reflect the way gems are loaded by a user, i.e. "in production".

I added a test case to asciidoctorj-distribution that creates a ditaa diagram, very similar to the test in asciidoctorj-diagram.
But as asciidoctorj-diagram is referenced as a dependency, the gem will be loaded from a jar.

#401 can be reproduced with this PR when setting the JRuby version to 1.7.22.