### PR TITLE
Fix for Issue 419

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -56,3 +56,49 @@ jar {
       '*'
   }
 }
+
+test {
+  useJUnit {
+    excludeCategories 'org.asciidoctor.categories.Polluted'
+  }
+}
+
+task pollutedTest(type: Test) {
+  useJUnit {
+    includeCategories 'org.asciidoctor.categories.Polluted'
+  }
+  forkEvery = 10
+  minHeapSize = '128m'
+  maxHeapSize = '1024m'
+  if (JavaVersion.current().isJava8Compatible()) {
+    jvmArgs '-XX:-UseGCOverheadLimit'
+  }
+  else {
+    jvmArgs '-XX:MaxPermSize=256m', '-XX:-UseGCOverheadLimit'
+  }
+
+  environment 'GEM_PATH', '/some/path'
+  environment 'GEM_HOME', '/some/other/path'
+
+  testLogging {
+    // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
+    // events 'standard_out', 'standard_error'
+    afterSuite { desc, result ->
+      if (!desc.parent && logger.infoEnabled) {
+        logger.info "Test results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+      }
+    }
+  }
+
+  reports {
+    html {
+      destination file("$buildDir/reports/pollutedTest")
+    }
+    junitXml {
+      destination file("$buildDir/pollutedTest-result")
+    }
+  }
+}
+
+test.dependsOn pollutedTest
+

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
@@ -115,7 +115,7 @@ public class AsciidoctorInvoker {
             if (asciidoctorCliOptions.isLoadPaths()) {
                 asciidoctor = JRubyAsciidoctor.create(asciidoctorCliOptions.getLoadPaths());
             } else {
-                asciidoctor = JRubyAsciidoctor.create();
+                asciidoctor = JRubyAsciidoctor.create((String) null);
             }
             return asciidoctor;
         } finally {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -51,27 +51,27 @@ public class JRubyAsciidoctor implements Asciidoctor {
         //Map<String, Object> env = new HashMap<String, Object>();
         // ideally, we want to clear GEM_PATH by default, but for backwards compatibility we play nice
         //env.put(GEM_PATH, null);
-        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), null, null));
+        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), null));
     }
 
     public static JRubyAsciidoctor create(String gemPath) {
-        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), null, gemPath));
+        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), new ArrayList<String>(), null));
     }
 
     public static JRubyAsciidoctor create(List<String> loadPaths) {
-        return processRegistrations(createJRubyAsciidoctorInstance(null, loadPaths, null, null));
+        return processRegistrations(createJRubyAsciidoctorInstance(null, loadPaths, null));
     }
 
     public static JRubyAsciidoctor create(ClassLoader classloader) {
-        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), classloader, null));
+        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), classloader));
     }
 
     public static JRubyAsciidoctor create(ClassLoader classloader, String gemPath) {
-        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), classloader, gemPath));
+        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), new ArrayList<String>(), classloader));
     }
 
     public static JRubyAsciidoctor create(List<String> loadPaths, String gemPath) {
-        return processRegistrations(createJRubyAsciidoctorInstance(null, loadPaths, null, gemPath));
+        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), loadPaths, null));
     }
 
     private static JRubyAsciidoctor processRegistrations(JRubyAsciidoctor asciidoctor) {
@@ -88,13 +88,10 @@ public class JRubyAsciidoctor implements Asciidoctor {
         new ExtensionRegistryExecutor(asciidoctor).registerAllExtensions();
     }
 
-    private static JRubyAsciidoctor createJRubyAsciidoctorInstance(Map<String, String> environmentVars, List<String> loadPaths, ClassLoader classloader, String gemPath) {
+    private static JRubyAsciidoctor createJRubyAsciidoctorInstance(Map<String, String> environmentVars, List<String> loadPaths, ClassLoader classloader) {
 
         Map<String, String> env = environmentVars != null ?
                 new HashMap<String, String>(environmentVars) : new HashMap<String, String>();
-        if (gemPath != null) {
-            env.put(GEM_PATH, gemPath);
-        }
 
         RubyInstanceConfig config = createOptimizedConfiguration();
         if (classloader != null) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
@@ -29,7 +29,7 @@ public class WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath {
         Asciidoctor asciidoctor = Asciidoctor.Factory.create((String) null);
 
         // Then: The org.jruby.JRuby instance does not see this variable
-        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        Ruby rubyRuntime = JRubyRuntimeContext.get(asciidoctor);
         assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is(rubyRuntime.getNil()));
         assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is(rubyRuntime.getNil()));
     }
@@ -44,7 +44,7 @@ public class WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath {
         Asciidoctor asciidoctor = Asciidoctor.Factory.create();
 
         // Then: The org.jruby.JRuby instance sees this variable
-        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        Ruby rubyRuntime = JRubyRuntimeContext.get(asciidoctor);
         assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), not(is(rubyRuntime.getNil())));
         assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), not(is(rubyRuntime.getNil())));
     }
