### PR TITLE
Added method StructuralNode.setStyle() and added test to check that a…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/StructuralNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/StructuralNode.java
@@ -53,6 +53,8 @@ public interface StructuralNode extends ContentNode {
     String style();
     String getStyle();
 
+    void setStyle(String style);
+
     /**
      * @return The list of child blocks of this block
      * @deprecated Please use {@linkplain #getBlocks()} instead

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/StructuralNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/StructuralNodeImpl.java
@@ -46,6 +46,11 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     }
 
     @Override
+    public void setStyle(String style) {
+        setString("style", style);
+    }
+
+    @Override
     public List<StructuralNode> blocks() {
         return getBlocks();
     }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorCreatesNodes.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorCreatesNodes.groovy
@@ -1,0 +1,66 @@
+package org.asciidoctor.extension
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.ast.Document
+import org.asciidoctor.ast.StructuralNode
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.jsoup.Jsoup
+import org.jsoup.select.Elements
+import org.junit.runner.RunWith
+import spock.lang.Issue
+import spock.lang.Specification
+
+@RunWith(ArquillianSputnik)
+class WhenATreeProcessorCreatesNodes extends Specification {
+
+    public static final String NEW_CODE = 'puts "World"'
+
+    public static final String OLD_CODE = 'puts "Hello"'
+
+    public static final String ATTR_VALUE_LANGUAGE_RUBY = 'language-ruby'
+
+    public static final String ELEM_CODE = 'code'
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    @Issue('https://github.com/asciidoctor/asciidoctorj/issues/513')
+    def 'it should be able to copy attributes from another node'() {
+
+        given: 'A Asciidoctor document with one Ruby source block'
+        String document = '''== Test doc
+
+[source,ruby]
+----
+puts "Hello"
+----
+'''
+
+        and: 'a Treeprocessor that creates an additional source block passing the same attributes'
+        Treeprocessor tp = new Treeprocessor() {
+            @Override
+            Document process(Document doc) {
+                StructuralNode newSourceBlock = createBlock(doc.blocks[0], 'listing', NEW_CODE, doc.blocks[0].blocks[0].attributes)
+                // The style 'source' is visible in the attributes, but for new blocks it has to be set individually as a object property.
+                newSourceBlock.style = 'source'
+                doc.blocks[0].append(newSourceBlock)
+            }
+        }
+        asciidoctor.javaExtensionRegistry().treeprocessor(tp)
+
+        when: 'The document is converted'
+        String html = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(true))
+
+        then: 'The second source block uses the same value of the language attribute and highlight as Ruby'
+        org.jsoup.nodes.Document htmlDocument = Jsoup.parse(html)
+        Elements elements = htmlDocument.getElementsByTag(ELEM_CODE)
+        elements.size() == 2
+        elements.get(0).hasClass(ATTR_VALUE_LANGUAGE_RUBY)
+        elements.get(0).text() == OLD_CODE
+        elements.get(1).hasClass(ATTR_VALUE_LANGUAGE_RUBY)
+        elements.get(1).text() == NEW_CODE
+    }
+
+}


### PR DESCRIPTION
…ttributes are copied.

This PR contains a test to find the error described in #513.
Unfortunately I cannot reproduce the error, but we didn't have a test for that yet.
Maybe this PR serves as a discussion basis to find an error if there is one.

Additionally added the method `StructuralNode.setStyle` to set the style of a node, e.g. `style="source"` for blocks with `context=listing` to create formatted source blocks.