### PR TITLE
Upgrade distribution to use JRuby 9.1.5.0 instead of 1.7.xx

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -9,6 +9,8 @@ dependencies {
   compile project(':asciidoctorj-diagram')
   compile project(':asciidoctorj-epub3')
   compile project(':asciidoctorj-pdf')
+
+  compile 'org.jruby:jruby-complete:9.1.5.0'
 }
 
 jar.enabled = false


### PR DESCRIPTION
If we want to deliver the distribution with the latest and greatest asciidoctor(j)-pdf soon, we will have to deliver it with JRuby 9xxx.

This PR simply pulls up the version for the asciidoctorj-distribution to 9.1.5.0, so that it contains jruby-complete-9.1.5.0.jar instead of jruby-complete-1.7.25.jar.
