### PR TITLE
Fix upstream build

### DIFF
--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
@@ -47,7 +47,7 @@ class GithubContributorsBlockMacro extends BlockMacroProcessor {
             Row row = createTableRow(table)
 
             Document document = createDocument(parent.getDocument())
-            document.blocks << createBlock(document, IMAGE, null, ['type': IMAGE, 'target': contributor.avatar_url])
+            document.blocks << createBlock(document, IMAGE, null, ['type': IMAGE, 'target': contributor.avatar_url, 'alt': "Avatar of ${contributor.login}" as String])
             Cell avatarCell = createTableCell(loginColumn, document)
             row.cells << avatarCell
             row.cells << createTableCell(loginColumn, contributor.login)

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -72,7 +72,7 @@ public class WhenAsciiDocIsRenderedToDocument {
         Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
         Section section = (Section) document.blocks().get(1);
         assertThat(section.index(), is(0));
-        assertThat(section.sectname(), is("sect1"));
+        assertThat(section.sectname(), either(is("sect1")).or(is("section")));
         assertThat(section.special(), is(false));
     }
 


### PR DESCRIPTION
The current upstream version of asciidoctor core (1.5.6.dev) has some changes that break our tests.
(Requiring an alt text for images and different section names)

This PR fixes the tests so that they run against asciidoctor 1.5.5 and the current 1.5.6.dev