### PR TITLE
Change behavior of Asciidoctor.Factory.create() to isolate from a sys…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -48,10 +48,7 @@ public class JRubyAsciidoctor implements Asciidoctor {
     }
 
     public static JRubyAsciidoctor create() {
-        //Map<String, Object> env = new HashMap<String, Object>();
-        // ideally, we want to clear GEM_PATH by default, but for backwards compatibility we play nice
-        //env.put(GEM_PATH, null);
-        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), null));
+        return create((String) null);
     }
 
     public static JRubyAsciidoctor create(String gemPath) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
@@ -35,7 +35,7 @@ public class WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath {
     }
 
     @Test
-    public void should_have_gempath_in_ruby_env_when_created_with_non_null_gempath() {
+    public void should_have_gempath_in_ruby_env_when_created_with_default_create() {
         // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
         assertThat(System.getenv("GEM_PATH"), notNullValue());
         assertThat(System.getenv("GEM_HOME"), notNullValue());
@@ -45,8 +45,8 @@ public class WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath {
 
         // Then: The org.jruby.JRuby instance sees this variable
         Ruby rubyRuntime = JRubyRuntimeContext.get(asciidoctor);
-        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), not(is(rubyRuntime.getNil())));
-        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), not(is(rubyRuntime.getNil())));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is(rubyRuntime.getNil()));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is(rubyRuntime.getNil()));
     }
 
     @Test


### PR DESCRIPTION
Same as #518 but for the 1.6.0 branch:
Isolate from system gem path when default factory method `Asciidoctor.Factor.create()` is used.