### PR TITLE
Ensure that content model and substitutions can be just copied from a…

### DIFF
--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockShouldBeDuplicated.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockShouldBeDuplicated.groovy
@@ -1,0 +1,93 @@
+package org.asciidoctor.extension
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.SafeMode
+import org.asciidoctor.ast.ContentModel
+import org.asciidoctor.ast.Document
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.jsoup.Jsoup
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+@RunWith(ArquillianSputnik)
+class WhenABlockShouldBeDuplicated extends Specification {
+
+
+    public static final String VERBATIM = 'verbatim'
+    public static final String CLASS_LISTINGBLOCK = '.listingblock'
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    def 'it should be possible to copy the content_model'() {
+
+        given:
+        String newSource = 'a source'
+        asciidoctor.javaExtensionRegistry().treeprocessor(new BlockDuplicator('paragraph', newSource))
+
+        final String asciidoctorSource = '''
+
+  This will be ignored
+
+    '''
+
+        when:
+        Document document = asciidoctor.load(asciidoctorSource, OptionsBuilder.options().safe(SafeMode.SAFE).asMap())
+
+        then:
+        document.blocks.size() == 2
+        document.blocks[0].contentModel == VERBATIM
+        document.blocks[1].contentModel == VERBATIM
+    }
+
+
+
+    def 'it should be possible to copy substitutions'() {
+
+        given:
+        String newSource = 'Asciidoctor asciidoctor = ...'
+        asciidoctor.javaExtensionRegistry().treeprocessor(new BlockDuplicator('listing', newSource))
+
+        final String asciidoctorSource = '''
+[source,java,subs="replacements"]
+----
+This will be ignored
+----
+
+    '''
+
+        when:
+        org.jsoup.nodes.Document html = Jsoup.parse(asciidoctor.convert(asciidoctorSource, OptionsBuilder.options().safe(SafeMode.SAFE).headerFooter(false).asMap()))
+
+        then:
+        html.select(CLASS_LISTINGBLOCK).get(0).text() == 'This will be ignored'
+        html.select(CLASS_LISTINGBLOCK).get(1).text() == 'Asciidoctor asciidoctor = \u2026\u200B'
+    }
+
+    static class BlockDuplicator extends Treeprocessor {
+
+        private final String newSource
+        private final String newContext
+
+        BlockDuplicator(String newContext, String newSource) {
+            super(new HashMap<>())
+            this.newContext = newContext
+            this.newSource = newSource
+        }
+
+        @Override
+        Document process(Document document) {
+
+            String contentModel = document.blocks[0].contentModel
+            Map<Object, Object> options = new HashMap<Object, Object>()
+            options.put('subs', document.blocks[0].substitutions)
+            options.put(ContentModel.KEY, contentModel)
+
+            document.blocks << createBlock(document, newContext, newSource, [:], options)
+
+            document
+        }
+    }
+
+}


### PR DESCRIPTION
…n existing node.

This PR goes for the part of #513 that says that when creating a new node the content model and the substitutions cannot be copied from an existing node.
As JRuby returns the symbols used by Asciidoctor as plain strings this PR converts the options `subs` and `content_model` explicitly back to Ruby symbols when creating a new node. 
This is not the nicest solution as it requires knowledge about what Asciidoctor does internally but I have no other solution for that problem yet.