### PR TITLE
Add DescriptionListEntry.setDescription() to allow a processor to cha…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DescriptionListEntry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/DescriptionListEntry.java
@@ -6,4 +6,22 @@ public interface DescriptionListEntry {
 
     ListItem getDescription();
 
+    /**
+     * Sets a new description for a description list item.
+     * Description list items are ordinary ListItems and can be created using the factory methods of
+     * a processor:
+     * <code><pre>
+     * class MyTreeprocessor extends Treeprocessor() {
+     *   public Document process(Document doc) {
+     *     final String newDescription = "A new description for this entry.";
+     *     DescriptionList dl = ...
+     *     DescriptionListEntry dlEntry = ...
+     *     dlEntry.setDescription(createListItem(dl, newDescription));
+     *     return doc;
+     *   }
+     * }</pre></code>
+     * @param description The new description for this description list entry,
+     */
+    void setDescription(final ListItem description);
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DescriptionListEntryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DescriptionListEntryImpl.java
@@ -4,6 +4,7 @@ import org.asciidoctor.ast.DescriptionListEntry;
 import org.asciidoctor.ast.ListItem;
 import org.asciidoctor.ast.NodeConverter;
 import org.asciidoctor.internal.RubyBlockListDecorator;
+import org.asciidoctor.internal.RubyObjectWrapper;
 import org.jruby.RubyArray;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -26,7 +27,17 @@ public class DescriptionListEntryImpl extends StructuralNodeImpl implements Desc
         return firstItem == null ? null : (ListItem) NodeConverter.createASTNode(firstItem);
     }
 
+    public void setDescription(final ListItem description) {
+        setAt(1, description);
+    }
+
     private Object getAt(int i) {
         return ((RubyArray) getRubyObject()).get(i);
     }
+
+    private void setAt(int i, Object object) {
+        ((RubyArray) getRubyObject()).set(i, RubyObjectWrapper.class.cast(object).getRubyObject());
+    }
+
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
@@ -1,10 +1,24 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.Options;
-import org.asciidoctor.ast.*;
+import org.asciidoctor.ast.Block;
+import org.asciidoctor.ast.Cell;
+import org.asciidoctor.ast.Column;
+import org.asciidoctor.ast.ContentModel;
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.ListItem;
+import org.asciidoctor.ast.NodeConverter;
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.Row;
+import org.asciidoctor.ast.Section;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.ast.Table;
 import org.asciidoctor.ast.impl.ColumnImpl;
 import org.asciidoctor.ast.impl.ContentNodeImpl;
+import org.asciidoctor.ast.impl.DescriptionListImpl;
 import org.asciidoctor.ast.impl.DocumentImpl;
+import org.asciidoctor.ast.impl.ListImpl;
 import org.asciidoctor.ast.impl.RowImpl;
 import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.asciidoctor.internal.JRubyRuntimeContext;
@@ -21,7 +35,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.asciidoctor.ast.NodeConverter.NodeType.*;
+import static org.asciidoctor.ast.NodeConverter.NodeType.BLOCK_CLASS;
+import static org.asciidoctor.ast.NodeConverter.NodeType.DOCUMENT_CLASS;
+import static org.asciidoctor.ast.NodeConverter.NodeType.INLINE_CLASS;
+import static org.asciidoctor.ast.NodeConverter.NodeType.LIST_ITEM_CLASS;
+import static org.asciidoctor.ast.NodeConverter.NodeType.SECTION_CLASS;
+import static org.asciidoctor.ast.NodeConverter.NodeType.TABLE_CELL_CLASS;
+import static org.asciidoctor.ast.NodeConverter.NodeType.TABLE_CLASS;
+import static org.asciidoctor.ast.NodeConverter.NodeType.TABLE_COLUMN_CLASS;
 
 public class Processor {
 
@@ -350,6 +371,18 @@ public class Processor {
                 ((DocumentImpl) parentDocument).getRubyObject());
 
         return (Document) NodeConverter.createASTNode(runtime, DOCUMENT_CLASS, runtime.getNil(), options);
+    }
+
+    public ListItem createListItem(final org.asciidoctor.ast.List parent, final String text) {
+        Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
+
+        return (ListItem) NodeConverter.createASTNode(rubyRuntime, LIST_ITEM_CLASS, ListImpl.class.cast(parent).getRubyObject(), rubyRuntime.newString(text));
+    }
+
+    public ListItem createListItem(final org.asciidoctor.ast.DescriptionList parent, final String text) {
+        Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
+
+        return (ListItem) NodeConverter.createASTNode(rubyRuntime, LIST_ITEM_CLASS, DescriptionListImpl.class.cast(parent).getRubyObject(), rubyRuntime.newString(text));
     }
 
     /**


### PR DESCRIPTION
…nge the description of a description list entry.

This PR goes for this item of #513:

> Looking at the interface DescriptionListEntry, it appears that it might require a setter for its description, too, but I haven't had the need for this (yet).

It adds a method `Processor.createListItem()` which was missing until now.
A new `ListItem` can then be set as description of a `DescriptionListEntry`.
