### PR TITLE
Rename isAttr(), setAttr() and getAttr() to more Java like names, isA…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ContentNode.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/ContentNode.java
@@ -37,13 +37,43 @@ public interface ContentNode {
     boolean isInline();
     boolean isBlock();
     Map<String, Object> getAttributes();
+
+    /**
+     *
+     * @param name
+     * @param defaultValue
+     * @param inherit
+     * @return
+     * @deprecated Use {@link #getAttribute(Object, Object, boolean)} instead
+     */
     Object getAttr(Object name, Object defaultValue, boolean inherit);
+
+    /**
+     *
+     * @param name
+     * @param defaultValue
+     * @return
+     * @deprecated Use {@link #getAttribute(Object, Object)} instead
+     */
     Object getAttr(Object name, Object defaultValue);
+
+    /**
+     * @param name
+     * @return
+     * @deprecated Use {@link #getAttribute(Object)} instead
+     */
     Object getAttr(Object name);
+
+    Object getAttribute(Object name, Object defaultValue, boolean inherit);
+
+    Object getAttribute(Object name, Object defaultValue);
+
+    Object getAttribute(Object name);
 
     /**
      * @param name
      * @return {@code true} if this node or the document has an attribute with the given name
+     * @deprecated Use {@link #hasAttribute(Object)} instead
      */
     boolean hasAttr(Object name);
 
@@ -52,11 +82,74 @@ public interface ContentNode {
      * @param name
      * @param inherited
      * @return {@code true} if the current node or depending on the inherited parameter the document has an attribute with the given name.
+     * @deprecated Use {@link #hasAttribute(Object, boolean)} instead
      */
     boolean hasAttr(Object name, boolean inherited);
+
+    /**
+     * @param name
+     * @return {@code true} if this node or the document has an attribute with the given name
+     */
+    boolean hasAttribute(Object name);
+
+    /**
+     *
+     * @param name
+     * @param inherited
+     * @return {@code true} if the current node or depending on the inherited parameter the document has an attribute with the given name.
+     */
+    boolean hasAttribute(Object name, boolean inherited);
+
+    /**
+     *
+     * @param name
+     * @param expected
+     * @return
+     * @deprecated Use {@link #isAttribute(Object, Object)} instead.
+     */
     boolean isAttr(Object name, Object expected);
+
+    /**
+     *
+     * @param name
+     * @param expected
+     * @param inherit
+     * @return
+     * @deprecated Use {@link #isAttribute(Object, Object, boolean)} instead.
+     */
     boolean isAttr(Object name, Object expected, boolean inherit);
+
+    /**
+     *
+     * @param name
+     * @param expected
+     * @return
+     */
+    boolean isAttribute(Object name, Object expected);
+
+    /**
+     *
+     * @param name
+     * @param expected
+     * @param inherit
+     * @return
+     */
+    boolean isAttribute(Object name, Object expected, boolean inherit);
+
+    /**
+     *
+     * @param name
+     * @param value
+     * @param overwrite
+     * @return
+     * @deprecated Use {@link #setAttribute(Object, Object, boolean)} instead.
+     */
     boolean setAttr(Object name, Object value, boolean overwrite);
+
+    boolean setAttribute(Object name, Object value, boolean overwrite);
+
+
+
     boolean isOption(Object name);
     //boolean isRole(String expect); cannot be implemented because it tries to use the non argument isRole.
     boolean isRole();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ContentNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ContentNodeImpl.java
@@ -87,41 +87,81 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
 
     @Override
     public Object getAttr(Object name, Object defaultValue, boolean inherit) {
-        return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name, defaultValue, inherit));
+        return getAttribute(name, defaultValue, inherit);
     }
 
     @Override
     public Object getAttr(Object name, Object defaultValue) {
-        return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name, defaultValue));
+        return getAttribute(name, defaultValue);
     }
 
     @Override
     public Object getAttr(Object name) {
+        return getAttribute(name);
+    }
+
+    @Override
+    public Object getAttribute(Object name, Object defaultValue, boolean inherit) {
+        return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name, defaultValue, inherit));
+    }
+
+    @Override
+    public Object getAttribute(Object name, Object defaultValue) {
+        return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name, defaultValue));
+    }
+
+    @Override
+    public Object getAttribute(Object name) {
         return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name));
     }
 
     @Override
     public boolean isAttr(Object name, Object expected, boolean inherit) {
-        return getBoolean("attr?", name, expected, inherit);
-    }
-
-    @Override
-    public boolean hasAttr(Object name) {
-        return getBoolean("attr?", name);
-    }
-
-    @Override
-    public boolean hasAttr(Object name, boolean inherited) {
-        return getBoolean("attr?", name, null, inherited);
+        return isAttribute(name, expected, inherit);
     }
 
     @Override
     public boolean isAttr(Object name, Object expected) {
+        return isAttribute(name, expected);
+    }
+
+    @Override
+    public boolean isAttribute(Object name, Object expected, boolean inherit) {
+        return getBoolean("attr?", name, expected, inherit);
+    }
+
+    @Override
+    public boolean isAttribute(Object name, Object expected) {
         return getBoolean("attr?", name, expected);
     }
 
     @Override
+    public boolean hasAttr(Object name) {
+        return hasAttribute(name);
+    }
+
+    @Override
+    public boolean hasAttr(Object name, boolean inherited) {
+        return hasAttribute(name, inherited);
+    }
+
+    @Override
+    public boolean hasAttribute(Object name) {
+        return getBoolean("attr?", name);
+    }
+
+    @Override
+    public boolean hasAttribute(Object name, boolean inherited) {
+        return getBoolean("attr?", name, null, inherited);
+    }
+
+    @Override
     public boolean setAttr(Object name, Object value, boolean overwrite) {
+        return setAttribute(name, value, overwrite);
+    }
+
+    @Override
+    public boolean setAttribute(Object name, Object value, boolean overwrite) {
         return getBoolean("set_attr", name, value, overwrite);
     }
 


### PR DESCRIPTION
…ttribute(), setAttribute() and getAttribute().

This PR adds alternatives for the methods `getAttr()`, `setAttr()`, `isAttr()` and `hasAttr()` that are more Java-like, i.e. `getAttribute()`, ...
I marked the current methods as deprecated.