### PR TITLE
Fixes #473. Upgrade asciidoctor-diagram to 1.5.0.

### DIFF
--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=1.3.1
+version=1.5.0
 gem_name=asciidoctor-diagram

--- a/asciidoctorj-diagram/src/test/java/org/asciidoctor/WhenDocumentContainsDitaaDiagram.java
+++ b/asciidoctorj-diagram/src/test/java/org/asciidoctor/WhenDocumentContainsDitaaDiagram.java
@@ -21,7 +21,7 @@ public class WhenDocumentContainsDitaaDiagram {
     public void png_should_be_rendered_for_diagram() {
         File inputFile = classpath.getResource("sample.adoc");
         File outputFile1 = new File(inputFile.getParentFile(), "asciidoctor-diagram-process.png");
-        File outputFile2 = new File(inputFile.getParentFile(), "asciidoctor-diagram-process.png.cache");
+        File outputFile2 = new File(inputFile.getParentFile(), ".asciidoctor/diagram/asciidoctor-diagram-process.png.cache");
         asciidoctor.requireLibrary("asciidoctor-diagram");
         asciidoctor.convertFile(inputFile, options().backend("html5").get());
         assertThat(outputFile1.exists(), is(true));

--- a/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenDitaaDiagramIsRendered.java
+++ b/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenDitaaDiagramIsRendered.java
@@ -38,7 +38,9 @@ public class WhenDitaaDiagramIsRendered {
         // then:
         assertThat(result, containsString("src=\"" + imageFileName + ".png\""));
         assertThat("PNG file not created!", new File("build/" + imageFileName + ".png").exists(), is(true));
-        assertThat("PNG cache file not created!", new File("build/" + imageFileName + ".png.cache").exists(), is(true));
+
+        File cacheFile = new File(".asciidoctor/diagram/" + imageFileName + ".png.cache");
+        assertThat("PNG cache file " + cacheFile + " not created!", cacheFile.exists(), is(true));
     }
 
     @Test
@@ -66,7 +68,7 @@ public class WhenDitaaDiagramIsRendered {
         assertThat(destinationFile.exists(), is(true));
         assertThat(destinationFile.length(), greaterThan(0L));
         assertThat("PNG file not created!", new File("build/" + imageFileName + ".png").exists(), is(true));
-        assertThat("PNG cache file not created!", new File("build/" + imageFileName + ".png.cache").exists(), is(true));
+        assertThat("PNG cache file not created!", new File("build/.asciidoctor/diagram/" + imageFileName + ".png.cache").exists(), is(true));
     }
 
     private String getTestDocument(String imageFileName) {

--- a/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenPlantumlDiagramIsRendered.java
+++ b/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenPlantumlDiagramIsRendered.java
@@ -37,7 +37,8 @@ public class WhenPlantumlDiagramIsRendered {
         // then:
         assertThat(result, containsString("src=\"" + imageFileName + ".png\""));
         assertThat("PNG file not created!", new File("build/" + imageFileName + ".png").exists(), is(true));
-        assertThat("PNG cache file not created!", new File("build/" + imageFileName + ".png.cache").exists(), is(true));
+        File cacheFile = new File(".asciidoctor/diagram/" + imageFileName + ".png.cache");
+        assertThat("PNG cache file " + cacheFile + " not created!", cacheFile.exists(), is(true));
     }
 
     @Test
@@ -65,7 +66,7 @@ public class WhenPlantumlDiagramIsRendered {
         assertThat(destinationFile.exists(), is(true));
         assertThat(destinationFile.length(), greaterThan(0L));
         assertThat("PNG file not created!", new File("build/" + imageFileName + ".png").exists(), is(true));
-        assertThat("PNG cache file not created!", new File("build/" + imageFileName + ".png.cache").exists(), is(true));
+        assertThat("PNG cache file not created!", new File("build/.asciidoctor/diagram/" + imageFileName + ".png.cache").exists(), is(true));
     }
 
     private String getTestDocument(String imageFileName) {


### PR DESCRIPTION
Apparently the cache files are no longer located in the `imagesoutdir` but in the current working directory below `.asciidoctor/diagram/`.