### PR TITLE
added sdkman verndors plugin

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'application'
 
+if (project.statusIsRelease) {
+    apply from: rootProject.file('gradle/sdkman.gradle')
+}
+
 dependencies {
   compile project(':asciidoctorj')
   compile project(':asciidoctorj-diagram')

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,14 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath "com.github.jruby-gradle:jruby-gradle-plugin:0.1.17"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7"
+        classpath "gradle.plugin.io.sdkman:gradle-sdkvendor-plugin:1.1.0"
     }
 }
 
@@ -71,7 +75,7 @@ subprojects {
     }
     apply from: rootProject.file('gradle/deploy.gradle')
   }
-  
+
   status = _status
 
   // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle

--- a/gradle/sdkman.gradle
+++ b/gradle/sdkman.gradle
@@ -1,0 +1,10 @@
+apply plugin: "io.sdkman.vendors"
+
+sdkman {
+    consumerKey = project.sdkman_consumer_key
+    consumerToken = project.sdkman_consumer_token
+    candidate = rootProject.name
+    version = rootProject.version
+    url = "https://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/$rootProject.version/$distZip.archiveName"
+    hashtag = "#asciidoctorj"
+}

--- a/gradle/sdkman.gradle
+++ b/gradle/sdkman.gradle
@@ -5,6 +5,30 @@ sdkman {
     consumerToken = project.sdkman_consumer_token
     candidate = rootProject.name
     version = rootProject.version
-    url = "https://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/$rootProject.version/$distZip.archiveName"
     hashtag = "#asciidoctorj"
+}
+
+afterEvaluate {
+    sdkman.url = "https://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/$rootProject.version/$distZip.archiveName"
+}
+
+task distributionAvailable() {
+    group = "Verification"
+    description = "Check if distribution is available on bintray"
+
+    doLast {
+        String errorMsg = "Distribution is not available at $sdkman.url"
+
+        HttpURLConnection connection = sdkman.url.toURL().openConnection()
+        connection.setRequestMethod("HEAD")
+        connection.connect()
+
+        if ( connection.responseCode != 200 ){
+            throw new GradleException(errorMsg)
+        }
+    }
+}
+
+tasks.findAll{ it.name ==~ /sdk.*(Release|Version)/ }.each {
+    it.dependsOn distributionAvailable
 }


### PR DESCRIPTION
Configure your local gradle.properties file with the following credentials.

* sdkman_consumer_key=_some_key_
* sdkman_consumer_token=_some_token_

Adds the following Tasks to the configuration if project status is 'release'.
See project.statusIsRelease.

* _sdkAnnounceVersion_ - Announce a Release on SDKMAN.

* _sdkDefaultVersion_ - Make an existing Candidate Version the new Default on SDKMAN.

* _sdkReleaseVersion_ - Release a new Candidate Version on SDKMAN.

* _sdkMajorRelease_ - Convenience task performs a Major Release consisting of Release, Default and Announce combined.

* _sdkMinorRelease_ - Convenience task performs a Minor Release consisting of Release and Announce combined

See https://github.com/sdkman/sdkman-vendor-gradle-plugin for more information.