### PR TITLE
First proposal to unregister an extension.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -12,6 +12,7 @@ import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.converter.JavaConverterRegistry;
+import org.asciidoctor.extension.ExtensionRegistration;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.internal.JRubyAsciidoctor;
@@ -779,7 +780,13 @@ public interface Asciidoctor {
      * Unregister all registered extensions.
      */
     void unregisterAllExtensions();
-    
+
+    /**
+     * Unregisters the extension represented by the given registration instance.
+     * @param registration
+     */
+    void unregisterExtension(ExtensionRegistration registration);
+
     /**
      * This method frees all resources consumed by asciidoctorJ module. Keep in mind that if this method is called, instance becomes unusable and you should create another instance.
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionRegistration.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionRegistration.java
@@ -1,0 +1,34 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.internal.RubyUtils;
+import org.jruby.Ruby;
+import org.jruby.RubySymbol;
+
+import java.util.UUID;
+
+/**
+ * This object represents a registration of a single Extension.
+ * It can be used to unregister an extension at an Asciidoctor instance again.
+ *
+ * <p>Example:</p>
+ * <pre><code>
+ * Asciidoctor asciidoctor = ...
+ * ExtensionRegistration registration =
+ *     asciidoctor.javaExtensionRegistry().docInfoProcessor(...);
+ * asciidoctor.convert(...); // Convert with the docInfoProcessor enabled.
+ * asciidoctor.unregisterExtension(registration);
+ * asciidoctor.convert(...); // Convert without the docInfoProcessor.
+ * </code></pre>
+ */
+public class ExtensionRegistration {
+
+  private String name;
+
+  public ExtensionRegistration() {
+    this.name = UUID.randomUUID().toString();
+  }
+
+  public RubySymbol getName(Ruby rubyInstance) {
+    return RubyUtils.toSymbol(rubyInstance, name);
+  }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
@@ -23,240 +23,247 @@ public class JavaExtensionRegistry {
         this.rubyRuntime = rubyRuntime;
     }
 
-    public JavaExtensionRegistry docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor) {
+    public ExtensionRegistration docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor) {
         RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
-        this.asciidoctorModule.docinfo_processor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.docinfo_processor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
 
-    public JavaExtensionRegistry docinfoProcessor(DocinfoProcessor docInfoProcessor) {
+    public ExtensionRegistration docinfoProcessor(DocinfoProcessor docInfoProcessor) {
         RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
-        this.asciidoctorModule.docinfo_processor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        asciidoctorModule.docinfo_processor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
 
-    public JavaExtensionRegistry docinfoProcessor(String docInfoProcessor) {
+    public ExtensionRegistration docinfoProcessor(String docInfoProcessor) {
         try {
             Class<? extends DocinfoProcessor>  docinfoProcessorClass = (Class<? extends DocinfoProcessor>) Class.forName(docInfoProcessor);
-            docinfoProcessor(docinfoProcessorClass);
-            return this;
+            return docinfoProcessor(docinfoProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public JavaExtensionRegistry preprocessor(Class<? extends Preprocessor> preprocessor) {
+    public ExtensionRegistration preprocessor(Class<? extends Preprocessor> preprocessor) {
         RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
-        this.asciidoctorModule.preprocessor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.preprocessor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
 
-    public JavaExtensionRegistry preprocessor(Preprocessor preprocessor) {
+    public ExtensionRegistration preprocessor(Preprocessor preprocessor) {
         RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
-        this.asciidoctorModule.preprocessor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.preprocessor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
     
-    public JavaExtensionRegistry preprocessor(String preprocessor) {
+    public ExtensionRegistration preprocessor(String preprocessor) {
         try {
             Class<? extends Preprocessor>  preprocessorClass = (Class<? extends Preprocessor>) Class.forName(preprocessor);
-            preprocessor(preprocessorClass);
-            return this;
+            return preprocessor(preprocessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
     
-    public JavaExtensionRegistry postprocessor(String postprocessor) {
+    public ExtensionRegistration postprocessor(String postprocessor) {
         try {
             Class<? extends Postprocessor>  postprocessorClass = (Class<? extends Postprocessor>) Class.forName(postprocessor);
-            postprocessor(postprocessorClass);
-            return this;
+            return postprocessor(postprocessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
     
-    public JavaExtensionRegistry postprocessor(Class<? extends Postprocessor> postprocessor) {
+    public ExtensionRegistration postprocessor(Class<? extends Postprocessor> postprocessor) {
         RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
-        this.asciidoctorModule.postprocessor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.postprocessor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
     
-    public JavaExtensionRegistry postprocessor(Postprocessor postprocessor) {
+    public ExtensionRegistration postprocessor(Postprocessor postprocessor) {
         RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
-        this.asciidoctorModule.postprocessor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.postprocessor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
 
-    public JavaExtensionRegistry includeProcessor(String includeProcessor) {
+    public ExtensionRegistration includeProcessor(String includeProcessor) {
         try {
             Class<? extends IncludeProcessor>  includeProcessorClass = (Class<? extends IncludeProcessor>) Class.forName(includeProcessor);
-            includeProcessor(includeProcessorClass);
-            return this;
+            return includeProcessor(includeProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
     
-    public JavaExtensionRegistry includeProcessor(
+    public ExtensionRegistration includeProcessor(
             Class<? extends IncludeProcessor> includeProcessor) {
         RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
-        this.asciidoctorModule.include_processor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.include_processor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
 
-    public JavaExtensionRegistry includeProcessor(IncludeProcessor includeProcessor) {
+    public ExtensionRegistration includeProcessor(IncludeProcessor includeProcessor) {
         RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
-        this.asciidoctorModule.include_processor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.include_processor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
     
-    public JavaExtensionRegistry treeprocessor(Treeprocessor treeprocessor) {
+    public ExtensionRegistration treeprocessor(Treeprocessor treeprocessor) {
         RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeprocessor);
-        this.asciidoctorModule.treeprocessor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.treeprocessor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
 
-    public JavaExtensionRegistry treeprocessor(Class<? extends Treeprocessor> abstractTreeProcessor) {
+    public ExtensionRegistration treeprocessor(Class<? extends Treeprocessor> abstractTreeProcessor) {
         RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, abstractTreeProcessor);
-        this.asciidoctorModule.treeprocessor(rubyClass);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.treeprocessor(registration.getName(rubyRuntime), rubyClass);
+        return registration;
     }
     
-    public JavaExtensionRegistry treeprocessor(String treeProcessor) {
+    public ExtensionRegistration treeprocessor(String treeProcessor) {
         try {
             Class<? extends Treeprocessor>  treeProcessorClass = (Class<? extends Treeprocessor>) Class.forName(treeProcessor);
-            treeprocessor(treeProcessorClass);
-            return this;
+            return treeprocessor(treeProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public JavaExtensionRegistry block(String blockName,
+    public ExtensionRegistration block(String blockName,
            String blockProcessor) {
         try {
             Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
-            block(blockName, blockProcessorClass);
-            return this;
+            return block(blockName, blockProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public JavaExtensionRegistry block(String blockProcessor) {
+    public ExtensionRegistration block(String blockProcessor) {
         try {
             Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
-            block(blockProcessorClass);
-            return this;
+            return block(blockProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public JavaExtensionRegistry block(String blockName,
+    public ExtensionRegistration block(String blockName,
             Class<? extends BlockProcessor> blockProcessor) {
         RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-        this.asciidoctorModule.block_processor(rubyClass, blockName);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.block_processor(registration.getName(rubyRuntime), rubyClass, blockName);
+        return registration;
     }
 
-    public JavaExtensionRegistry block(Class<? extends BlockProcessor> blockProcessor) {
+    public ExtensionRegistration block(Class<? extends BlockProcessor> blockProcessor) {
         String name = getName(blockProcessor);
-        block(name, blockProcessor);
-        return this;
+        return block(name, blockProcessor);
     }
 
-    public JavaExtensionRegistry block(BlockProcessor blockProcessor) {
+    public ExtensionRegistration block(BlockProcessor blockProcessor) {
         RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-        this.asciidoctorModule.block_processor(rubyClass, blockProcessor.getName());
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.block_processor(registration.getName(rubyRuntime), rubyClass, blockProcessor.getName());
+        return registration;
     }
 
-    public JavaExtensionRegistry block(String blockName,
+    public ExtensionRegistration block(String blockName,
             BlockProcessor blockProcessor) {
         RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-        this.asciidoctorModule.block_processor(rubyClass, blockName);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.block_processor(registration.getName(rubyRuntime), rubyClass, blockName);
+        return registration;
     }
 
-    public JavaExtensionRegistry blockMacro(String blockName,
+    public ExtensionRegistration blockMacro(String blockName,
             Class<? extends BlockMacroProcessor> blockMacroProcessor) {
         RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-        this.asciidoctorModule.block_macro(rubyClass, blockName);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.block_macro(registration.getName(rubyRuntime), rubyClass, blockName);
+        return registration;
     }
 
-    public JavaExtensionRegistry blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor) {
+    public ExtensionRegistration blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor) {
         String name = getName(blockMacroProcessor);
         RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-        this.asciidoctorModule.block_macro(rubyClass, name);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.block_macro(registration.getName(rubyRuntime), rubyClass, name);
+        return registration;
     }
 
-    public JavaExtensionRegistry blockMacro(String blockName,
+    public ExtensionRegistration blockMacro(String blockName,
             String blockMacroProcessor) {
         try {
             Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
-            blockMacro(blockName, blockMacroProcessorClass);
-            return this;
+            return blockMacro(blockName, blockMacroProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public JavaExtensionRegistry blockMacro(String blockMacroProcessor) {
+    public ExtensionRegistration blockMacro(String blockMacroProcessor) {
         try {
             Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
-            blockMacro(blockMacroProcessorClass);
-            return this;
+            return blockMacro(blockMacroProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public JavaExtensionRegistry blockMacro(BlockMacroProcessor blockMacroProcessor) {
+    public ExtensionRegistration blockMacro(BlockMacroProcessor blockMacroProcessor) {
         RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-        this.asciidoctorModule.block_macro(rubyClass, blockMacroProcessor.getName());
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.block_macro(registration.getName(rubyRuntime), rubyClass, blockMacroProcessor.getName());
+        return registration;
     }
 
-    public JavaExtensionRegistry inlineMacro(InlineMacroProcessor inlineMacroProcessor) {
+    public ExtensionRegistration inlineMacro(InlineMacroProcessor inlineMacroProcessor) {
         RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        this.asciidoctorModule.inline_macro(rubyClass, inlineMacroProcessor.getName());
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.inline_macro(registration.getName(rubyRuntime), rubyClass, inlineMacroProcessor.getName());
+        return registration;
     }
     
-    public JavaExtensionRegistry inlineMacro(String blockName,
+    public ExtensionRegistration inlineMacro(String blockName,
             Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
         RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        this.asciidoctorModule.inline_macro(rubyClass, blockName);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.inline_macro(registration.getName(rubyRuntime), rubyClass, blockName);
+        return registration;
     }
 
-    public JavaExtensionRegistry inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
+    public ExtensionRegistration inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
         String name = getName(inlineMacroProcessor);
         RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        this.asciidoctorModule.inline_macro(rubyClass, name);
-        return this;
+        ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.inline_macro(registration.getName(rubyRuntime), rubyClass, name);
+        return registration;
     }
 
-    public JavaExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor) {
+    public ExtensionRegistration inlineMacro(String blockName, String inlineMacroProcessor) {
         try {
             Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
-            inlineMacro(blockName, inlineMacroProcessorClass);
-            return this;
+            return inlineMacro(blockName, inlineMacroProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public JavaExtensionRegistry inlineMacro(String inlineMacroProcessor) {
+    public ExtensionRegistration inlineMacro(String inlineMacroProcessor) {
         try {
             Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
-            inlineMacro(inlineMacroProcessorClass);
-            return this;
+            return inlineMacro(inlineMacroProcessorClass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
@@ -28,49 +28,57 @@ public class RubyExtensionRegistry {
         return this;
     }
     
-    public RubyExtensionRegistry preprocessor(String preprocessor) {
-        this.asciidoctorModule.preprocessor(preprocessor);
-        return this;
+    public ExtensionRegistration preprocessor(String preprocessor) {
+        final ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.preprocessor(registration.getName(rubyRuntime), preprocessor);
+        return registration;
     }
 
-    public RubyExtensionRegistry postprocessor(String postprocesor) {
-        this.asciidoctorModule.postprocessor(postprocesor);
-        return this;
+    public ExtensionRegistration postprocessor(String postprocesor) {
+        final ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.postprocessor(registration.getName(rubyRuntime), postprocesor);
+        return registration;
     }
 
-    public RubyExtensionRegistry docinfoProcessor(String docinfoProcessor) {
-        this.asciidoctorModule.docinfo_processor(docinfoProcessor);
-        return this;
+    public ExtensionRegistration docinfoProcessor(String docinfoProcessor) {
+        final ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.docinfo_processor(registration.getName(rubyRuntime), docinfoProcessor);
+        return registration;
     }
 
-    public RubyExtensionRegistry includeProcessor(String includeProcessor) {
-        this.asciidoctorModule.include_processor(includeProcessor);
-        return this;
+    public ExtensionRegistration includeProcessor(String includeProcessor) {
+        final ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.include_processor(registration.getName(rubyRuntime), includeProcessor);
+        return registration;
     }
 
-    public RubyExtensionRegistry treeprocessor(String treeProcessor) {
-        this.asciidoctorModule.treeprocessor(treeProcessor);
-        return this;
+    public ExtensionRegistration treeprocessor(String treeProcessor) {
+        final ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.treeprocessor(registration.getName(rubyRuntime), treeProcessor);
+        return registration;
     }
 
-    public RubyExtensionRegistry block(String blockName, String blockProcessor) {
-        this.asciidoctorModule.block_processor(
-                blockProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
-        return this;
+    public ExtensionRegistration block(String blockName, String blockProcessor) {
+        final ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.block_processor(registration.getName(rubyRuntime),
+            blockProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
+        return registration;
     }
 
-    public RubyExtensionRegistry blockMacro(String blockName, String blockMacroProcessor) {
+    public ExtensionRegistration blockMacro(String blockName, String blockMacroProcessor) {
 
-        this.asciidoctorModule.block_macro(
-                blockMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
-        return this;
+        final ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.block_macro(registration.getName(rubyRuntime),
+            blockMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
+        return registration;
     }
 
-    public RubyExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor) {
+    public ExtensionRegistration inlineMacro(String blockName, String inlineMacroProcessor) {
 
-        this.asciidoctorModule.inline_macro(
-                inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
-        return this;
+        final ExtensionRegistration registration = new ExtensionRegistration();
+        this.asciidoctorModule.inline_macro(registration.getName(rubyRuntime),
+            inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
+        return registration;
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
@@ -6,44 +6,46 @@ import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.*;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
+import org.jruby.RubySymbol;
 
 
 public interface AsciidoctorModule {
 
-    void preprocessor(String preprocessorClassName);
-    void preprocessor(RubyClass preprocessorClassName);
-	void preprocessor(Preprocessor preprocessor);
+    void preprocessor(RubySymbol name, String preprocessorClassName);
+    void preprocessor(RubySymbol name, RubyClass preprocessorClassName);
+    void preprocessor(RubySymbol name, Preprocessor preprocessor);
 	
-    void postprocessor(String postprocessorClassName);
-    void postprocessor(RubyClass postprocessorClassName);
-    void postprocessor(Postprocessor postprocessor);
+    void postprocessor(RubySymbol name, String postprocessorClassName);
+    void postprocessor(RubySymbol name, RubyClass postprocessorClassName);
+    void postprocessor(RubySymbol name, Postprocessor postprocessor);
     
-    void treeprocessor(String treeprocessor);
-    void treeprocessor(RubyClass treeprocessorClassName);
-    void treeprocessor(Treeprocessor treeprocessorClassName);
+    void treeprocessor(RubySymbol name, String treeprocessor);
+    void treeprocessor(RubySymbol name, RubyClass treeprocessorClassName);
+    void treeprocessor(RubySymbol name, Treeprocessor treeprocessorClassName);
     
-    void include_processor(String includeProcessorClassName);
-    void include_processor(RubyClass includeProcessorClassName);
-    void include_processor(IncludeProcessor includeProcessor);
+    void include_processor(RubySymbol name, String includeProcessorClassName);
+    void include_processor(RubySymbol name, RubyClass includeProcessorClassName);
+    void include_processor(RubySymbol name, IncludeProcessor includeProcessor);
     
-    void block_processor(String blockClassName, Object blockName);
-    void block_processor(RubyClass blockClass, Object blockName);
-    void block_processor(BlockProcessor blockInstance, Object blockName);
+    void block_processor(RubySymbol name, String blockClassName, Object blockName);
+    void block_processor(RubySymbol name, RubyClass blockClass, Object blockName);
+    void block_processor(RubySymbol name, BlockProcessor blockInstance, Object blockName);
     
-    void block_macro(String blockMacroClassName, Object blockName);
-    void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName);
-    void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName);
-    void block_macro(RubyClass blockClassName, Object blockSymbol);
+    void block_macro(RubySymbol name, String blockMacroClassName, Object blockName);
+    void block_macro(RubySymbol name, Class<BlockMacroProcessor> blockMacroClass, Object blockName);
+    void block_macro(RubySymbol name, BlockMacroProcessor blockMacroInstance, Object blockName);
+    void block_macro(RubySymbol name, RubyClass blockClassName, Object blockSymbol);
 
-    void inline_macro(String blockClassName, Object blockSymbol);
-    void inline_macro(RubyClass blockClassName, Object blockSymbol);
-    void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol);
+    void inline_macro(RubySymbol name, String blockClassName, Object blockSymbol);
+    void inline_macro(RubySymbol name, RubyClass blockClassName, Object blockSymbol);
+    void inline_macro(RubySymbol name, InlineMacroProcessor blockClassName, Object blockSymbol);
     
-    void docinfo_processor(String docInfoClassName);
-    void docinfo_processor(RubyClass docInfoClassName);
-    void docinfo_processor(DocinfoProcessor docInfoClassName);
+    void docinfo_processor(RubySymbol name, String docInfoClassName);
+    void docinfo_processor(RubySymbol name, RubyClass docInfoClassName);
+    void docinfo_processor(RubySymbol name, DocinfoProcessor docInfoClassName);
     
     void unregister_all_extensions();
+    void unregister_extension(RubySymbol name);
 
     Object convert(String content, Map<String, Object> options);
     Object convertFile(String filename, Map<String, Object> options);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -14,6 +14,7 @@ import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.ast.Title;
 import org.asciidoctor.converter.JavaConverterRegistry;
 import org.asciidoctor.converter.internal.ConverterRegistryExecutor;
+import org.asciidoctor.extension.ExtensionRegistration;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.extension.internal.ExtensionRegistryExecutor;
@@ -402,6 +403,11 @@ public class JRubyAsciidoctor implements Asciidoctor {
     @Override
     public void unregisterAllExtensions() {
         this.asciidoctorModule.unregister_all_extensions();
+    }
+
+    @Override
+    public void unregisterExtension(ExtensionRegistration registration) {
+        this.asciidoctorModule.unregister_extension(registration.getName(getRubyRuntime()));
     }
 
     @Override

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -19,50 +19,54 @@ class AsciidoctorModule
         Asciidoctor::Extensions.unregister_all
     end
 
-    def docinfo_processor(extensionName)
-        Asciidoctor::Extensions.register do
+    def unregister_extension name
+        Asciidoctor::Extensions.unregister name
+    end
+
+    def docinfo_processor name, extensionName
+        Asciidoctor::Extensions.register name do
             docinfo_processor extensionName
         end
     end
 
-    def treeprocessor(extensionName)
-        Asciidoctor::Extensions.register do 
+    def treeprocessor name, extensionName
+        Asciidoctor::Extensions.register name do
             treeprocessor extensionName
         end
     end
     
-    def include_processor(extensionName)
-        Asciidoctor::Extensions.register do
+    def include_processor name, extensionName
+        Asciidoctor::Extensions.register name do
             include_processor extensionName
         end
     end
 
-    def preprocessor(extensionName)
-        Asciidoctor::Extensions.register do
+    def preprocessor name, extensionName
+        Asciidoctor::Extensions.register name do
             preprocessor extensionName
         end
     end
     
-    def postprocessor(extensionName)
-        Asciidoctor::Extensions.register do
+    def postprocessor name, extensionName
+        Asciidoctor::Extensions.register name do
             postprocessor extensionName
         end
     end
 
-    def block_processor(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def block_processor name, extensionName, blockSymbol
+        Asciidoctor::Extensions.register name do
             block extensionName, blockSymbol
         end
     end
 
-    def block_macro(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def block_macro name, extensionName, blockSymbol
+        Asciidoctor::Extensions.register name do
             block_macro extensionName, blockSymbol
         end
     end
 
-    def inline_macro(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def inline_macro name, extensionName, blockSymbol
+        Asciidoctor::Extensions.register name do
             inline_macro extensionName, blockSymbol
         end
     end

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -734,6 +734,39 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
+    public void should_unregister_postprocessor() throws IOException {
+
+        // Given: A registered Postprocessor
+        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+        ExtensionRegistration registration = javaExtensionRegistry.postprocessor(CustomFooterPostProcessor.class);
+
+        // When: I render a document
+        Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
+                .safe(SafeMode.UNSAFE).get();
+
+        asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options);
+
+        // Then: it is invoked
+        File renderedFile = new File(testFolder.getRoot(), "rendersample.html");
+        org.jsoup.nodes.Document doc = Jsoup.parse(renderedFile, "UTF-8");
+        Element footer = doc.getElementById("footer-text");
+        assertThat(footer.text(), containsString("Copyright Acme, Inc."));
+
+        // When: I unregister the Postprocessor and render again with the same Asciidoctor instance
+        asciidoctor.unregisterExtension(registration);
+
+        Options options2 = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample2.html"))
+                .safe(SafeMode.UNSAFE).get();
+        asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options2);
+        File renderedFile2 = new File(testFolder.getRoot(), "rendersample2.html");
+        org.jsoup.nodes.Document doc2 = Jsoup.parse(renderedFile2, "UTF-8");
+
+        Element footer2 = doc2.getElementById("footer-text");
+        assertThat(footer2.text(), not(containsString("Copyright Acme, Inc.")));
+
+    }
+
+    @Test
     public void a_block_processor_as_string_should_be_executed_when_registered_block_is_found_in_document()
             throws IOException {
 


### PR DESCRIPTION
This is a first proposal for unregistering dedicated extensions.
The registration methods now return an `ExtensionRegistration` object that can be used to unregister the extension again with `Asciidoctor.unregisterExtension(ExtensionRegistration)`.
By changing the signature like this we have to give up on chaining calls to the registration methods, but I think that this is not really an issue, we also didn't have that yet in 1.5.x – it was a 1.6.x-only feature.

The group name is the symbol of a random UUID, I assume that this will not clash.

The tests are likely to fail against the current asciidoctor 1.5.5, but it should succeed against upstream.

What do you think about it?
If you are principally ok with it I would add more tests, there is only one test atm.