### PR TITLE
Add missing method implementations to Java AST classes and fixed some…

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -29,10 +29,9 @@ jrubyPrepareGems << {
     from gemFiles
     eachFile {
       // See https://github.com/asciidoctor/asciidoctorj/issues/497
-      if (it.path ==~ /gems\/asciidoctor-.+\/lib\/asciidoctor\/.*\.rb/) {
+      if (it.path ==~ /gems\/asciidoctor-.+\/lib\/asciidoctor\/abstract_block.rb/) {
         it.filter { line ->
-          line.replaceAll(/\.context /, '.context.to_sym ')
-                  .replaceAll(/\.context\)/, '.context.to_sym)')
+          line.replaceAll(/block.context == :section/, 'block.context.to_sym == :section')
         }
       }
     }

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -29,9 +29,10 @@ jrubyPrepareGems << {
     from gemFiles
     eachFile {
       // See https://github.com/asciidoctor/asciidoctorj/issues/497
-      if (it.path ==~ /gems\/asciidoctor-.+\/lib\/asciidoctor\/abstract_block.rb/) {
+      if (it.path ==~ /gems\/asciidoctor-.+\/lib\/asciidoctor\/.*\.rb/) {
         it.filter { line ->
-          line.replaceAll(/block.context == :section/, 'block.context.to_sym == :section')
+          line.replaceAll(/\.context /, '.context.to_sym ')
+                  .replaceAll(/\.context\)/, '.context.to_sym)')
         }
       }
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractBlockImpl.java
@@ -32,6 +32,10 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
         return delegate.getTitle();
     }
 
+    public boolean isTitle() {
+        return RubyUtils.invokeRubyMethod(delegate, "title?", new Object[0], Boolean.class);
+    }
+
     @Override
     public String style() {
         return getStyle();
@@ -66,6 +70,10 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
         return rubyBlocks;
     }
 
+    public boolean isBlocks() {
+        return RubyUtils.invokeRubyMethod(delegate, "blocks?", new Object[0], Boolean.class);
+    }
+
     @Override
     public Object content() {
         return getContent();
@@ -94,6 +102,14 @@ public class AbstractBlockImpl extends AbstractNodeImpl implements AbstractBlock
     @Override
     public AbstractBlock delegate() {
         return delegate;
+    }
+
+    public List<Section> getSections() {
+        return RubyUtils.invokeRubyMethod(delegate, "sections", new Object[0], List.class);
+    }
+
+    public boolean isSections() {
+        return RubyUtils.invokeRubyMethod(delegate, "sections?", new Object[0], Boolean.class);
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/BlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/BlockImpl.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.ast;
 
-import java.util.List;
-
 import org.jruby.Ruby;
+
+import java.util.List;
 
 public class BlockImpl extends AbstractBlockImpl implements Block {
     private Block blockDelegate;
@@ -20,5 +20,9 @@ public class BlockImpl extends AbstractBlockImpl implements Block {
     @Override
     public String source() {
         return blockDelegate.source();
+    }
+
+    public String getBlockname() {
+        return getContext();
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListImpl.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.ast;
 
+import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 
 import java.util.List;
@@ -19,8 +20,15 @@ public class ListImpl extends AbstractBlockImpl implements ListNode {
     }
 
     @Override
-    public boolean isItem() {
-        return isBlock();
+    public boolean hasItems() {
+        return isItems();
+    }
+
+    /**
+     * This method will be invoked by Ruby.
+     */
+    public boolean isItems() {
+        return isBlocks();
     }
 
     @Override
@@ -31,5 +39,10 @@ public class ListImpl extends AbstractBlockImpl implements ListNode {
     @Override
     public String convert() {
         return listDelegate.convert();
+    }
+
+    public boolean isOutline() {
+        final String context = getContext();
+        return "ulist".equals(context) || "olist".equals(context);
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItemImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItemImpl.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.ast;
 
+import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 
 public class ListItemImpl extends AbstractBlockImpl implements ListItem {
@@ -23,6 +24,18 @@ public class ListItemImpl extends AbstractBlockImpl implements ListItem {
 
     @Override
     public boolean hasText() {
-        return listDelegate.hasText();
+        return isText();
+    }
+
+    public boolean isText() {
+        return RubyUtils.invokeRubyMethod(delegate, "text?", new Object[0], Boolean.class);
+    }
+
+    public boolean isSimple() {
+        return RubyUtils.invokeRubyMethod(delegate, "simple?", new Object[0], Boolean.class);
+    }
+
+    public boolean isCompound() {
+        return RubyUtils.invokeRubyMethod(delegate, "compound?", new Object[0], Boolean.class);
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListNode.java
@@ -4,7 +4,7 @@ public interface ListNode extends AbstractBlock {
 
     java.util.List<AbstractBlock> getItems();
 
-    boolean isItem();
+    boolean hasItems();
 
     @Deprecated
     public String render();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Section.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Section.java
@@ -6,5 +6,5 @@ public interface Section extends AbstractBlock {
     int number();
     String sectname();
     boolean special();
-    int numbered();
+    boolean numbered();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/SectionImpl.java
@@ -35,8 +35,8 @@ public class SectionImpl extends AbstractBlockImpl implements Section {
     }
 
     @Override
-    public int numbered() {
-        return this.delegate.number();
+    public boolean numbered() {
+        return RubyUtils.invokeRubyMethod(delegate, "numbered", new Object[0], Boolean.class);
     }
 
     public String sectnum() {
@@ -51,15 +51,15 @@ public class SectionImpl extends AbstractBlockImpl implements Section {
         return RubyUtils.invokeRubyMethod(delegate, "sectnum", new Object[]{delimiter, append}, String.class);
     }
 
-    public List<Section> getSections() {
-        return RubyUtils.invokeRubyMethod(delegate, "sections", new Object[0], List.class);
-    }
-
-    public boolean isSections() {
-        return RubyUtils.invokeRubyMethod(delegate, "sections?", new Object[0], Boolean.class);
-    }
-
     public String getCaptionedTitle() {
         return RubyUtils.invokeRubyMethod(delegate, "captioned_title", new Object[0], String.class);
+    }
+
+    public String generateId() {
+        return RubyUtils.invokeRubyMethod(delegate, "generate_id", new Object[0], String.class);
+    }
+
+    public String getName() {
+        return getTitle();
     }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TouchEverythingTreeprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TouchEverythingTreeprocessor.java
@@ -1,0 +1,39 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.Block;
+import org.asciidoctor.ast.Document;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This Treeprocessor doesn't do anything useful but only touch every node in the
+ * AST so that the whole tree contains nothing but Java AST nodes instead of the Ruby originals.
+ * This should reveal misalignments in the between the Ruby AST classes and their Java counterparts.
+ */
+public class TouchEverythingTreeprocessor extends Treeprocessor {
+
+    public TouchEverythingTreeprocessor(Map<String, Object> config) {
+        super(config);
+    }
+
+    @Override
+    public Document process(Document document) {
+
+        touch(document);
+
+        return document;
+    }
+
+    public void touch(AbstractBlock block) {
+
+        if (block.getBlocks() != null) {
+            for (AbstractBlock abstractBlock : block.getBlocks()) {
+                touch(abstractBlock);
+            }
+        }
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -395,15 +395,31 @@ public class WhenJavaExtensionIsRegistered {
      * See https://github.com/asciidoctor/asciidoctorj/issues/497.
      */
     @Test
-    public void when_using_a_tree_processor_a_toc_should_still_be_created() {
+    public void when_using_a_tree_processor_a_toc_should_still_be_created_when_rendering_to_html() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.treeprocessor(TerminalCommandTreeprocessor.class);
+        javaExtensionRegistry.treeprocessor(TouchEverythingTreeprocessor.class);
 
         String content = asciidoctor.renderFile(
             classpath.getResource("sample-with-sections.ad"),
             options().toFile(false)
+                .backend("html")
+                .attributes(AttributesBuilder.attributes().tableOfContents(true))
+                .get());
+    }
+
+    @Test
+    public void when_using_a_tree_processor_a_toc_should_still_be_created_when_rendering_to_docbook() {
+
+        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+
+        javaExtensionRegistry.treeprocessor(TouchEverythingTreeprocessor.class);
+
+        String content = asciidoctor.renderFile(
+            classpath.getResource("sample-with-sections.ad"),
+            options().toFile(false)
+                .backend("docbook")
                 .attributes(AttributesBuilder.attributes().tableOfContents(true))
                 .get());
     }

--- a/asciidoctorj-core/src/test/resources/sample-with-sections.ad
+++ b/asciidoctorj-core/src/test/resources/sample-with-sections.ad
@@ -10,6 +10,20 @@ More text
 
 Subsections are also so important.
 
+* And unordered lists
+* are also very important
+
+. and numbered ones
+. too
+
 == Section B
 
 And even more text
+
+|===
+| A | Table
+
+| is | also
+| a  | nice
+| thing | !
+|===


### PR DESCRIPTION
… misalignments.

As a continuation of #498 this adds more methods missing in the Java AST classes that are required if nodes are touched once by a Treeprocessor.

Additionally all occurrences of .context are now replaced with .context.to_sym.
The contexts of content created by Blockmacros could for example never be handled correctly by the parser.

This PR should also fix the second issue mentioned in #497 .