@@ -60,7 +60,7 @@ public class WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath {
         Asciidoctor asciidoctor = Asciidoctor.Factory.create(gemPath);
 
         // Then: The org.jruby.JRuby instance does not see this variable
-        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        Ruby rubyRuntime = JRubyRuntimeContext.get(asciidoctor);
         RubyString rubyGemPath = rubyRuntime.newString(gemPath);
         assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is((Object) rubyGemPath));
         assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is((Object) rubyGemPath));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
@@ -1,0 +1,69 @@
+package org.asciidoctor;
+
+import org.asciidoctor.categories.Polluted;
+import org.asciidoctor.internal.JRubyRuntimeContext;
+import org.jruby.Ruby;
+import org.jruby.RubyString;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This test checks if the Ruby instance for an Asciidoctor instance is
+ * not affected by a GEM_HOME or GEM_PATH environment variable.
+ * It can mix up the JRuby instance when it can see gems from a C-Ruby
+ * with native extensions.
+ */
+@Category(Polluted.class)
+public class WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath {
+
+    @Test
+    public void should_not_have_gempath_in_ruby_env_when_created_with_null_gempath() {
+        // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
+        assertThat(System.getenv("GEM_PATH"), notNullValue());
+        assertThat(System.getenv("GEM_HOME"), notNullValue());
+
+        // When: A new Asciidoctor instance is created passing in a null GEM_PATH
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create((String) null);
+
+        // Then: The org.jruby.JRuby instance does not see this variable
+        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is(rubyRuntime.getNil()));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is(rubyRuntime.getNil()));
+    }
+
+    @Test
+    public void should_have_gempath_in_ruby_env_when_created_with_non_null_gempath() {
+        // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
+        assertThat(System.getenv("GEM_PATH"), notNullValue());
+        assertThat(System.getenv("GEM_HOME"), notNullValue());
+
+        // When: A new Asciidoctor instance is created passing in no GEM_PATH
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+        // Then: The org.jruby.JRuby instance sees this variable
+        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), not(is(rubyRuntime.getNil())));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), not(is(rubyRuntime.getNil())));
+    }
+
+    @Test
+    public void should_have_gempath_in_ruby_env_when_created_with_gempath() {
+        // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
+        final String gemPath = "/another/path";
+        assertThat(System.getenv("GEM_PATH"), notNullValue());
+        assertThat(System.getenv("GEM_HOME"), notNullValue());
+
+        // When: A new Asciidoctor instance is created passing in a null GEM_PATH
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create(gemPath);
+
+        // Then: The org.jruby.JRuby instance does not see this variable
+        Ruby rubyRuntime = JRubyRuntimeContext.get();
+        RubyString rubyGemPath = rubyRuntime.newString(gemPath);
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is((Object) rubyGemPath));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is((Object) rubyGemPath));
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/categories/Polluted.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/categories/Polluted.java
@@ -1,0 +1,8 @@
+package org.asciidoctor.categories;
+
+/**
+ * Defines tests that are executed within a "polluted" environemnt, that is environment variables GEM_PATH
+ * and GEM_HOME will be set.
+ */
+public class Polluted {
+}


### PR DESCRIPTION
Fixes #419 for the 1.6.0 branch.
Contains the same commits as #420.
Made a new PR as the tests revealed a new error in the 1.6.0 branch that I want tested on the CI system before merging: 
A null gemPath passed to `Asciidoctor.Factory.create((String) null)` was completely ignored so that a `GEM_PATH` still leaked into the JRuby instance!