### PR TITLE
Upgrade to Asciidoctor 1.5.6 and Asciidoctor-Diagram 1.5.5

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1380,6 +1380,30 @@ String content = asciidoctor.convertFile(new File(
 
 You can unregister all extensions by calling the `org.asciidoctor.Asciidoctor.unregisterAllExtensions()` method.
 
+Additionally, since AsciidoctorJ 1.5.6.1 it is possible to unregister specific extensions when using the ExtensionGroup API.
+This allows to register and unregister a group of extensions as a whole:
+
+[source,java]
+----
+BlockProcessor extension1 = ...
+Treeprocessor extension2 = ...
+ExtensionGroup extensionGroup =
+  asciidoctor.createGroup()
+    .block(extension1)
+    .treeprocessor(extension2);
+
+asciidoctor.convert(...) // <1>
+
+extensionGroup.register();
+asciidoctor.convert(); // <2>
+
+extensionGroup.register();
+asciidoctor.convert(); // <3>
+----
+<1> Convert a document without the extensions active because they were not registered yet.
+<2> Convert with extensions active after registration.
+<3> Convert without extensions active after the extensions were unregistered.
+
 === Ruby extensions
 
 You can even register extensions written in Ruby using AsciidoctorJ.

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -13,6 +13,7 @@ import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.DocumentRuby;
 import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.converter.JavaConverterRegistry;
+import org.asciidoctor.extension.ExtensionGroup;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.internal.JRubyAsciidoctor;
@@ -633,12 +634,23 @@ public interface Asciidoctor {
      * @return Converter Registry object.
      */
     JavaConverterRegistry javaConverterRegistry();
-    
+
+    /**
+     * Creates an ExtensionGroup that can be used to register and unregister a group of extensions.
+     * @return
+     */
+    ExtensionGroup createGroup();
+
+    /**
+     * Creates an ExtensionGroup that can be used to register and unregister a group of extensions.
+     * @return
+     */
+    ExtensionGroup createGroup(String groupName);
     /**
      * Unregister all registered extensions.
      */
     void unregisterAllExtensions();
-    
+
     /**
      * This method frees all resources consumed by asciidoctorJ module. Keep in mind that if this method is called, instance becomes unusable and you should create another instance.
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionGroup.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionGroup.java
@@ -1,0 +1,74 @@
+package org.asciidoctor.extension;
+
+
+import java.io.InputStream;
+
+/**
+ * An ExtensionGroup allows to collectively register and unregister extensions.
+ * All extensions are registered lazily and are not effective before a call to {@link #register()}.
+ *
+ * <p>Example:
+ * <code><pre>
+ * ExtensionGroup group = asciidoctor.createGroup();
+ * group.block(myBlock).preprocessor(mypreprocessor);
+ *
+ * // Convert with extensions
+ * group.register();
+ * asciidoctor.convert(...);
+ * group.unregister();
+ *
+ * // Convert without extensions
+ * asciidoctor.convert(...);
+ * </pre></code></p>
+ */
+public interface ExtensionGroup {
+
+  public void register();
+
+  public void unregister();
+
+  public ExtensionGroup docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor);
+  public ExtensionGroup docinfoProcessor(DocinfoProcessor docInfoProcessor);
+  public ExtensionGroup docinfoProcessor(String docInfoProcessor);
+
+  public ExtensionGroup preprocessor(Class<? extends Preprocessor> preprocessor);
+  public ExtensionGroup preprocessor(Preprocessor preprocessor);
+  public ExtensionGroup preprocessor(String preprocessor);
+
+  public ExtensionGroup postprocessor(String postprocessor);
+  public ExtensionGroup postprocessor(Class<? extends Postprocessor> postprocessor);
+  public ExtensionGroup postprocessor(Postprocessor postprocesor);
+
+  public ExtensionGroup includeProcessor(String includeProcessor);
+  public ExtensionGroup includeProcessor(Class<? extends IncludeProcessor> includeProcessor);
+  public ExtensionGroup includeProcessor(IncludeProcessor includeProcessor);
+
+  public ExtensionGroup treeprocessor(Treeprocessor treeprocessor);
+  public ExtensionGroup treeprocessor(Class<? extends Treeprocessor> treeProcessor);
+  public ExtensionGroup treeprocessor(String treeProcessor);
+
+  public ExtensionGroup block(String blockName, String blockProcessor);
+  public ExtensionGroup block(String blockName, Class<? extends BlockProcessor> blockProcessor);
+  public ExtensionGroup block(BlockProcessor blockProcessor);
+  public ExtensionGroup block(String blockName, BlockProcessor blockProcessor);
+
+  public ExtensionGroup blockMacro(String blockName, Class<? extends BlockMacroProcessor> blockMacroProcessor);
+  public ExtensionGroup blockMacro(String blockName, String blockMacroProcessor);
+  public ExtensionGroup blockMacro(BlockMacroProcessor blockMacroProcessor);
+
+  public ExtensionGroup inlineMacro(InlineMacroProcessor inlineMacroProcessor);
+  public ExtensionGroup inlineMacro(String blockName, Class<? extends InlineMacroProcessor> inlineMacroProcessor);
+  public ExtensionGroup inlineMacro(String blockName, String inlineMacroProcessor);
+
+  public ExtensionGroup requireRubyLibrary(String requiredLibrary);
+  public ExtensionGroup loadRubyClass(InputStream rubyClassStream);
+
+  public ExtensionGroup rubyPreprocessor(String preprocessor);
+  public ExtensionGroup rubyPostprocessor(String postprocessor);
+  public ExtensionGroup rubyDocinfoProcessor(String docinfoProcessor);
+  public ExtensionGroup rubyIncludeProcessor(String includeProcessor);
+  public ExtensionGroup rubyTreeprocessor(String treeProcessor);
+  public ExtensionGroup rubyBlock(String blockName, String blockProcessor);
+  public ExtensionGroup rubyBlockMacro(String blockName, String blockMacroProcessor);
+  public ExtensionGroup rubyInlineMacro(String blockName, String inlineMacroProcessor);
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
@@ -9,6 +9,7 @@ import org.jruby.Ruby;
 public class RubyExtensionRegistry {
 
     private AsciidoctorModule asciidoctorModule;
+
     private Ruby rubyRuntime;
 
     public RubyExtensionRegistry(AsciidoctorModule asciidoctorModule,
@@ -33,8 +34,8 @@ public class RubyExtensionRegistry {
         return this;
     }
 
-    public RubyExtensionRegistry postprocessor(String postprocesor) {
-        this.asciidoctorModule.postprocessor(postprocesor);
+    public RubyExtensionRegistry postprocessor(String postprocessor) {
+        this.asciidoctorModule.postprocessor(postprocessor);
         return this;
     }
 
@@ -72,5 +73,4 @@ public class RubyExtensionRegistry {
                 inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
         return this;
     }
-
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
@@ -13,38 +13,63 @@ import org.jruby.RubyHash;
 public interface AsciidoctorModule {
 
     void preprocessor(String preprocessorClassName);
+    void preprocessor(String preprocessorClassName, String registrationName);
     void preprocessor(RubyClass preprocessorClassName);
-	void preprocessor(Preprocessor preprocessor);
-	
+    void preprocessor(RubyClass preprocessorClassName, String registrationName);
+	  void preprocessor(Preprocessor preprocessor);
+	  void preprocessor(Preprocessor preprocessor, String registrationName);
+
     void postprocessor(String postprocessorClassName);
+    void postprocessor(String postprocessorClassName, String registrationName);
     void postprocessor(RubyClass postprocessorClassName);
+    void postprocessor(RubyClass postprocessorClassName, String registrationName);
     void postprocessor(Postprocessor postprocessor);
-    
+    void postprocessor(Postprocessor postprocessor, String registrationName);
+
     void treeprocessor(String treeprocessor);
+    void treeprocessor(String treeprocessor, String registrationName);
     void treeprocessor(RubyClass treeprocessorClassName);
+    void treeprocessor(RubyClass treeprocessorClassName, String registrationName);
     void treeprocessor(Treeprocessor treeprocessorClassName);
-    
+    void treeprocessor(Treeprocessor treeprocessorClassName, String registrationName);
+
     void include_processor(String includeProcessorClassName);
+    void include_processor(String includeProcessorClassName, String registrationName);
     void include_processor(RubyClass includeProcessorClassName);
+    void include_processor(RubyClass includeProcessorClassName, String registrationName);
     void include_processor(IncludeProcessor includeProcessor);
-    
+    void include_processor(IncludeProcessor includeProcessor, String registrationName);
+
     void block_processor(String blockClassName, Object blockName);
+    void block_processor(String blockClassName, Object blockName, String registrationName);
     void block_processor(RubyClass blockClass, Object blockName);
+    void block_processor(RubyClass blockClass, Object blockName, String registrationName);
     void block_processor(BlockProcessor blockInstance, Object blockName);
-    
+    void block_processor(BlockProcessor blockInstance, Object blockName, String registrationName);
+
     void block_macro(String blockMacroClassName, Object blockName);
+    void block_macro(String blockMacroClassName, Object blockName, String registrationName);
     void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName);
+    void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName, String registrationName);
     void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName);
-    
+    void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName, String registrationName);
+
     void inline_macro(String blockClassName, Object blockSymbol);
+    void inline_macro(String blockClassName, Object blockSymbol, String registrationName);
     void inline_macro(RubyClass blockClassName, Object blockSymbol);
+    void inline_macro(RubyClass blockClassName, Object blockSymbol, String registrationName);
     void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol);
-    
+    void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol, String registrationName);
+
     void docinfo_processor(String docInfoClassName);
+    void docinfo_processor(String docInfoClassName, String registrationName);
     void docinfo_processor(RubyClass docInfoClassName);
+    void docinfo_processor(RubyClass docInfoClassName, String registrationName);
     void docinfo_processor(DocinfoProcessor docInfoClassName);
-    
+    void docinfo_processor(DocinfoProcessor docInfoClassName, String registrationName);
+
     void unregister_all_extensions();
+    void unregister_extension(String groupName);
 
     Object convert(String content, Map<String, Object> options);
     Object convertFile(String filename, Map<String, Object> options);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/ExtensionGroupImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/ExtensionGroupImpl.java
@@ -1,0 +1,506 @@
+package org.asciidoctor.internal;
+
+import org.asciidoctor.extension.BlockMacroProcessor;
+import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.DocinfoProcessor;
+import org.asciidoctor.extension.ExtensionGroup;
+import org.asciidoctor.extension.IncludeProcessor;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Postprocessor;
+import org.asciidoctor.extension.Preprocessor;
+import org.asciidoctor.extension.Treeprocessor;
+import org.jruby.Ruby;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by robertpanzer on 21.07.17.
+ */
+public class ExtensionGroupImpl implements ExtensionGroup {
+
+  private final JRubyAsciidoctor asciidoctor;
+
+  private final Ruby rubyRuntime;
+
+  private final AsciidoctorModule asciidoctorModule;
+
+  private final String groupName;
+
+  private final List<Runnable> registrations = new ArrayList<Runnable>();
+
+  public ExtensionGroupImpl(String groupName, JRubyAsciidoctor asciidoctor) {
+    this.groupName = groupName;
+    this.asciidoctor = asciidoctor;
+    this.rubyRuntime = asciidoctor.getRubyRuntime();
+    asciidoctorModule = asciidoctor.getAsciidoctorModule();
+  }
+
+  @Override
+  public void register() {
+    for (Runnable r: registrations) {
+      r.run();
+    }
+  }
+
+  @Override
+  public void unregister() {
+    asciidoctorModule.unregister_extension(groupName);
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final Class<? extends DocinfoProcessor> docInfoProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, docInfoProcessor);
+        asciidoctorModule.docinfo_processor(RubyUtils.toRubyClass(rubyRuntime, docInfoProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final DocinfoProcessor docInfoProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, docInfoProcessor.getClass());
+        asciidoctorModule.docinfo_processor(docInfoProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final String docInfoProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, docInfoProcessor);
+        asciidoctorModule.docinfo_processor(getClassName(docInfoProcessor), groupName);
+
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final Class<? extends Preprocessor> preprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, preprocessor);
+        asciidoctorModule.preprocessor(RubyUtils.toRubyClass(rubyRuntime, preprocessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final Preprocessor preprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, preprocessor.getClass());
+        asciidoctorModule.preprocessor(preprocessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final String preprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, preprocessor);
+        asciidoctorModule.preprocessor(getClassName(preprocessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final String postprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, postprocessor);
+        asciidoctorModule.postprocessor(getClassName(postprocessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final Class<? extends Postprocessor> postprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, postprocessor);
+        asciidoctorModule.postprocessor(RubyUtils.toRubyClass(rubyRuntime, postprocessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final Postprocessor postprocesor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, postprocesor.getClass());
+        asciidoctorModule.postprocessor(postprocesor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final String includeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, includeProcessor);
+        asciidoctorModule.include_processor(getClassName(includeProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final Class<? extends IncludeProcessor> includeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, includeProcessor);
+        asciidoctorModule.include_processor(RubyUtils.toRubyClass(rubyRuntime, includeProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final IncludeProcessor includeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        String importLine = getImportLine(includeProcessor.getClass());
+        javaImport(rubyRuntime, importLine);
+        asciidoctorModule.include_processor(includeProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final Treeprocessor treeprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, treeprocessor.getClass());
+        asciidoctorModule.treeprocessor(treeprocessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final Class<? extends Treeprocessor> treeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, treeProcessor);
+        asciidoctorModule.treeprocessor(RubyUtils.toRubyClass(rubyRuntime, treeProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final String treeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, treeProcessor);
+        asciidoctorModule.treeprocessor(getClassName(treeProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final String blockProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockProcessor);
+
+        asciidoctorModule.block_processor(
+            getClassName(blockProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final Class<? extends BlockProcessor> blockProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockProcessor);
+
+        asciidoctorModule.block_processor(
+            RubyUtils.toRubyClass(rubyRuntime, blockProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final BlockProcessor blockProcessor) {
+    block(blockProcessor.getName(), blockProcessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final BlockProcessor blockProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockProcessor.getClass());
+
+        asciidoctorModule.block_processor(
+            blockProcessor,
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final String blockName, final Class<? extends BlockMacroProcessor> blockMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockMacroProcessor);
+        asciidoctorModule.block_macro(
+            blockMacroProcessor.getSimpleName(),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final String blockName, final String blockMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockMacroProcessor);
+        asciidoctorModule.block_macro(
+            getClassName(blockMacroProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final BlockMacroProcessor blockMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockMacroProcessor.getClass());
+        asciidoctorModule.block_macro(
+            blockMacroProcessor,
+            RubyUtils.toSymbol(rubyRuntime, blockMacroProcessor.getName()), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final InlineMacroProcessor inlineMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, inlineMacroProcessor.getClass());
+
+        asciidoctorModule.inline_macro(
+            inlineMacroProcessor,
+            RubyUtils.toSymbol(rubyRuntime, inlineMacroProcessor.getName()), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final String blockName, final Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, inlineMacroProcessor);
+
+        asciidoctorModule.inline_macro(
+            RubyUtils.toRubyClass(rubyRuntime, inlineMacroProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final String blockName, final String inlineMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, inlineMacroProcessor);
+
+        asciidoctorModule.inline_macro(
+            getClassName(inlineMacroProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup requireRubyLibrary(final String requiredLibrary) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        RubyUtils.requireLibrary(rubyRuntime, requiredLibrary);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup loadRubyClass(final InputStream rubyClassStream) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        RubyUtils.loadRubyClass(rubyRuntime, rubyClassStream);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyPreprocessor(final String preprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.preprocessor(preprocessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyPostprocessor(final String postprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.postprocessor(postprocessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyDocinfoProcessor(final String docinfoProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.docinfo_processor(docinfoProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyIncludeProcessor(final String includeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.include_processor(includeProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyTreeprocessor(final String treeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.treeprocessor(treeProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyBlock(final String blockName, final String blockProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.block_processor(
+            blockProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyBlockMacro(final String blockName, final String blockMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.block_macro(
+            blockMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyInlineMacro(final String blockName, final String inlineMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.inline_macro(
+            inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  private void javaImport(Ruby ruby, Class<?> clazz) {
+    ruby.evalScriptlet(String.format("java_import '%s'", getImportLine(clazz)));
+  }
+
+  private void javaImport(Ruby ruby, String className) {
+    ruby.evalScriptlet(String.format("java_import '%s'", className));
+  }
+
+  private String getImportLine(Class<?> extensionClass) {
+    int dollarPosition = -1;
+    String className = extensionClass.getName();
+    if ((dollarPosition = className.indexOf("$")) != -1) {
+      className = className.substring(0, dollarPosition);
+    }
+    return className;
+  }
+
+  private String getClassName(String clazz) {
+    return clazz.substring(clazz.lastIndexOf(".")+1);
+  }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -299,13 +299,16 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
 
+        ClassLoader oldTCCL = Thread.currentThread().getContextClassLoader();
         try {
+            Thread.currentThread().setContextClassLoader(rubyRuntime.getJRubyClassLoader());
             Object object = this.asciidoctorModule.convert(content, rubyHash);
             return returnExpectedValue(object);
         } catch(RaiseException e) {
             logger.severe(e.getException().getClass().getCanonicalName());
             throw new AsciidoctorCoreException(e);
         } finally {
+            Thread.currentThread().setContextClassLoader(oldTCCL);
             // we restore current directory to its original value.
             rubyRuntime.setCurrentDirectory(currentDirectory);
         }
@@ -329,14 +332,16 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
 
+        ClassLoader oldTCCL = Thread.currentThread().getContextClassLoader();
         try {
+            Thread.currentThread().setContextClassLoader(rubyRuntime.getJRubyClassLoader());
             Object object = this.asciidoctorModule.convertFile(filename.getAbsolutePath(), rubyHash);
             return returnExpectedValue(object);
         } catch(RaiseException e) {
             logger.severe(e.getMessage());
-
             throw new AsciidoctorCoreException(e);
         } finally {
+            Thread.currentThread().setContextClassLoader(oldTCCL);
             // we restore current directory to its original value.
             rubyRuntime.setCurrentDirectory(currentDirectory);
         }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -26,9 +26,17 @@ import org.jruby.embed.ScriptingContainer;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaEmbedUtils;
 
-import java.io.*;
-import java.util.*;
-import java.util.logging.Level;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 public class JRubyAsciidoctor implements Asciidoctor {
@@ -299,16 +307,13 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
 
-        ClassLoader oldTCCL = Thread.currentThread().getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(rubyRuntime.getJRubyClassLoader());
             Object object = this.asciidoctorModule.convert(content, rubyHash);
             return returnExpectedValue(object);
         } catch(RaiseException e) {
             logger.severe(e.getException().getClass().getCanonicalName());
             throw new AsciidoctorCoreException(e);
         } finally {
-            Thread.currentThread().setContextClassLoader(oldTCCL);
             // we restore current directory to its original value.
             rubyRuntime.setCurrentDirectory(currentDirectory);
         }
@@ -332,16 +337,13 @@ public class JRubyAsciidoctor implements Asciidoctor {
 
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
 
-        ClassLoader oldTCCL = Thread.currentThread().getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(rubyRuntime.getJRubyClassLoader());
             Object object = this.asciidoctorModule.convertFile(filename.getAbsolutePath(), rubyHash);
             return returnExpectedValue(object);
         } catch(RaiseException e) {
             logger.severe(e.getMessage());
             throw new AsciidoctorCoreException(e);
         } finally {
-            Thread.currentThread().setContextClassLoader(oldTCCL);
             // we restore current directory to its original value.
             rubyRuntime.setCurrentDirectory(currentDirectory);
         }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -14,6 +14,7 @@ import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.ast.Title;
 import org.asciidoctor.converter.JavaConverterRegistry;
 import org.asciidoctor.converter.internal.ConverterRegistryExecutor;
+import org.asciidoctor.extension.ExtensionGroup;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.extension.internal.ExtensionRegistryExecutor;
@@ -37,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 public class JRubyAsciidoctor implements Asciidoctor {
@@ -599,6 +601,23 @@ public class JRubyAsciidoctor implements Asciidoctor {
     public Document loadFile(File file, Map<String, Object> options) {
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
         return new Document(this.asciidoctorModule.load_file(file.getAbsolutePath(), rubyHash), this.rubyRuntime);
+    }
 
+    Ruby getRubyRuntime() {
+        return this.rubyRuntime;
+    }
+
+    AsciidoctorModule getAsciidoctorModule() {
+        return asciidoctorModule;
+    }
+
+    @Override
+    public ExtensionGroup createGroup() {
+        return new ExtensionGroupImpl(UUID.randomUUID().toString(), this);
+    }
+
+    @Override
+    public ExtensionGroup createGroup(String groupName) {
+        return new ExtensionGroupImpl(groupName, this);
     }
 }

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -4,7 +4,7 @@ module AsciidoctorJ
         include_package 'org.asciidoctor.extension'
         # Treeprocessor was renamed in to TreeProcessor in https://github.com/asciidoctor/asciidoctor/commit/f1dd816ade9db457b899581841e4cf7b788aa26d
         # This is necessary to run against both Asciidoctor 1.5.5 and 1.5.6
-        TreeProcessor = Treeprocessor
+        TreeProcessor = Treeprocessor unless defined? TreeProcessor
     end
 end
 
@@ -19,50 +19,54 @@ class AsciidoctorModule
         Asciidoctor::Extensions.unregister_all
     end
 
-    def docinfo_processor(extensionName)
-        Asciidoctor::Extensions.register do
+    def unregister_extension name
+        Asciidoctor::Extensions.unregister name
+    end
+
+    def docinfo_processor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             docinfo_processor extensionName
         end
     end
 
-    def treeprocessor(extensionName)
-        Asciidoctor::Extensions.register do 
+    def treeprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             treeprocessor extensionName
         end
     end
     
-    def include_processor(extensionName)
-        Asciidoctor::Extensions.register do
+    def include_processor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             include_processor extensionName
         end
     end
 
-    def preprocessor(extensionName)
-        Asciidoctor::Extensions.register do
+    def preprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             preprocessor extensionName
         end
     end
     
-    def postprocessor(extensionName)
-        Asciidoctor::Extensions.register do
+    def postprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             postprocessor extensionName
         end
     end
 
-    def block_processor(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def block_processor(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             block extensionName, blockSymbol
         end
     end
 
-    def block_macro(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def block_macro(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             block_macro extensionName, blockSymbol
         end
     end
 
-    def inline_macro(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def inline_macro(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             inline_macro extensionName, blockSymbol
         end
     end

--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=1.5.5
+version=1.5.4
 gem_name=asciidoctor-diagram

--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=1.5.4
+version=1.5.4.1
 gem_name=asciidoctor-diagram

--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=1.5.4
+version=1.5.5
 gem_name=asciidoctor-diagram

--- a/asciidoctorj-diagram/src/test/java/org/asciidoctor/WhenDocumentContainsDitaaDiagram.java
+++ b/asciidoctorj-diagram/src/test/java/org/asciidoctor/WhenDocumentContainsDitaaDiagram.java
@@ -6,6 +6,7 @@ import org.asciidoctor.util.ClasspathResources;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static org.asciidoctor.AttributesBuilder.attributes;
 import static org.asciidoctor.OptionsBuilder.options;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   compile("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
     transitive = false
   }
-  compile 'org.jruby:jruby-complete:9.1.12.0'
+  compile 'org.jruby:jruby-complete:9.1.8.0'
 }
 
 jar.enabled = false

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   compile("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
     transitive = false
   }
-  compile 'org.jruby:jruby-complete:9.1.8.0'
+  compile 'org.jruby:jruby-complete:9.1.12.0'
 }
 
 jar.enabled = false

--- a/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenDitaaDiagramIsRendered.java
+++ b/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenDitaaDiagramIsRendered.java
@@ -5,9 +5,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.UUID;
 
+import static org.asciidoctor.AttributesBuilder.attributes;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
@@ -32,7 +32,7 @@ public class WhenDitaaDiagramIsRendered {
             document,
             OptionsBuilder.options()
                 .toFile(false)
-                .attributes(AttributesBuilder.attributes()
+                .attributes(attributes()
                     .attribute("imagesoutdir", "build")));
 
         // then:
@@ -48,7 +48,8 @@ public class WhenDitaaDiagramIsRendered {
         // given:
         final String imageFileName = UUID.randomUUID().toString();
 
-        final File destinationFile = new File("build/ditaa.pdf");
+        final File destinationDir = new File( "build");
+        final File destinationFile = new File( "ditaa.pdf");
 
         final String document = getTestDocument(imageFileName);
 
@@ -60,15 +61,22 @@ public class WhenDitaaDiagramIsRendered {
             document,
             OptionsBuilder.options()
                 .backend("pdf")
+                .toDir(destinationDir)
                 .toFile(destinationFile)
-                .attributes(AttributesBuilder.attributes()
-                    .attribute("imagesoutdir", "build")));
+                .attributes(
+                    attributes()
+                        .attribute("imagesdir", destinationDir.getPath())
+                        .attribute("imagesoutdir", destinationDir.getPath()))
+        );
 
         // then:
-        assertThat(destinationFile.exists(), is(true));
-        assertThat(destinationFile.length(), greaterThan(0L));
-        assertThat("PNG file not created!", new File("build/" + imageFileName + ".png").exists(), is(true));
-        assertThat("PNG cache file not created!", new File("build/.asciidoctor/diagram/" + imageFileName + ".png.cache").exists(), is(true));
+        final File expectedPdfFile = new File(destinationDir, "ditaa.pdf");
+        assertThat(expectedPdfFile + " does not exist", expectedPdfFile.exists(), is(true));
+        assertThat(expectedPdfFile.length(), greaterThan(0L));
+        final File imageFile = new File("build/" + imageFileName + ".png");
+        final File cacheFile = new File(destinationDir, ".asciidoctor/diagram/" + imageFileName + ".png.cache");
+        assertThat("PNG file " + imageFile + " not created!", imageFile.exists(), is(true));
+        assertThat("PNG cache file " + cacheFile + " not created!", cacheFile.exists(), is(true));
     }
 
     private String getTestDocument(String imageFileName) {

--- a/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenPlantumlDiagramIsRendered.java
+++ b/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenPlantumlDiagramIsRendered.java
@@ -7,6 +7,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.util.UUID;
 
+import static org.asciidoctor.AttributesBuilder.attributes;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
@@ -46,7 +47,8 @@ public class WhenPlantumlDiagramIsRendered {
         // given:
         final String imageFileName = UUID.randomUUID().toString();
 
-        final File destinationFile = new File("build/plantuml.pdf");
+        final File destinationDir = new File( "build");
+        final File destinationFile = new File( "plantuml.pdf");
 
         final String document = getTestDocument(imageFileName);
 
@@ -58,15 +60,21 @@ public class WhenPlantumlDiagramIsRendered {
             document,
             OptionsBuilder.options()
                 .backend("pdf")
+                .toDir(destinationDir)
                 .toFile(destinationFile)
-                .attributes(AttributesBuilder.attributes()
-                    .attribute("imagesoutdir", "build")));
+                .attributes(
+                    attributes()
+                        .attribute("imagesdir", destinationDir.getPath())
+                        .attribute("imagesoutdir", destinationDir.getPath())));
 
         // then:
-        assertThat(destinationFile.exists(), is(true));
-        assertThat(destinationFile.length(), greaterThan(0L));
-        assertThat("PNG file not created!", new File("build/" + imageFileName + ".png").exists(), is(true));
-        assertThat("PNG cache file not created!", new File("build/.asciidoctor/diagram/" + imageFileName + ".png.cache").exists(), is(true));
+        final File expectedPdfFile = new File(destinationDir, "plantuml.pdf");
+        assertThat(expectedPdfFile + " does not exist", expectedPdfFile.exists(), is(true));
+        assertThat(expectedPdfFile.length(), greaterThan(0L));
+        final File imageFile = new File("build/" + imageFileName + ".png");
+        final File cacheFile = new File(destinationDir, ".asciidoctor/diagram/" + imageFileName + ".png.cache");
+        assertThat("PNG file " + imageFile + " not created!", imageFile.exists(), is(true));
+        assertThat("PNG cache file " + cacheFile + " not created!", cacheFile.exists(), is(true));
     }
 
     private String getTestDocument(String imageFileName) {

--- a/asciidoctorj-epub3/gradle.properties
+++ b/asciidoctorj-epub3/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ EPUB3
 description=AsciidoctorJ EPUB3 bundles the Asciidoctor EPUB3 RubyGem (asciidoctor-epub3) so it can be loaded into the JVM using JRuby.
-version=1.5.0-alpha.6
+version=1.5.0-alpha.7
 gem_name=asciidoctor-epub3

--- a/asciidoctorj-epub3/src/test/java/org/asciidoctor/WhenEpub3BackendIsUsed.java
+++ b/asciidoctorj-epub3/src/test/java/org/asciidoctor/WhenEpub3BackendIsUsed.java
@@ -14,7 +14,7 @@ import org.junit.Ignore;
 
 public class WhenEpub3BackendIsUsed {
 
-    private Asciidoctor asciidoctor = JRubyAsciidoctor.create();
+    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
     
     @Rule
     public ClasspathResources classpath = new ClasspathResources();

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
   statusIsRelease = (status == 'release')
 
   // jar versions
-  asciidoctorjPdfVersion = '1.5.0-alpha.15'
+  asciidoctorjPdfVersion = '1.5.0-alpha.16'
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
   hamlGemVersion = '4.0.5'
   openUriCachedGemVersion = '0.0.5'
   slimGemVersion = '3.0.6'
-  threadSafeGemVersion = '0.3.5'
+  threadSafeGemVersion = '0.3.6'
   tiltGemVersion = '2.0.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
   xmlMatchersVersion = '1.0-RC1'
 
   // gem versions
-  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.5'
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.6'
   asciidoctorEpub3GemVersion = project(':asciidoctorj-epub3').version.replace('-', '.')
 
   asciidoctorDiagramGemVersion = project(':asciidoctorj-diagram').version.replace('-', '.')

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
   xmlMatchersVersion = '1.0-RC1'
 
   // gem versions
-  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.6'
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.6.1'
   asciidoctorEpub3GemVersion = project(':asciidoctorj-epub3').version.replace('-', '.')
 
   asciidoctorDiagramGemVersion = project(':asciidoctorj-diagram').version.replace('-', '.')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.5.5-SNAPSHOT
+version=1.5.6-SNAPSHOT
 sourceCompatibility=1.6
 targetCompatibility=1.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.5.6-SNAPSHOT
+version=1.5.6
 sourceCompatibility=1.6
 targetCompatibility=1.6


### PR DESCRIPTION
This PR updates Asciidoctor core to 1.5.6 and Asciidoctor-Diagram to 1.5.5.
(Asciidoctor 1.5.6 will not run with any other version Asciidoctor-Diagram – see asciidoctor/asciidoctor-diagram#154 and asciidoctor/asciidoctor-diagram#159)

To fix asciidoctor/asciidoctor-diagram#159 the TCCL is changed while rendering the document to the current JRubyClassLoader. This is necessary because asciidoctor-diagram requires access to other jars in that gem via the TCCL.
This might impact extensions though, that require the TCCL to be set to sth else, possibly extensions that run in a JavaEE environment. I can't say anything about how OSGi class loading would be impacted due to my lack of knowledge.

What is missing though is the update to the latest epub3 converter, the first test failed and I'll look into it.