### PR TITLE
Add Cell.getRawText() and ListItem.getRawText() to get unsubstituted …

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
@@ -16,7 +16,7 @@ public interface Cell extends ContentNode {
     /**
      * @return The text of the cell without substitutions being applied.
      */
-    String getRawText();
+    String getSource();
 
     Object getContent();
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Cell.java
@@ -8,7 +8,15 @@ public interface Cell extends ContentNode {
 
     int getRowspan();
 
+    /**
+     * @return The text of the cell including substitutions being applied.
+     */
     String getText();
+
+    /**
+     * @return The text of the cell without substitutions being applied.
+     */
+    String getRawText();
 
     Object getContent();
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItem.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItem.java
@@ -12,7 +12,7 @@ public interface ListItem extends StructuralNode {
     /**
      * @return The text of the cell without substitutions being applied.
      */
-    public String getRawText();
+    public String getSource();
 
     public boolean hasText();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItem.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ListItem.java
@@ -4,7 +4,15 @@ public interface ListItem extends StructuralNode {
 
     public String getMarker();
 
+    /**
+     * @return The text of the cell including substitutions being applied.
+     */
     public String getText();
+
+    /**
+     * @return The text of the cell without substitutions being applied.
+     */
+    public String getRawText();
 
     public boolean hasText();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
@@ -34,6 +34,11 @@ public class CellImpl extends ContentNodeImpl implements Cell {
     }
 
     @Override
+    public String getRawText() {
+        return getString("@text");
+    }
+
+    @Override
     public Object getContent() {
         return toJava(getRubyProperty("content"));
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
@@ -34,7 +34,7 @@ public class CellImpl extends ContentNodeImpl implements Cell {
     }
 
     @Override
-    public String getRawText() {
+    public String getSource() {
         return getString("@text");
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListItemImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListItemImpl.java
@@ -21,6 +21,11 @@ public class ListItemImpl extends StructuralNodeImpl implements ListItem {
     }
 
     @Override
+    public String getRawText() {
+        return getString("@text");
+    }
+
+    @Override
     public boolean hasText() {
         return getBoolean("text?");
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListItemImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListItemImpl.java
@@ -21,7 +21,7 @@ public class ListItemImpl extends StructuralNodeImpl implements ListItem {
     }
 
     @Override
-    public String getRawText() {
+    public String getSource() {
         return getString("@text");
     }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheRawTextShouldBeRetrieved.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheRawTextShouldBeRetrieved.groovy
@@ -1,0 +1,94 @@
+package org.asciidoctor
+
+import org.asciidoctor.ast.Block
+import org.asciidoctor.ast.Cell
+import org.asciidoctor.ast.Document
+import org.asciidoctor.ast.List
+import org.asciidoctor.ast.ListItem
+import org.asciidoctor.ast.Table
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+/**
+ * Tests that the unsubstituted text can be retrieved from nodes
+ */
+@RunWith(ArquillianSputnik)
+class WhenTheRawTextShouldBeRetrieved extends Specification {
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    def 'it should be possible to get the raw text from a paragraph'() {
+
+        given:
+        String document = '''
+= Test
+:foo: bar
+
+== Section
+
+This paragraph should show {foo}
+
+'''
+        when:
+        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Block block = doc.blocks[0].blocks[0]
+
+        then:
+        block.lines == ['This paragraph should show {foo}']
+        block.content == 'This paragraph should show bar'
+    }
+
+    def 'it should be possible to get the raw text from a list item'() {
+
+        given:
+        String document = '''
+= Test
+:foo: bar
+
+== Section
+
+* This list item should show {foo}
+  and should continue here
+* This does not interest at all
+
+'''
+        when:
+        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        List list = doc.blocks[0].blocks[0]
+        ListItem listItem = list.items[0]
+
+        then:
+        listItem.rawText == '''This list item should show {foo}
+and should continue here'''
+        listItem.text == '''This list item should show bar
+and should continue here'''
+    }
+
+    def 'it should be possible to get the raw text from a table cell'() {
+
+        given:
+        String document = '''
+= Test
+:foo: bar
+
+== Section
+
+|===
+| Hello {foo}
+|===
+
+'''
+        when:
+        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Table table = doc.blocks[0].blocks[0]
+        Cell cell = table.body[0].cells[0]
+
+        then:
+        cell.rawText == 'Hello {foo}'
+        cell.text == 'Hello bar'
+    }
+
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheRawTextShouldBeRetrieved.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheRawTextShouldBeRetrieved.groovy
@@ -37,7 +37,7 @@ This paragraph should show {foo}
         Block block = doc.blocks[0].blocks[0]
 
         then:
-        block.lines == ['This paragraph should show {foo}']
+        block.source == 'This paragraph should show {foo}'
         block.content == 'This paragraph should show bar'
     }
 
@@ -61,7 +61,7 @@ This paragraph should show {foo}
         ListItem listItem = list.items[0]
 
         then:
-        listItem.rawText == '''This list item should show {foo}
+        listItem.source == '''This list item should show {foo}
 and should continue here'''
         listItem.text == '''This list item should show bar
 and should continue here'''
@@ -87,7 +87,7 @@ and should continue here'''
         Cell cell = table.body[0].cells[0]
 
         then:
-        cell.rawText == 'Hello {foo}'
+        cell.source == 'Hello {foo}'
         cell.text == 'Hello bar'
     }
 


### PR DESCRIPTION
…text of table cells and list items.

This PR goes for the first point in https://github.com/asciidoctor/asciidoctorj/issues/513#issuecomment-247933943 :
Add accessors to get the raw, unsubstituted text from a Table Cell or a ListItem.
The methods are each called `getRawText()` and they get the field `@text` of the associated nodes instead of invoking the accessor method `text` on the respective Ruby nodes, as these apply the substitutions.

I am not really happy with the naming of the methods yet, as we have `String getContent()` and `List<String> getLines()` on Blocks, but `String getText()` and `String getRawText()` on Cells and ListItems.

But the thing that we're even able now to directly access members of the Ruby objects is already a great thing! This approach wouldn't work on 1.5.x without reimplementing all the functionality in the Java nodes in the same way as it works in the Ruby nodes.
