### PR TITLE
Avoid NPE with JRuby 9.1.0.0

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyHashMapDecorator.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyHashMapDecorator.java
@@ -22,12 +22,12 @@ public class RubyHashMapDecorator implements Map<String, Object> {
 
     @Override
     public int size() {
-        return rubyHash.size();
+        return createJavaMap().size();
     }
 
     @Override
     public boolean isEmpty() {
-        return rubyHash.isEmpty();
+        return size() == 0;
     }
 
     @Override


### PR DESCRIPTION
One test currently fails with JRuby 9.1.0.0 with this exception:
```
java.lang.NullPointerException
    at org.jruby.java.proxies.MapJavaProxy$RubyHashMap.visitAll(MapJavaProxy.java:261)
    at org.jruby.RubyHash.replaceCommon(RubyHash.java:1870)
    at org.jruby.RubyHash.replace(RubyHash.java:1845)
```
This is due to `RubyHashMapDecorator.size()` not returning the exact result if the wrapped map contains entries (e.g. positional parameters) that are filtered and not added to the iterator.

This PR fixes `size()` and `isEmpty()` to work correctly even with positional attributes.
