### PR TITLE
prevent multiple upload of artifacts to bintray

### DIFF
--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -6,7 +6,6 @@ bintray {
 
   if ( !project.isDistribution() ) {
     publications = ['jars']
-    configurations = ['signatures']
   }
   else {
     configurations = ['archives']

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -6,8 +6,11 @@ bintray {
 
   if ( !project.isDistribution() ) {
     publications = ['jars']
+    configurations = ['signatures']
   }
-  configurations = ['archives']
+  else {
+    configurations = ['archives']
+  }
 
   dryRun = project.hasProperty('dryRun') && project.dryRun.toBoolean()
   publish = project.statusIsRelease

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,6 +1,4 @@
-// NOTE replace deficient built-in publishing plugin with nebula-publishing,
-// which does a better job generating the POM and properly aggregates signature files for upload to Bintray
-apply plugin: 'maven'
+// NOTE the nebula-publishing plugin does not handle signature files anymore
 apply plugin: 'maven-publish'
 
 def projectMeta = {
@@ -87,6 +85,26 @@ afterEvaluate {
         }
     }
 }
+
+task addSignaturesToPublication(dependsOn: signArchives) {
+    group "publishing"
+    description "add all signatures to the publication"
+
+    doLast {
+        publishing.publications {
+            jars(MavenPublication) {
+                configurations.signatures.getArtifacts().each { sig ->
+                    logger.debug "adding signature to jars publication: $sig"
+                    artifact(sig){
+                        extension "jar.asc"
+                    }
+                }
+            }
+        }
+    }
+}
+
+tasks["signPom"].finalizedBy addSignaturesToPublication
 
 // QUESTION should we move manifest creation to general Java plugin config?
 jar {


### PR DESCRIPTION
The bintray plugin allows two ways to define the artifacts to be uploaded.

* Maven Publications
* Configurations

We use both, as it is not possible to add the signatures for the jars to the maven publication.

(Or maybe it is possible, but I couldn't figure out how. Adding the signed artifacts to the publication like adding the
pom signature failed with an error while publishing to maven local.)

The _archives_ configuration holds the jar-artifacts and the signatures. And that is why the jar artifacts are doubled and the signatures not.
Defining the _signatures_ configuration is the solution for every non distribution module.

One thing I was not able to prevent from uploading twice is the pom file.
But I think that is tolerable.

(Maybe it is not supposed to mix those two definitions and each of them is adding the pom transparently...)