### PR TITLE
Fix master build and distribution classpath

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -37,6 +37,7 @@ startScripts {
     '-Xverify:none', '-XX:+UseFastAccessorMethods', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC',
     '-Djruby.compile.mode=OFF', '-Djruby.compat.version=RUBY2_0'
   ]
+  classpath = configurations.getByName('compile').asFileTree
 }
 
 artifacts {

--- a/asciidoctorj-pdf/build.gradle
+++ b/asciidoctorj-pdf/build.gradle
@@ -6,9 +6,13 @@ dependencies {
     exclude module: 'thread_safe'
     // We must lock Prawn to 1.3.0 until AsciidoctorJ upgrades to JRuby 9.0.0.0
     exclude module: 'prawn'
+    exclude module: 'addressable'
+    exclude module: 'public_suffix'
   }
   gems "rubygems:prawn:$prawnGemVersion"
   gems "rubygems:rouge:$rougeGemVersion"
+  gems "rubygems:addressable:$addressableVersion"
+  gems "rubygems:public_suffix:$public_suffixVersion"
 }
 
 def gemFiles = fileTree(jruby.gemInstallDir) {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '1.7.25'
+  jrubyVersion = '1.7.26'
   jsoupVersion = '1.8.3'
   junitVersion = '4.12'
   saxonVersion = '9.5.1-6'
@@ -46,6 +46,9 @@ ext {
   asciidoctorPdfGemVersion = project(':asciidoctorj-pdf').version.replace('-', '.')
 
   asciidoctorDiagramGemVersion = project(':asciidoctorj-diagram').version.replace('-', '.')
+  addressableVersion = '2.4.0'
+  public_suffixVersion = '1.4.6'
+
   coderayGemVersion = '1.1.0'
   erubisGemVersion = '2.7.0'
   hamlGemVersion = '4.0.5'


### PR DESCRIPTION
- Fixes #530: Add the change proposed by @abelsromero 
- Fixes #533: Add fixed dependencies for then gems `addressable` and `public_suffix`
- Also upgrades the version  of jruby to 1.7.26