### PR TITLE
Multiple small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 build/
 target/
 .classpath

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/StructuralNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/StructuralNode.java
@@ -80,6 +80,15 @@ public interface StructuralNode extends ContentNode {
     int getLevel();
 
     /**
+     * Returns the content model.
+     *
+     * @see ContentModel
+     *
+     * @return the content model
+     */
+    String getContentModel();
+
+    /**
      * Returns the source location of this block.
      * This information is only available if the {@code sourcemap} option is enabled when loading or rendering the document.
      * @return the source location of this block or {@code null} if the {@code sourcemap} option is not enabled when loading the document.

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
@@ -70,7 +70,10 @@ public class CellImpl extends ContentNodeImpl implements Cell {
 
     @Override
     public Document getInnerDocument() {
-        return (Document) NodeConverter.createASTNode(getRubyProperty("inner_document"));
+        IRubyObject innerDocument = getRubyProperty("inner_document");
+        if (innerDocument.isNil())
+        	return null;
+		return (Document) NodeConverter.createASTNode(innerDocument);
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
@@ -71,8 +71,9 @@ public class CellImpl extends ContentNodeImpl implements Cell {
     @Override
     public Document getInnerDocument() {
         IRubyObject innerDocument = getRubyProperty("inner_document");
-        if (innerDocument.isNil())
+        if (innerDocument.isNil()) {
         	return null;
+        }
 		return (Document) NodeConverter.createASTNode(innerDocument);
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/StructuralNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/StructuralNodeImpl.java
@@ -15,7 +15,7 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
 
     private static final String BLOCK_CLASS = "Block";
     private static final String SECTION_CLASS = "Section";
-    
+
     public StructuralNodeImpl(IRubyObject blockDelegate) {
         super(blockDelegate);
     }
@@ -89,6 +89,11 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
             return null;
         }
         return new CursorImpl(object);
+    }
+
+    @Override
+    public String getContentModel() {
+    	return getString("content_model");
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyHashUtil.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyHashUtil.java
@@ -161,7 +161,7 @@ public class RubyHashUtil {
         if (value instanceof List) {
             return toRubyArray(rubyRuntime, (List<Object>) value);
         } else if (value instanceof Map) {
-        	return convertMapToRubyHashWithSymbolsIfNecessary(rubyRuntime, (Map<Object, Object>) value);
+        	return convertMapToRubyHashWithStrings(rubyRuntime, (Map<String, Object>) value);
         } else {
 
             if (isNotARubySymbol(value)) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyHashUtil.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyHashUtil.java
@@ -160,6 +160,8 @@ public class RubyHashUtil {
 
         if (value instanceof List) {
             return toRubyArray(rubyRuntime, (List<Object>) value);
+        } else if (value instanceof Map) {
+        	return convertMapToRubyHashWithSymbolsIfNecessary(rubyRuntime, (Map<Object, Object>) value);
         } else {
 
             if (isNotARubySymbol(value)) {

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenATableIsLoaded.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenATableIsLoaded.groovy
@@ -4,7 +4,9 @@ import org.asciidoctor.ast.Document
 import org.asciidoctor.ast.Table
 import org.jboss.arquillian.spock.ArquillianSputnik
 import org.jboss.arquillian.test.api.ArquillianResource
+import org.jruby.exceptions.RaiseException
 import org.junit.runner.RunWith
+
 import spock.lang.Specification
 
 @RunWith(ArquillianSputnik)
@@ -55,4 +57,33 @@ class WhenATableIsLoaded extends Specification {
         tableNode.body[0].cells[0].colspan == 0
     }
 
+	def "asking a table cell for its inner document when it does not have one should return null"() {
+
+		given:
+		String document = '''= Test document
+
+[cols="40,60"]
+|===
+| Source | Output
+
+a|
+
+The first content cell
+
+a|
+
+The second content cell
+
+|===
+'''
+
+		when:
+		Document documentNode = asciidoctor.load(document, OptionsBuilder.options().headerFooter(false).asMap())
+		Table tableNode = documentNode.blocks[0]
+
+		then:
+		tableNode.header[0].cells[0].innerDocument == null
+		tableNode.header[0].cells[1].innerDocument == null
+		notThrown(RaiseException)
+	}
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockProcessorCreatesABlockThatATreeProcessorVisits.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockProcessorCreatesABlockThatATreeProcessorVisits.groovy
@@ -16,29 +16,29 @@ import spock.lang.Specification
 @RunWith(ArquillianSputnik)
 class WhenABlockProcessorCreatesABlockThatATreeProcessorVisits extends Specification {
 
-	@Name("tst")
+	@Name('tst')
 	@Contexts(Contexts.CONTEXT_OPEN)
 	@ContentModel(ContentModel.COMPOUND)
-	public static class BlockCreator extends BlockProcessor {
+	static class BlockCreator extends BlockProcessor {
 
 		@Override
-		public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
-			List<String> output = new LinkedList<>();
-			output.add("line 1");
-			output.add("line 2");
+		Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
+			List<String> output = new LinkedList<>()
+			output.add('line 1')
+			output.add('line 2')
 
-			attributes.put("name", "value");
+			attributes.put('name', 'value')
 
-			return createBlock(parent, "open", output, attributes);
+			createBlock(parent, 'open', output, attributes)
 		}
 	}
 
-	public static class BlockVisitor extends Treeprocessor {
+	static class BlockVisitor extends Treeprocessor {
 
 		@Override
-		public Document process(Document document) {
-			recurse(document);
-			return document;
+		Document process(Document document) {
+			recurse(document)
+			document
 		}
 
 		private void recurse(StructuralNode node) {
@@ -46,10 +46,14 @@ class WhenABlockProcessorCreatesABlockThatATreeProcessorVisits extends Specifica
 			// causes a ClassCastException in ContentNodeImpl#getAttributes since the value returned
 			// from the AbstractNode in the JRuby AST is an instance of MapJavaProxy, which does not
 			// conform to RubyHash.
-			Map<String, Object> attributes = node.getAttributes();
+			Map<String, Object> attributes = node.getAttributes()
 
-			for (Block block : node.getBlocks())
-				recurse(block);
+			// To silence Codenarc. We must access the attributes to provoke the error.
+			attributes = new HashMap<String, Object>(attributes)
+
+			for (Block block : node.getBlocks()) {
+				recurse(block)
+			}
 		}
 	}
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockProcessorCreatesABlockThatATreeProcessorVisits.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockProcessorCreatesABlockThatATreeProcessorVisits.groovy
@@ -1,0 +1,83 @@
+package org.asciidoctor.extension
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.SafeMode
+import org.asciidoctor.ast.Block
+import org.asciidoctor.ast.ContentModel
+import org.asciidoctor.ast.Document
+import org.asciidoctor.ast.StructuralNode
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.runner.RunWith
+
+import spock.lang.Specification
+
+@RunWith(ArquillianSputnik)
+class WhenABlockProcessorCreatesABlockThatATreeProcessorVisits extends Specification {
+
+	@Name("tst")
+	@Contexts(Contexts.CONTEXT_OPEN)
+	@ContentModel(ContentModel.COMPOUND)
+	public static class BlockCreator extends BlockProcessor {
+
+		@Override
+		public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
+			List<String> output = new LinkedList<>();
+			output.add("line 1");
+			output.add("line 2");
+
+			attributes.put("name", "value");
+
+			return createBlock(parent, "open", output, attributes);
+		}
+	}
+
+	public static class BlockVisitor extends Treeprocessor {
+
+		@Override
+		public Document process(Document document) {
+			recurse(document);
+			return document;
+		}
+
+		private void recurse(StructuralNode node) {
+			// Accessing the attributes of a block that was previously created by a block processor
+			// causes a ClassCastException in ContentNodeImpl#getAttributes since the value returned
+			// from the AbstractNode in the JRuby AST is an instance of MapJavaProxy, which does not
+			// conform to RubyHash.
+			Map<String, Object> attributes = node.getAttributes();
+
+			for (Block block : node.getBlocks())
+				recurse(block);
+		}
+	}
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    private static final String DOCUMENT = '''
+= Block and Tree Processor Interaction Test
+
+[tst]
+--
+This will be ignored
+--
+
+'''
+
+    def "execution should not throw class cast exception"() {
+
+        given:
+        asciidoctor.javaExtensionRegistry().block(BlockCreator)
+		asciidoctor.javaExtensionRegistry().treeprocessor(BlockVisitor)
+
+        when:
+        asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).headerFooter(true))
+
+        then:
+        notThrown(ClassCastException)
+    }
+
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -29,25 +29,25 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class WhenAsciiDocIsRenderedToDocument {
 
-    private static final String DOCUMENT = "= Document Title\n" + 
-            "\n" + 
-            "preamble\n" + 
-            "\n" + 
-            "== Section A\n" + 
-            "\n" + 
-            "paragraph\n" + 
-            "\n" + 
-            "--\n" + 
-            "Exhibit A::\n" + 
-            "+\n" + 
-            "[#tiger.animal]\n" + 
-            "image::tiger.png[Tiger]\n" + 
-            "--\n" + 
-            "\n" + 
-            "image::cat.png[Cat]\n" + 
-            "\n" + 
-            "== Section B\n" + 
-            "\n" + 
+    private static final String DOCUMENT = "= Document Title\n" +
+            "\n" +
+            "preamble\n" +
+            "\n" +
+            "== Section A\n" +
+            "\n" +
+            "paragraph\n" +
+            "\n" +
+            "--\n" +
+            "Exhibit A::\n" +
+            "+\n" +
+            "[#tiger.animal]\n" +
+            "image::tiger.png[Tiger]\n" +
+            "--\n" +
+            "\n" +
+            "image::cat.png[Cat]\n" +
+            "\n" +
+            "== Section B\n" +
+            "\n" +
             "paragraph";
 
     private static final String ROLE = "[\"quote\", \"author\", \"source\", role=\"famous\"]\n" +
@@ -74,34 +74,34 @@ public class WhenAsciiDocIsRenderedToDocument {
         assertThat(section.sectname(), is("sect1"));
         assertThat(section.special(), is(false));
     }
-    
+
     @Test
     public void should_return_blocks_from_a_document() {
-        
+
         Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
         assertThat(document.doctitle(), is("Document Title"));
-        
+
     }
-    
+
     @Test
     public void should_return_a_document_object_from_string() {
-        
+
         Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
         assertThat(document.doctitle(), is("Document Title"));
     }
-    
+
     @Test
     public void should_find_elements_from_document() {
-        
+
         Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
         Map<Object, Object> selector = new HashMap<Object, Object>();
         selector.put("context", ":image");
         List<StructuralNode> findBy = document.findBy(selector);
         assertThat(findBy, hasSize(2));
-        
+
         assertThat((String)findBy.get(0).getAttributes().get("target"), is("tiger.png"));
         assertThat(findBy.get(0).getLevel(), greaterThan(0));
-        
+
     }
 
     @Test
@@ -309,4 +309,31 @@ public class WhenAsciiDocIsRenderedToDocument {
         assertThat(section.hasAttr("docattr", false), is(false));
     }
 
+    @Test
+    public void should_get_content_model() {
+    	final String documentWithPreambleAndSection = ""
+    			+ "= Document Title\n"
+    			+ "\n"
+    			+ "A test document with a preamble and a section.\n"
+    			+ "\n"
+    			+ "The preamble contains multiple paragraphs to force the outer block to be compound.\n"
+    			+ "\n"
+    			+ "== First Section\n"
+    			+ "\n"
+    			+ "And herein lies the problem.\n"
+    			+ "\n";
+
+        Document document = asciidoctor.load(documentWithPreambleAndSection, new HashMap<String, Object>());
+        List<StructuralNode> blocks = document.getBlocks();
+
+        StructuralNode preambleContainer = blocks.get(0);
+        assertThat(preambleContainer.getContentModel(), is("compound"));
+
+        assertThat(preambleContainer.getBlocks().get(0).getContentModel(), is("simple"));
+        assertThat(preambleContainer.getBlocks().get(1).getContentModel(), is("simple"));
+
+        Section section = (Section) blocks.get(1);
+        assertThat(section.getContentModel(), is("compound"));
+        assertThat(section.getBlocks().get(0).getContentModel(), is("simple"));
+    }
 }


### PR DESCRIPTION
Sorry to submit multiple changes in one pull request (and not using branches), but I had to make these changes in quick succession and could not isolate them. They are independent of each other, however. There are three changes:

**Convert nested Java maps to Ruby hashes in `RubyHashUtil#toRubyObject`**
This prevents a `ClassCastException` when, after creating a new block in a block processor, you attempt to access the attributes of that block later in a tree processor. When asking the block for its attributes, AsciidoctorJ assumes that what it gets from the asciidoctor AST is an instance of `RubyHash`, when in this case what it really gets is an instance of ` MapJavaProxy` that was injected by JRuby into the asciidoctor AST when the block was created originally.

I'm not sure about this change, since I had to choose one of several different methods to convert Java maps to Ruby hashes in `RubyHashUtil`.

**Return `null` if the inner document of a table cell is `nil`**
This prevents a `NullPointerException` when attempting to access the inner document of a table cell in a processor when that cell doesn't have an inner document in the asciidoctor AST.

**Add getter for `@content_model`**
This adds a getter for the `@content_model` attribute of an asciidoctor `AbstractBlock` to `StructuralNode`.

I hope these changes are useful for you and that you can apply them. I have run the tests in the asciidoctorj-asciidoctorj and asciidoctorj-distribution projects and there were no failures.