### PR TITLE
Fixes #497. Patch Asciidoctor::AbstractBlock#section? in abstract_blo…

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -27,6 +27,14 @@ def gemFiles = fileTree(jruby.gemInstallDir) {
 jrubyPrepareGems << {
   copy { // bundles the gems inside this artifact
     from gemFiles
+    eachFile {
+      // See https://github.com/asciidoctor/asciidoctorj/issues/497
+      if (it.path ==~ /gems\/asciidoctor-.+\/lib\/asciidoctor\/abstract_block.rb/) {
+        it.filter { line ->
+          line.replaceAll(/block.context == :section/, 'block.context.to_sym == :section')
+        }
+      }
+    }
     into sourceSets.main.output.resourcesDir
   }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -1,15 +1,13 @@
 package org.asciidoctor.ast;
 
-import java.util.List;
-import java.util.Map;
-
-import org.asciidoctor.converter.ConverterProxy;
 import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyObject;
-import org.jruby.javasupport.JavaEmbedUtils;
+
+import java.util.List;
+import java.util.Map;
 
 public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock {
 
@@ -42,6 +40,10 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     @Override
     public String getStyle() {
         return delegate.getStyle();
+    }
+
+    public String getCaption() {
+        return RubyUtils.invokeRubyMethod(delegate, "caption", new Object[0], String.class);
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/SectionImpl.java
@@ -1,6 +1,9 @@
 package org.asciidoctor.ast;
 
+import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
+
+import java.util.List;
 
 public class SectionImpl extends AbstractBlockImpl implements Section {
 
@@ -36,4 +39,27 @@ public class SectionImpl extends AbstractBlockImpl implements Section {
         return this.delegate.number();
     }
 
+    public String sectnum() {
+        return RubyUtils.invokeRubyMethod(delegate, "sectnum", new Object[0], String.class);
+    }
+
+    public String sectnum(String delimiter) {
+        return RubyUtils.invokeRubyMethod(delegate, "sectnum", new Object[]{delimiter}, String.class);
+    }
+
+    public String sectnum(String delimiter, boolean append) {
+        return RubyUtils.invokeRubyMethod(delegate, "sectnum", new Object[]{delimiter, append}, String.class);
+    }
+
+    public List<Section> getSections() {
+        return RubyUtils.invokeRubyMethod(delegate, "sections", new Object[0], List.class);
+    }
+
+    public boolean isSections() {
+        return RubyUtils.invokeRubyMethod(delegate, "sections?", new Object[0], Boolean.class);
+    }
+
+    public String getCaptionedTitle() {
+        return RubyUtils.invokeRubyMethod(delegate, "captioned_title", new Object[0], String.class);
+    }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyUtils.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyUtils.java
@@ -7,6 +7,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.RubySymbol;
 import org.jruby.internal.runtime.GlobalVariable.Scope;
+import org.jruby.java.proxies.RubyObjectHolderProxy;
 import org.jruby.javasupport.JavaClass;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.GlobalVariable;
@@ -39,6 +40,19 @@ public class RubyUtils {
     public static final void setGlobalVariable(Ruby rubyRuntime, String variableName, Object variableValue) {
         String script = String.format("$%s = %s", variableName, variableValue);
         rubyRuntime.evalScriptlet(script);
+    }
+
+    public static <T> T invokeRubyMethod(final Object target, final String methodName, final Object[] args, final Class<T> resultType) {
+        IRubyObject rubyObject = null;
+        if (target instanceof RubyObjectHolderProxy) {
+            rubyObject = RubyObjectHolderProxy.class.cast(target).__ruby_object();
+        } else if (target instanceof IRubyObject) {
+            rubyObject = (IRubyObject) target;
+        }
+        if (rubyObject != null) {
+            return (T) JavaEmbedUtils.invokeMethod(rubyObject.getRuntime(), rubyObject, methodName, args, resultType);
+        }
+        throw new IllegalArgumentException("Target is a " + target.getClass() + " instead of a Ruby object.");
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.ast.DocumentRuby;
@@ -389,6 +390,24 @@ public class WhenJavaExtensionIsRegistered {
         assertThat(contentElement.text(), is("gem install asciidoctor"));
 
     }
+
+    /**
+     * See https://github.com/asciidoctor/asciidoctorj/issues/497.
+     */
+    @Test
+    public void when_using_a_tree_processor_a_toc_should_still_be_created() {
+
+        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+
+        javaExtensionRegistry.treeprocessor(TerminalCommandTreeprocessor.class);
+
+        String content = asciidoctor.renderFile(
+            classpath.getResource("sample-with-sections.ad"),
+            options().toFile(false)
+                .attributes(AttributesBuilder.attributes().tableOfContents(true))
+                .get());
+    }
+
 
     @Test
     public void a_treeprocessor_as_string_should_be_executed_in_document() {

--- a/asciidoctorj-core/src/test/resources/sample-with-sections.ad
+++ b/asciidoctorj-core/src/test/resources/sample-with-sections.ad
@@ -1,0 +1,15 @@
+= Hello World
+
+Some text
+
+== Section A
+
+More text
+
+=== Subsection A1
+
+Subsections are also so important.
+
+== Section B
+
+And even more text


### PR DESCRIPTION
…ck.rb to return context by string instead of Symbol because Java blocks always return strings.

There's a problem currently in the way AsciidoctorJ 1.5.x sits on top of Asciidoctor:
It replaces all blocks in the AST once touched by a processor by their Java counterparts, which is necessary.
This makes it impossible for public methods exposed via the Java API to return Ruby specifics like for example Ruby Symbols.

There's a recent change in Asciidoctor 1.5.4 that uses the result of `Asciidoctor::AbstractBlock#context` and compares it to `:section`.
As the Java object returns a String instead of a Symbol this test always fails and therefore the error described in asciidoctor/asciidoctor-maven-plugin#258 and filed in #497 occurs.

This PR fixes this by 
1. patching abstract_block.rb to compare the String representation of the symbol instead of the symbol
2. Implementing the methods in SectionImpl and AbstractBlockImpl necessary to build a table of contents.

Also tested locally building the asciidoctor-maven-plugin.