### PR TITLE
Fixes #472. Add support for Tables in AST.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
@@ -1,0 +1,71 @@
+package org.asciidoctor.ast;
+
+public interface Cell extends AbstractNode {
+
+    Column getColumn();
+
+    int getColspan();
+
+    int getRowspan();
+
+    String getText();
+
+    Object getContent();
+
+    /**
+     * Returns the style of this cell.
+     * The default is {@code null}.
+     * Possible values are:
+     * <ul>
+     *     <li>{@code null}</li>
+     *     <li>{@code "strong"}</li>
+     *     <li>{@code "emphasis"}</li>
+     *     <li>{@code "monospaced"}</li>
+     *     <li>{@code "header"}</li>
+     *     <li>{@code "literal"}</li>
+     *     <li>{@code "verse"}</li>
+     *     <li>{@code "asciidoc"}</li>
+     * </ul>
+     * @return The style of this cell.
+     */
+    String getStyle();
+
+    /**
+     * Sets the style of this cell.
+     * @see #getStyle()
+     * @param style Values like {@code asciidoc}, {@code verse}, {@code literal}or {@code header}.
+     */
+    void setStyle(String style);
+
+    /**
+     * Returns the horizonzal alignment of this cell.
+     * @return a constant representing the horizontal alignment.
+     */
+    Table.HorizontalAlignment getHorizontalAlignment();
+
+    /**
+     * Sets the horizontal alignment of this cell.
+     * @param halign Either {@link Table.HorizontalAlignment#LEFT}, {@link Table.HorizontalAlignment#CENTER} or {@link Table.HorizontalAlignment#RIGHT}
+     */
+    void setHorizontalAlignment(Table.HorizontalAlignment halign);
+
+    /**
+     * Returns the vertical alignment of this cell.
+     * @return a constant representing the vertical alignment.
+     */
+    Table.VerticalAlignment getVerticalAlignment();
+
+    /**
+     * Sets the vertical alignment of this cell.
+     * @param valign Either {@link Table.VerticalAlignment#TOP}, {@link Table.VerticalAlignment#MIDDLE} or {@link Table.VerticalAlignment#BOTTOM}
+     */
+    void setVerticalAlignment(Table.VerticalAlignment valign);
+
+    /**
+     * If the style of a cell is {@code asciidoc} the content of the cell is an inner document.
+     * This method returns this inner document.
+     * @return The inner document if the cell style is {@code asciidoc}
+     */
+    DocumentRuby getInnerDocument();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/CellImpl.java
@@ -1,0 +1,75 @@
+package org.asciidoctor.ast;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
+
+public class CellImpl extends AbstractNodeImpl implements Cell {
+
+    private final Cell delegate;
+
+    public CellImpl(Cell delegate, Ruby rubyRuntime) {
+        super(delegate, rubyRuntime);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Column getColumn() {
+        return (Column) getParent();
+    }
+
+    @Override
+    public int getColspan() {
+        return delegate.getColspan();
+    }
+
+    @Override
+    public int getRowspan() {
+        return getRowspan();
+    }
+
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+
+    @Override
+    public Object getContent() {
+        return delegate.getContent();
+    }
+
+    @Override
+    public String getStyle() {
+        return delegate.getStyle();
+    }
+
+    @Override
+    public void setStyle(String style) {
+        delegate.setStyle(style);
+    }
+
+    @Override
+    public Table.HorizontalAlignment getHorizontalAlignment() {
+        return Table.HorizontalAlignment.valueOf(((String) getAttr("halign", "left")).toUpperCase());
+    }
+
+    @Override
+    public void setHorizontalAlignment(Table.HorizontalAlignment halign) {
+        setAttr("halign", halign.name().toLowerCase(), true);
+    }
+
+    @Override
+    public Table.VerticalAlignment getVerticalAlignment() {
+        return Table.VerticalAlignment.valueOf(((String) getAttr("valign", "top")).toUpperCase());
+    }
+
+    @Override
+    public void setVerticalAlignment(Table.VerticalAlignment valign) {
+        setAttr("valign", valign.name().toLowerCase(), true);
+    }
+
+    @Override
+    public DocumentRuby getInnerDocument() {
+        return (DocumentRuby) NodeConverter.createASTNode((IRubyObject) delegate.getInnerDocument());
+    }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Column.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Column.java
@@ -1,0 +1,62 @@
+package org.asciidoctor.ast;
+
+public interface Column extends AbstractNode {
+
+    /**
+     * Returns the style of this column.
+     * The default is {@code null}.
+     * Possible values are:
+     * <ul>
+     *     <li>{@code null}</li>
+     *     <li>{@code "strong"}</li>
+     *     <li>{@code "emphasis"}</li>
+     *     <li>{@code "monospaced"}</li>
+     *     <li>{@code "header"}</li>
+     *     <li>{@code "literal"}</li>
+     *     <li>{@code "verse"}</li>
+     *     <li>{@code "asciidoc"}</li>
+     * </ul>
+     * @return The style of this cell.
+     */
+    String getStyle();
+
+    /**
+     * Sets the style of this column.
+     * @see #getStyle()
+     * @param style Values like {@code asciidoc}, {@code verse}, {@code literal}or {@code header}.
+     */
+    void setStyle(String style);
+
+    Table getTable();
+
+    int getColnumber();
+
+    int getWidth();
+
+    void setWidth(int width);
+
+    /**
+     * Returns the horizonzal alignment of all cells in this column.
+     * @return a constant representing the horizontal alignment.
+     */
+    Table.HorizontalAlignment getHorizontalAlignment();
+
+    /**
+     * Sets the horizontal alignment of all cells of this column.
+     * @param halign Either {@link Table.HorizontalAlignment#LEFT}, {@link Table.HorizontalAlignment#CENTER} or {@link Table.HorizontalAlignment#RIGHT}
+     */
+    void setHorizontalAlignment(Table.HorizontalAlignment halign);
+
+    /**
+     * Returns the vertical alignment of all cells in this column.
+     * @return a constant representing the vertical alignment.
+     */
+    Table.VerticalAlignment getVerticalAlignment();
+
+    /**
+     * Sets the vertical alignment of all cells of this column.
+     * @param valign Either {@link Table.VerticalAlignment#TOP}, {@link Table.VerticalAlignment#MIDDLE} or {@link Table.VerticalAlignment#BOTTOM}
+     */
+    void setVerticalAlignment(Table.VerticalAlignment valign);
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ColumnImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ColumnImpl.java
@@ -1,0 +1,66 @@
+package org.asciidoctor.ast;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
+
+public class ColumnImpl extends AbstractNodeImpl implements Column {
+
+    private final Column delegate;
+
+    public ColumnImpl(Column delegate, Ruby rubyRuntime) {
+        super(delegate, rubyRuntime);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getStyle() {
+        return delegate.getStyle();
+    }
+
+    @Override
+    public void setStyle(String style) {
+        delegate.setStyle(style);
+    }
+
+    @Override
+    public Table getTable() {
+        return (Table) NodeConverter.createASTNode((IRubyObject) delegate.getParent());
+    }
+
+    @Override
+    public int getColnumber() {
+        return delegate.getColnumber();
+    }
+
+    @Override
+    public int getWidth() {
+        Number width =  (Number) getAttr("width");
+        return width == null ? 0 : width.intValue();
+    }
+
+    @Override
+    public void setWidth(int width) {
+        setAttr("width", width, true);
+    }
+
+    @Override
+    public Table.HorizontalAlignment getHorizontalAlignment() {
+        return Table.HorizontalAlignment.valueOf(((String) getAttr("halign", "left")).toUpperCase());
+    }
+
+    @Override
+    public void setHorizontalAlignment(Table.HorizontalAlignment halign) {
+        setAttr("halign", halign.name().toLowerCase(), true);
+    }
+
+    @Override
+    public Table.VerticalAlignment getVerticalAlignment() {
+        return Table.VerticalAlignment.valueOf(((String) getAttr("valign", "top")).toUpperCase());
+    }
+
+    @Override
+    public void setVerticalAlignment(Table.VerticalAlignment valign) {
+        setAttr("valign", valign.name().toLowerCase(), true);
+    }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
@@ -22,6 +22,12 @@ public final class NodeConverter {
 
     private static final String LIST_ITEM_CLASS = "Asciidoctor::ListItem";
 
+    private static final String TABLE_CLASS = "Asciidoctor::Table";
+
+    private static final String TABLE_COLUMN_CLASS = "Asciidoctor::Table::Column";
+
+    private static final String TABLE_CELL_CLASS = "Asciidoctor::Table::Cell";
+
     private NodeConverter() {}
 
     public static AbstractNode createASTNode(IRubyObject rubyObject) {
@@ -50,6 +56,18 @@ public final class NodeConverter {
         else if (LIST_ITEM_CLASS.equals(rubyClassName)) {
             ListItem list = RubyUtils.rubyToJava(runtime, rubyObject, ListItem.class);
             return new ListItemImpl(list, runtime);
+        }
+        else if (TABLE_CLASS.equals(rubyClassName)) {
+            Table table = RubyUtils.rubyToJava(runtime, rubyObject, Table.class);
+            return new TableImpl(table, runtime);
+        }
+        else if (TABLE_CELL_CLASS.equals(rubyClassName)) {
+            Cell cell = RubyUtils.rubyToJava(runtime, rubyObject, Cell.class);
+            return new CellImpl(cell, runtime);
+        }
+        else if (TABLE_COLUMN_CLASS.equals(rubyClassName)) {
+            Column column = RubyUtils.rubyToJava(runtime, rubyObject, Column.class);
+            return new ColumnImpl(column, runtime);
         }
         throw new IllegalArgumentException("Don't know what to do with a " + rubyObject);
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Row.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Row.java
@@ -1,0 +1,9 @@
+package org.asciidoctor.ast;
+
+import java.util.List;
+
+public interface Row {
+
+    public List<Cell> getCells();
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/RowImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/RowImpl.java
@@ -1,0 +1,23 @@
+package org.asciidoctor.ast;
+
+import org.jruby.Ruby;
+
+import java.util.List;
+
+public class RowImpl implements Row {
+
+    private final List<Cell> cells;
+
+    private final Ruby rubyRuntime;
+
+    public RowImpl(List<Cell> cells, Ruby rubyRuntime) {
+        this.rubyRuntime = rubyRuntime;
+
+        this.cells = cells;
+    }
+
+    @Override
+    public List<Cell> getCells() {
+        return cells;
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Table.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Table.java
@@ -1,0 +1,57 @@
+package org.asciidoctor.ast;
+
+import java.util.List;
+
+public interface Table extends AbstractBlock {
+
+    public static enum HorizontalAlignment {
+        LEFT, CENTER, RIGHT
+    }
+
+    public static enum VerticalAlignment {
+        TOP, BOTTOM, MIDDLE
+    }
+
+    boolean hasHeaderOption();
+
+    List<Column> getColumns();
+
+    List<Row> getHeader();
+
+    List<Row> getFooter();
+
+    List<Row> getBody();
+
+    /**
+     * Returns the frame attribute of the table that defines what frame to render around the table.
+     * By default, the frame attribute is assigned the {@code all} value, which draws a border on each side of the table.
+     * If you set the frame attribute, you can override the default value with {@code topbot}, {@code sides} or {@code none}.
+     * @return the frame attribute
+     */
+    String getFrame();
+
+    /**
+     * Sets the frame attribute.
+     * @see #getFrame()
+     * @param frame {@code all}, {@code topbot}, {@code sides} or {@code none}
+     */
+    void setFrame(String frame);
+
+    /**
+     * Returns the grid attribute that defines what boundary lines to draw between rows and columns.
+     * By default the grid attribute is assigned the {@code all} value, which draws lines around each cell.
+     * Alternative values are {@code cols} to draw lines between columns, {@code rows} to draw boundary lines
+     * between rows and {@code none} to draw no boundary lines
+     * @return the value of the {@code grid} attribute, usually either {@code all}, {@code cols}, {@code rows} or {@code none}
+     */
+    String getGrid();
+
+    /**
+     * Sets the value of the {@grid} attribute.
+     * @see #getGrid()
+     * @param grid usually either {@code all}, {@code cols}, {@code rows} or {@code none}
+     */
+    void setGrid(String grid);
+
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/TableImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/TableImpl.java
@@ -1,0 +1,135 @@
+package org.asciidoctor.ast;
+
+import org.asciidoctor.internal.RubyUtils;
+import org.jruby.Ruby;
+import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TableImpl extends AbstractBlockImpl implements Table {
+
+    private static final String FRAME_ATTR = "frame";
+
+    private static final String GRID_ATTR  = "grid";
+
+    private Table delegate;
+
+    private Rows rows;
+
+    public TableImpl(Table delegate, Ruby rubyRuntime) {
+        super(delegate, rubyRuntime);
+        this.delegate = delegate;
+
+        IRubyObject rubyTable = JavaEmbedUtils.javaToRuby(rubyRuntime, delegate);
+        rows = new RowsImpl(
+            RubyUtils.rubyToJava(rubyRuntime, rubyTable.getInstanceVariables().getInstanceVariable("@rows"), Rows.class),
+            rubyRuntime);
+    }
+
+    @Override
+    public boolean hasHeaderOption() {
+        return delegate.hasHeaderOption();
+    }
+
+    @Override
+    public String getFrame() {
+        return (String)getAttr(FRAME_ATTR, "all");
+    }
+
+    @Override
+    public void setFrame(String frame) {
+        setAttr(FRAME_ATTR, frame, true);
+    }
+
+    @Override
+    public String getGrid() {
+        return (String)getAttr(GRID_ATTR, "all");
+    }
+
+    @Override
+    public void setGrid(String grid) {
+        setAttr(GRID_ATTR, grid, true);
+    }
+
+    @Override
+    public List<Column> getColumns() {
+        List<Column> rubyColumns = delegate.getColumns();
+        List<Column> result = new ArrayList<Column>(rubyColumns.size());
+
+        for (int i = 0; i < rubyColumns.size(); i++) {
+            IRubyObject rubyColumn = (IRubyObject) rubyColumns.get(i);
+            result.add((Column) NodeConverter.createASTNode(rubyColumn));
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<Row> getFooter() {
+        return rows.getFoot();
+    }
+
+    @Override
+    public List<Row> getBody() {
+        return rows.getBody();
+    }
+
+    @Override
+    public List<Row> getHeader() {
+        return rows.getHead();
+    }
+
+    public static interface Rows {
+        List<Row> getHead();
+
+        List<Row> getFoot();
+
+        List<Row> getBody();
+    }
+
+    public static class RowsImpl implements Rows {
+
+        private final Rows delegate;
+
+        private final Ruby rubyRuntime;
+
+        public RowsImpl(Rows delegate, Ruby rubyRuntime) {
+            this.delegate = delegate;
+            this.rubyRuntime = rubyRuntime;
+        }
+
+        public List<Row> getHead() {
+            return convertRows(delegate.getHead());
+        }
+
+        public List<Row> getFoot() {
+            return convertRows(delegate.getFoot());
+        }
+
+        public List<Row> getBody() {
+            return convertRows(delegate.getBody());
+        }
+
+        private List<Row> convertRows(List<?> rows) {
+            List<Row> result = new ArrayList<Row>(rows.size());
+            for (int i = 0; i < rows.size(); i++) {
+                List<? extends IRubyObject> rubyRow = (List<? extends IRubyObject>) rows.get(i);
+                result.add(convertRow(rubyRow));
+            }
+            return result;
+        }
+
+        private Row convertRow(List<? extends IRubyObject> rubyRow) {
+            List<Cell> cells = new ArrayList<Cell>(rubyRow.size());
+            for (int j = 0; j < rubyRow.size(); j++) {
+                IRubyObject rubyCell = rubyRow.get(j);
+                cells.add((Cell) NodeConverter.createASTNode(rubyCell));
+            }
+            return new RowImpl(cells, rubyRuntime);
+        }
+
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -16,8 +16,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.Column;
 import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.Row;
 import org.asciidoctor.ast.Section;
+import org.asciidoctor.ast.Table;
 import org.asciidoctor.internal.IOUtils;
 import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.util.ClasspathResources;
@@ -219,6 +222,67 @@ public class WhenAsciiDocIsRenderedToDocument {
         Section section = (Section) document.blocks().get(0);
         assertEquals(1, section.getBlocks().size());
         assertEquals("<strong>Section A</strong> paragraph.", section.getBlocks().get(0).getContent());
+    }
+
+    @Test
+    public void should_load_document_with_table() throws Exception {
+
+        final String doc = "= Test\n" +
+            "\n" +
+            "== Section \n" +
+            "\n" +
+            "[options=\"header,footer\"]\n" +
+            "[cols=\"<,>\"]\n" +
+            "|===\n" +
+            "| A | B\n" +
+            "\n" +
+            "| C\n" +
+            "| D\n" +
+            "\n" +
+            "| E\n" +
+            "| F\n" +
+            "\n" +
+            "| G | H\n" +
+            "|===\n";
+
+        Document document = asciidoctor.load(doc, OptionsBuilder.options().asMap());
+
+        Table table = (Table) document.getBlocks().get(0).getBlocks().get(0);
+
+        List<Row> header = table.getHeader();
+        assertThat(header, hasSize(1));
+
+        Row headerRow = header.get(0);
+        assertThat(headerRow.getCells(), hasSize(2));
+        assertThat(headerRow.getCells().get(0).getText(), is("A"));
+        assertThat(headerRow.getCells().get(1).getText(), is("B"));
+
+        List<Row> footer = table.getFooter();
+        assertThat(footer, hasSize(1));
+
+        Row footerRow = footer.get(0);
+        assertThat(footerRow.getCells(), hasSize(2));
+        assertThat(footerRow.getCells().get(0).getText(), is("G"));
+        assertThat(footerRow.getCells().get(1).getText(), is("H"));
+
+        List<Row> body = table.getBody();
+        assertThat(body, hasSize(2));
+
+        Row firstBodyRow = body.get(0);
+        assertThat(firstBodyRow.getCells(), hasSize(2));
+        assertThat(firstBodyRow.getCells().get(0).getText(), is("C"));
+        assertThat(firstBodyRow.getCells().get(1).getText(), is("D"));
+
+        Row secondBodyRow = body.get(1);
+        assertThat(secondBodyRow.getCells(), hasSize(2));
+        assertThat(secondBodyRow.getCells().get(0).getText(), is("E"));
+        assertThat(secondBodyRow.getCells().get(1).getText(), is("F"));
+
+        List<Column> columns = table.getColumns();
+        assertThat(columns, hasSize(2));
+
+        assertThat(columns.get(0).getHorizontalAlignment(), is(Table.HorizontalAlignment.LEFT));
+        assertThat(columns.get(1).getHorizontalAlignment(), is(Table.HorizontalAlignment.RIGHT));
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenStructuredDocumentIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenStructuredDocumentIsRequired.java
@@ -190,4 +190,16 @@ public class WhenStructuredDocumentIsRequired {
 		assertThat(parts, hasSize(0));
 	}
 
+	@Test
+	public void document_with_table_should_be_read() {
+		final String doc = "= Test\n" +
+			"\n" +
+			"|===\n" +
+			"| A | B\n" +
+			"|===\n";
+
+		StructuredDocument document = asciidoctor.readDocumentStructure(doc, new HashMap<String, Object>());
+
+	}
+
 }


### PR DESCRIPTION
This PR fixes #472 by adding interfaces and classes for Tables to the AST classes.
In contrast to the imply in the AsciidoctorJ 1.6.0 branch however this does not add support for creating Tables from a Processor.
This would imo require to downport all changes made on the AST classes for the 1.6.0 branch to 1.5.x.
