### PR TITLE
Asciidoctorj 1.6.0 - pom generation fix

### DIFF
--- a/asciidoctorj-arquillian-extension/build.gradle
+++ b/asciidoctorj-arquillian-extension/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  provided project(path: ':asciidoctorj')
-  compile project(path: ':asciidoctorj-test-support')
+  provided project(':asciidoctorj')
+  compile project(':asciidoctorj-test-support')
   compile "org.jboss.arquillian.container:arquillian-container-spi:$arquillianVersion"
   compile "org.jboss.arquillian.container:arquillian-container-test-spi:$arquillianVersion"
   compile "org.jboss.arquillian.container:arquillian-container-impl-base:$arquillianVersion"

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 }
 
 jar.enabled = false
+signPom.enabled = false
 
 configurations.all {
   artifacts.clear()

--- a/build.gradle
+++ b/build.gradle
@@ -77,14 +77,19 @@ subprojects {
   apply plugin: 'groovy'
   apply from: "$rootDir/gradle/providedConfiguration.gradle"
 
-  if (!it.name.endsWith('-documentation')) {
-    apply from: rootProject.file('gradle/publish.gradle')
+  if (JavaVersion.current().isJava7Compatible() && !it.name.endsWith('-documentation')) {
+
+    apply from: rootProject.file('gradle/signing.gradle')
+    if (!it.isDistribution()) {
+      apply from: rootProject.file('gradle/publish.gradle')
+    }
     if (statusIsRelease) {
       apply from: rootProject.file('gradle/deploy.gradle')
     } else if (it.version.endsWith('SNAPSHOT')) {
       apply from: rootProject.file('gradle/deploySnapshot.gradle')
     }
   }
+  
   status = _status
 
   // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -3,66 +3,6 @@
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
-ext.pom = file("$buildDir/publications/jars/pom-default.xml")
-ext.signedPom = file("$buildDir/publications/jars/pom-default.xml.asc")
-
-if ( !project.hasProperty('skip.signing') ){
-    apply plugin: 'signing'
-
-    signing {
-        sign configurations.archives
-    }
-
-    if ( !signing.signatory ) {
-        logger.warn "No Signatory configured for project $project.name. Skip signing! See https://docs.gradle.org/current/userguide/signing_plugin.html"
-        signArchives.enabled = false
-        ext."skip.signing" = true
-    }
-
-    task signPom(type: Sign) {
-        group "publishing"
-        description "Sign the projects pom file"
-
-        inputs.file pom
-        outputs.file signedPom
-
-        doLast{
-
-            def input = pom.newInputStream()
-            def output = signedPom.newOutputStream()
-            try{
-                signatory.sign(input, output)
-            }
-            catch (Exception e){
-                logger.error e.message
-            }
-            finally {
-                input.close()
-                output.close()
-            }
-        }
-    }
-
-    /**
-     * The signPom Task depends on the GenerateMavenPom task which gets dynamically added
-     * with a name derived from a publication. In our case 'jars'.
-     *
-     * Our jars publication registers the signed pom as artifact.
-     * If the task does not run before publishJarsPublicationToMavenLocal this task will fail.
-     */
-    tasks.whenTaskAdded {
-
-        switch (it.name) {
-            case "generatePomFileForJarsPublication":
-                signPom.dependsOn it
-                break
-            case "publishJarsPublicationToMavenLocal":
-                it.dependsOn signPom
-                break
-        }
-    }
-}
-
 def projectMeta = {
     resolveStrategy = groovy.lang.Closure.DELEGATE_FIRST
     name project.name

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -63,8 +63,8 @@ def projectMeta = {
     }
 }
 
-publishing {
-    publications {
+afterEvaluate {
+    publishing.publications {
         jars(MavenPublication) {
 
             // NOTE only build sources and javadoc jars when releasing
@@ -78,7 +78,7 @@ publishing {
 
                 // register the signed pom file
                 // signedPom is an output file from the signPom task
-                if ( !project.hasProperty('skip.signing') ) {
+                if (!project.hasProperty('skip.signing')) {
                     artifact(signedPom) {
                         extension = "pom.asc"
                         classifier = null
@@ -90,14 +90,12 @@ publishing {
                 asNode().children().last() + projectMeta
             }
 
-            if ( !project.isDistribution() ) {
+            if (!project.isDistribution()) {
                 from components.java
             }
         }
-
     }
 }
-
 
 // QUESTION should we move manifest creation to general Java plugin config?
 jar {

--- a/gradle/signing.gradle
+++ b/gradle/signing.gradle
@@ -1,0 +1,59 @@
+ext.pom = file("$buildDir/publications/jars/pom-default.xml")
+ext.signedPom = file("$buildDir/publications/jars/pom-default.xml.asc")
+
+if ( !project.hasProperty('skip.signing') ){
+    apply plugin: 'signing'
+
+    signing {
+        sign configurations.archives
+    }
+
+    if ( !signing.signatory ) {
+        logger.warn "No Signatory configured for project $project.name. Skip signing! See https://docs.gradle.org/current/userguide/signing_plugin.html"
+        signArchives.enabled = false
+        ext."skip.signing" = true
+    }
+
+    task signPom(type: Sign) {
+        group "publishing"
+        description "Sign the projects pom file"
+
+        inputs.file pom
+        outputs.file signedPom
+
+        doLast{
+
+            def input = pom.newInputStream()
+            def output = signedPom.newOutputStream()
+            try{
+                signatory.sign(input, output)
+            }
+            catch (Exception e){
+                logger.error e.message
+            }
+            finally {
+                input.close()
+                output.close()
+            }
+        }
+    }
+
+    /**
+     * The signPom Task depends on the GenerateMavenPom task which gets dynamically added
+     * with a name derived from a publication. In our case 'jars'.
+     *
+     * Our jars publication registers the signed pom as artifact.
+     * If the task does not run before publishJarsPublicationToMavenLocal this task will fail.
+     */
+    tasks.whenTaskAdded {
+
+        switch (it.name) {
+            case "generatePomFileForJarsPublication":
+                signPom.dependsOn it
+                break
+            case "publishJarsPublicationToMavenLocal":
+                it.dependsOn signPom
+                break
+        }
+    }
+}


### PR DESCRIPTION
I think I found a solution to make the pom generation work again.
Something is strange. I should not have to add the publishing configuration block into afterEvaluate.
But it works that way with the current configuration in the 1.6.0 branch.
Before the pom where generated too, but without the dependencies block o.O