### PR TITLE
add checkVersion Task to keep track of published gem versions

### DIFF
--- a/asciidoctorj-core/gradle.properties
+++ b/asciidoctorj-core/gradle.properties
@@ -1,2 +1,3 @@
 properName=AsciidoctorJ
 description=AsciidoctorJ provides Java bindings for the Asciidoctor RubyGem (asciidoctor) using JRuby.
+gem_name=asciidoctor

--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,3 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
 version=1.3.1
+gem_name=asciidoctor-diagram

--- a/asciidoctorj-epub3/gradle.properties
+++ b/asciidoctorj-epub3/gradle.properties
@@ -1,3 +1,4 @@
 properName=AsciidoctorJ EPUB3
 description=AsciidoctorJ EPUB3 bundles the Asciidoctor EPUB3 RubyGem (asciidoctor-epub3) so it can be loaded into the JVM using JRuby.
 version=1.5.0-alpha.6
+gem_name=asciidoctor-epub3

--- a/asciidoctorj-pdf/gradle.properties
+++ b/asciidoctorj-pdf/gradle.properties
@@ -1,3 +1,4 @@
 properName=AsciidoctorJ PDF
 description=AsciidoctorJ PDF bundles the Asciidoctor PDF RubyGem (asciidoctor-pdf) so it can be loaded into the JVM using JRuby.
 version=1.5.0-alpha.11
+gem_name=asciidoctor-pdf

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ configure(subprojects.findAll { !it.isDistribution() }) {
 
   apply plugin: 'com.github.jruby-gradle.base'
   apply from: rootProject.file('gradle/eclipse.gradle')
+  apply from: rootProject.file('gradle/versioncheck.gradle')
 
   repositories {
     maven {

--- a/gradle/versioncheck.gradle
+++ b/gradle/versioncheck.gradle
@@ -1,0 +1,54 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.zafarkhaja:java-semver:0.9.0'
+    }
+}
+
+import groovy.json.JsonSlurper
+import com.github.zafarkhaja.semver.Version
+
+task checkVersion() {
+    group "verification"
+    description "Check if current project version is behind published gem version. (skip with -P skip.checkVersion)"
+
+    if ( !project.hasProperty("gem_name")) {
+        throw new GradleException("I need the gem name to check the version. Add a 'gem_name' property to the gradle.properties file. (e.g.: gem_name=asciidoctor-diagram)")
+    }
+
+    def gem_version_pattern = ~/(((\d+\.){1,2}\d+)(\.)?(.*))/
+    def gem_latest_version_url = "https://rubygems.org/api/v1/versions/${gem_name}/latest.json".toURL()
+
+    def json = new JsonSlurper().parse( gem_latest_version_url )
+    def gem_latest_version = json.version
+
+    def matcher = gem_latest_version =~ gem_version_pattern
+    def javaVersion = gem_latest_version
+
+    doLast {
+
+        if ( gem_latest_version ==~ gem_version_pattern ) {
+            matcher.find()
+            if (matcher.group(4)) {
+                javaVersion = "${matcher.group(2)}-${matcher.group(5)}"
+            }
+        }
+
+
+        Version projectVersion = Version.valueOf(version)
+        Version gemJavaVersion = Version.valueOf(javaVersion)
+
+        if ( projectVersion.lessThan(gemJavaVersion) ) {
+            logger.warn "\nWARNING\nVersion mismatch: Current Version: $version, Gem Version: $gem_latest_version\n"
+        }
+        else {
+            println "up-to-date"
+        }
+    }
+}
+
+checkVersion.onlyIf { !gradle.startParameter.isOffline() }
+checkVersion.onlyIf { !project.hasProperty("skip.checkVersion") }
+check.dependsOn checkVersion


### PR DESCRIPTION
Wrote a little helper task called _checkVersion_ to keep track of published gem versions.

Here is an example of the tasks output:

```
gradle checkVersion
Configuration(s) specified but the install task does not exist in project :asciidoctorj-distribution.
:asciidoctorj:checkVersion
up-to-date
:asciidoctorj-diagram:checkVersion

WARNING
Version mismatch: Current Version: 1.3.1, Gem Version: 1.4.0

:asciidoctorj-epub3:checkVersion
up-to-date
:asciidoctorj-pdf:checkVersion
up-to-date

BUILD SUCCESSFUL
```

It prints a brief warning for each project which version is less than the published gem.
You can skip the the check with `-P skip.checkVersion`
The task is disabled in offline mode.

Maybe it helps.