### PR TITLE
Fixes #492. Deprecate Processor.CONTENT_MODEL_* and moved @ContentMod…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ContentModel.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ContentModel.java
@@ -1,4 +1,4 @@
-package org.asciidoctor.extension;
+package org.asciidoctor.ast;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -26,6 +26,24 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ContentModel {
+
+    /**
+     * This value is used as the config option key to configure how Asciidoctor should treat blocks created by
+     * this Processor.
+     * Its value must be a String constant.
+     *
+     * <p>Example to Asciidoctor know that a BlockProcessor creates zero or more child blocks:
+     * <pre>
+     * <verbatim>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put(ContentModel.KEY, ContentModel.COMPOUND);
+     * BlockProcessor blockProcessor = new BlockProcessor("foo", config);
+     * asciidoctor.javaExtensionRegistry().block(blockProcessor);
+     * </verbatim>
+     * </pre>
+     * </p>
+     */
+    public static final String KEY = "content_model";
 
     /**
      * Predefined constant to let Asciidoctor know that this BlockProcessor creates zero or more child blocks.

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
@@ -34,48 +34,65 @@ public class Processor {
      * <pre>
      * <verbatim>
      * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
-     * config.put(CONTENT_MODEL, CONTENT_MODEL_COMPOUND);
+     * config.put(CONTENT_MODEL, ContentModel.COMPOUND);
      * BlockProcessor blockProcessor = new BlockProcessor("foo", config);
      * asciidoctor.javaExtensionRegistry().block(blockProcessor);
      * </verbatim>
      * </pre>
      * </p>
+     *
+     * @deprecated Use the constant {@link ContentModel#KEY} instead or the annotation {@link ContentModel} to describe this Processor
      */
+    @Deprecated
     public static final String CONTENT_MODEL = "content_model";
 
     /**
      * Predefined constant to let Asciidoctor know that this BlockProcessor creates zero or more child blocks.
+     * @deprecated Use {@link ContentModel#COMPOUND} instead.
      */
+    @Deprecated
     public static final String CONTENT_MODEL_COMPOUND = ":compound";
 
     /**
      * Predefined constant to let Asciidoctor know that this BlockProcessor creates simple paragraph content.
+     * @deprecated Use {@link ContentModel#SIMPLE} instead.
      */
+    @Deprecated
     public static final String CONTENT_MODEL_SIMPLE =":simple";
 
     /**
      * Predefined constant to let Asciidoctor know that this BlockProcessor creates literal content.
+     * @deprecated Use {@link ContentModel#VERBATIM} instead.
      */
+    @Deprecated
     public static final String CONTENT_MODEL_VERBATIM =":verbatim";
 
     /**
      * Predefined constant to make Asciidoctor pass through the content unprocessed.
+     * @deprecated Use {@link ContentModel#RAW} instead.
      */
+    @Deprecated
     public static final String CONTENT_MODEL_RAW =":raw";
 
     /**
      * Predefined constant to make Asciidoctor drop the content.
+     * @deprecated Use {@link ContentModel#SKIP} instead.
      */
+    @Deprecated
     public static final String CONTENT_MODEL_SKIP =":skip";
 
     /**
      * Predefined constant to make Asciidoctor not expect any content.
+     * @deprecated Use {@link ContentModel#EMPTY} instead.
      */
+    @Deprecated
     public static final String CONTENT_MODEL_EMPTY =":empty";
 
     /**
      * Predefined constant to make Asciidoctor parse content as attributes.
+     * @deprecated Use {@link ContentModel#ATTRIBUTES} instead.
      */
+    @Deprecated
     public static final String CONTENT_MODEL_ATTRIBUTES =":attributes";
 
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension.processorproxies;
 
 import org.asciidoctor.ast.impl.ContentNodeImpl;
-import org.asciidoctor.extension.ContentModel;
+import org.asciidoctor.ast.ContentModel;
 import org.asciidoctor.extension.Contexts;
 import org.asciidoctor.extension.DefaultAttribute;
 import org.asciidoctor.extension.DefaultAttributes;

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockProcessor.groovy
@@ -1,6 +1,7 @@
 package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
+import org.asciidoctor.ast.ContentModel
 import org.asciidoctor.ast.StructuralNode
 
 @CompileStatic

--- a/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
+++ b/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
@@ -563,7 +563,7 @@ The AST is built from the following types:
   .. `literal`
   .. `open`
   .. `example`
-  .. `pass``
+  .. `pass`
 
 `org.asciidoctor.ast.List`::
   The list node is the container for ordered and unordered lists.

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/YellBlockProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/YellBlockProcessor.java
@@ -2,7 +2,7 @@ package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.BlockProcessor;
-import org.asciidoctor.extension.ContentModel;
+import org.asciidoctor.ast.ContentModel;
 import org.asciidoctor.extension.Contexts;
 import org.asciidoctor.extension.Name;
 import org.asciidoctor.extension.Reader;

--- a/docs/integrator-guide.adoc
+++ b/docs/integrator-guide.adoc
@@ -682,7 +682,7 @@ The AST is built from the following types:
   .. `literal`
   .. `open`
   .. `example`
-  .. `pass``
+  .. `pass`
 
 `org.asciidoctor.ast.List`::
   The list node is the container for ordered and unordered lists.


### PR DESCRIPTION
…el to org.asciidoctor.ast.

Also fixed a minor formatting bug in the integrator guide.