### PR TITLE
Fixes #359. Explicit unregistration of extensions.

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -638,7 +638,13 @@ public interface Asciidoctor {
      * Unregister all registered extensions.
      */
     void unregisterAllExtensions();
-    
+
+    /**
+     * Unregisters the extension represented by the given registration name.
+     * @param registrationName
+     */
+    void unregisterExtension(String registrationName);
+
     /**
      * This method frees all resources consumed by asciidoctorJ module. Keep in mind that if this method is called, instance becomes unusable and you should create another instance.
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -652,12 +652,6 @@ public interface Asciidoctor {
     void unregisterAllExtensions();
 
     /**
-     * Unregisters the extension represented by the given registration name.
-     * @param registrationName
-     */
-    void unregisterExtension(String registrationName);
-
-    /**
      * This method frees all resources consumed by asciidoctorJ module. Keep in mind that if this method is called, instance becomes unusable and you should create another instance.
      */
     void shutdown();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -13,6 +13,7 @@ import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.DocumentRuby;
 import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.converter.JavaConverterRegistry;
+import org.asciidoctor.extension.ExtensionGroup;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.internal.JRubyAsciidoctor;
@@ -633,7 +634,18 @@ public interface Asciidoctor {
      * @return Converter Registry object.
      */
     JavaConverterRegistry javaConverterRegistry();
-    
+
+    /**
+     * Creates an ExtensionGroup that can be used to register and unregister a group of extensions.
+     * @return
+     */
+    ExtensionGroup createGroup();
+
+    /**
+     * Creates an ExtensionGroup that can be used to register and unregister a group of extensions.
+     * @return
+     */
+    ExtensionGroup createGroup(String groupName);
     /**
      * Unregister all registered extensions.
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionGroup.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionGroup.java
@@ -1,0 +1,74 @@
+package org.asciidoctor.extension;
+
+
+import java.io.InputStream;
+
+/**
+ * An ExtensionGroup allows to collectively register and unregister extensions.
+ * All extensions are registered lazily and are not effective before a call to {@link #register()}.
+ *
+ * <p>Example:
+ * <code><pre>
+ * ExtensionGroup group = asciidoctor.createGroup();
+ * group.block(myBlock).preprocessor(mypreprocessor);
+ *
+ * // Convert with extensions
+ * group.register();
+ * asciidoctor.convert(...);
+ * group.unregister();
+ *
+ * // Convert without extensions
+ * asciidoctor.convert(...);
+ * </pre></code></p>
+ */
+public interface ExtensionGroup {
+
+  public void register();
+
+  public void unregister();
+
+  public ExtensionGroup docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor);
+  public ExtensionGroup docinfoProcessor(DocinfoProcessor docInfoProcessor);
+  public ExtensionGroup docinfoProcessor(String docInfoProcessor);
+
+  public ExtensionGroup preprocessor(Class<? extends Preprocessor> preprocessor);
+  public ExtensionGroup preprocessor(Preprocessor preprocessor);
+  public ExtensionGroup preprocessor(String preprocessor);
+
+  public ExtensionGroup postprocessor(String postprocessor);
+  public ExtensionGroup postprocessor(Class<? extends Postprocessor> postprocessor);
+  public ExtensionGroup postprocessor(Postprocessor postprocesor);
+
+  public ExtensionGroup includeProcessor(String includeProcessor);
+  public ExtensionGroup includeProcessor(Class<? extends IncludeProcessor> includeProcessor);
+  public ExtensionGroup includeProcessor(IncludeProcessor includeProcessor);
+
+  public ExtensionGroup treeprocessor(Treeprocessor treeprocessor);
+  public ExtensionGroup treeprocessor(Class<? extends Treeprocessor> treeProcessor);
+  public ExtensionGroup treeprocessor(String treeProcessor);
+
+  public ExtensionGroup block(String blockName, String blockProcessor);
+  public ExtensionGroup block(String blockName, Class<? extends BlockProcessor> blockProcessor);
+  public ExtensionGroup block(BlockProcessor blockProcessor);
+  public ExtensionGroup block(String blockName, BlockProcessor blockProcessor);
+
+  public ExtensionGroup blockMacro(String blockName, Class<? extends BlockMacroProcessor> blockMacroProcessor);
+  public ExtensionGroup blockMacro(String blockName, String blockMacroProcessor);
+  public ExtensionGroup blockMacro(BlockMacroProcessor blockMacroProcessor);
+
+  public ExtensionGroup inlineMacro(InlineMacroProcessor inlineMacroProcessor);
+  public ExtensionGroup inlineMacro(String blockName, Class<? extends InlineMacroProcessor> inlineMacroProcessor);
+  public ExtensionGroup inlineMacro(String blockName, String inlineMacroProcessor);
+
+  public ExtensionGroup requireRubyLibrary(String requiredLibrary);
+  public ExtensionGroup loadRubyClass(InputStream rubyClassStream);
+
+  public ExtensionGroup rubyPreprocessor(String preprocessor);
+  public ExtensionGroup rubyPostprocessor(String postprocessor);
+  public ExtensionGroup rubyDocinfoProcessor(String docinfoProcessor);
+  public ExtensionGroup rubyIncludeProcessor(String includeProcessor);
+  public ExtensionGroup rubyTreeprocessor(String treeProcessor);
+  public ExtensionGroup rubyBlock(String blockName, String blockProcessor);
+  public ExtensionGroup rubyBlockMacro(String blockName, String blockMacroProcessor);
+  public ExtensionGroup rubyInlineMacro(String blockName, String inlineMacroProcessor);
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
@@ -22,11 +22,25 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.docinfo_processor(RubyUtils.toRubyClass(rubyRuntime, docInfoProcessor));
     }
 
+    public void docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, docInfoProcessor);
+        this.asciidoctorModule.docinfo_processor(RubyUtils.toRubyClass(rubyRuntime, docInfoProcessor), registrationName);
+    }
+
     public void docinfoProcessor(DocinfoProcessor docInfoProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
         javaImport(rubyRuntime, docInfoProcessor.getClass());
         this.asciidoctorModule.docinfo_processor(docInfoProcessor);
+    }
+
+    public void docinfoProcessor(DocinfoProcessor docInfoProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, docInfoProcessor.getClass());
+        this.asciidoctorModule.docinfo_processor(docInfoProcessor, registrationName);
     }
 
     public void docinfoProcessor(String docInfoProcessor) {
@@ -36,11 +50,25 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.docinfo_processor(getClassName(docInfoProcessor));
     }
 
+    public void docinfoProcessor(String docInfoProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, docInfoProcessor);
+        this.asciidoctorModule.docinfo_processor(getClassName(docInfoProcessor), registrationName);
+    }
+
     public void preprocessor(Class<? extends Preprocessor> preprocessor) {
         // this may change in future to external class to deal with dynamic
         // imports
         javaImport(rubyRuntime, preprocessor);
         this.asciidoctorModule.preprocessor(RubyUtils.toRubyClass(rubyRuntime, preprocessor));
+    }
+
+    public void preprocessor(Class<? extends Preprocessor> preprocessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, preprocessor);
+        this.asciidoctorModule.preprocessor(RubyUtils.toRubyClass(rubyRuntime, preprocessor), registrationName);
     }
 
     public void preprocessor(Preprocessor preprocessor) {
@@ -50,6 +78,13 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.preprocessor(preprocessor);
     }
     
+    public void preprocessor(Preprocessor preprocessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, preprocessor.getClass());
+        this.asciidoctorModule.preprocessor(preprocessor, registrationName);
+    }
+
     public void preprocessor(String preprocessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -57,6 +92,13 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.preprocessor(getClassName(preprocessor));
     }
     
+    public void preprocessor(String preprocessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, preprocessor);
+        this.asciidoctorModule.preprocessor(getClassName(preprocessor), registrationName);
+    }
+
     public void postprocessor(String postprocessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -64,6 +106,13 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.postprocessor(getClassName(postprocessor));
     }
     
+    public void postprocessor(String postprocessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, postprocessor);
+        this.asciidoctorModule.postprocessor(getClassName(postprocessor), registrationName);
+    }
+
     public void postprocessor(Class<? extends Postprocessor> postprocessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -71,11 +120,25 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.postprocessor(RubyUtils.toRubyClass(rubyRuntime, postprocessor));
     }
     
+    public void postprocessor(Class<? extends Postprocessor> postprocessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, postprocessor);
+        this.asciidoctorModule.postprocessor(RubyUtils.toRubyClass(rubyRuntime, postprocessor), registrationName);
+    }
+
     public void postprocessor(Postprocessor postprocesor) {
         // this may change in future to external class to deal with dynamic
         // imports
         javaImport(rubyRuntime, postprocesor.getClass());
         this.asciidoctorModule.postprocessor(postprocesor);
+    }
+
+    public void postprocessor(Postprocessor postprocesor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, postprocesor.getClass());
+        this.asciidoctorModule.postprocessor(postprocesor, registrationName);
     }
 
     public void includeProcessor(String includeProcessor) {
@@ -85,6 +148,13 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.include_processor(getClassName(includeProcessor));
     }
     
+    public void includeProcessor(String includeProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, includeProcessor);
+        this.asciidoctorModule.include_processor(getClassName(includeProcessor), registrationName);
+    }
+
     public void includeProcessor(
             Class<? extends IncludeProcessor> includeProcessor) {
         // this may change in future to external class to deal with dynamic
@@ -93,17 +163,36 @@ public class JavaExtensionRegistry {
       this.asciidoctorModule.include_processor(RubyUtils.toRubyClass(rubyRuntime, includeProcessor));
     }
 
+    public void includeProcessor(
+            Class<? extends IncludeProcessor> includeProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, includeProcessor);
+      this.asciidoctorModule.include_processor(RubyUtils.toRubyClass(rubyRuntime, includeProcessor), registrationName);
+    }
+
     public void includeProcessor(IncludeProcessor includeProcessor) {
         String importLine = getImportLine(includeProcessor.getClass());
         javaImport(rubyRuntime, importLine);
         this.asciidoctorModule.include_processor(includeProcessor);
     }
     
+    public void includeProcessor(IncludeProcessor includeProcessor, String registrationName) {
+        String importLine = getImportLine(includeProcessor.getClass());
+        javaImport(rubyRuntime, importLine);
+        this.asciidoctorModule.include_processor(includeProcessor, registrationName);
+    }
+
     public void treeprocessor(Treeprocessor treeprocessor) {
         javaImport(rubyRuntime, treeprocessor.getClass());
         this.asciidoctorModule.treeprocessor(treeprocessor);
     }
     
+    public void treeprocessor(Treeprocessor treeprocessor, String registrationName) {
+        javaImport(rubyRuntime, treeprocessor.getClass());
+        this.asciidoctorModule.treeprocessor(treeprocessor, registrationName);
+    }
+
     public void treeprocessor(Class<? extends Treeprocessor> treeProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -111,11 +200,25 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.treeprocessor(RubyUtils.toRubyClass(rubyRuntime, treeProcessor));
     }
     
+    public void treeprocessor(Class<? extends Treeprocessor> treeProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, treeProcessor);
+        this.asciidoctorModule.treeprocessor(RubyUtils.toRubyClass(rubyRuntime, treeProcessor), registrationName);
+    }
+
     public void treeprocessor(String treeProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
         javaImport(rubyRuntime, treeProcessor);
         this.asciidoctorModule.treeprocessor(getClassName(treeProcessor));
+    }
+
+    public void treeprocessor(String treeProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, treeProcessor);
+        this.asciidoctorModule.treeprocessor(getClassName(treeProcessor), registrationName);
     }
 
     public void block(String blockName,
@@ -130,6 +233,17 @@ public class JavaExtensionRegistry {
     }
     
     public void block(String blockName,
+           String blockProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, blockProcessor);
+
+        this.asciidoctorModule.block_processor(
+                getClassName(blockProcessor),
+                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
+    }
+
+    public void block(String blockName,
             Class<? extends BlockProcessor> blockProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -140,10 +254,25 @@ public class JavaExtensionRegistry {
                 RubyUtils.toSymbol(rubyRuntime, blockName));
     }
 
+    public void block(String blockName,
+            Class<? extends BlockProcessor> blockProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, blockProcessor);
+
+        this.asciidoctorModule.block_processor(
+                RubyUtils.toRubyClass(rubyRuntime, blockProcessor),
+                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
+    }
+
     public void block(BlockProcessor blockProcessor) {
         block(blockProcessor.getName(), blockProcessor);
     }
     
+    public void block(BlockProcessor blockProcessor, String registrationName) {
+        block(blockProcessor.getName(), blockProcessor, registrationName);
+    }
+
     public void block(String blockName,
             BlockProcessor blockProcessor) {
         // this may change in future to external class to deal with dynamic
@@ -153,6 +282,17 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.block_processor(
                 blockProcessor,
                 RubyUtils.toSymbol(rubyRuntime, blockName));
+    }
+
+    public void block(String blockName,
+            BlockProcessor blockProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, blockProcessor.getClass());
+
+        this.asciidoctorModule.block_processor(
+                blockProcessor,
+                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
     }
 
     public void blockMacro(String blockName,
@@ -166,6 +306,16 @@ public class JavaExtensionRegistry {
     }
 
     public void blockMacro(String blockName,
+            Class<? extends BlockMacroProcessor> blockMacroProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, blockMacroProcessor);
+        this.asciidoctorModule.block_macro(
+                blockMacroProcessor.getSimpleName(),
+                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
+    }
+
+    public void blockMacro(String blockName,
             String blockMacroProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -175,6 +325,16 @@ public class JavaExtensionRegistry {
                 RubyUtils.toSymbol(rubyRuntime, blockName));
     }
     
+    public void blockMacro(String blockName,
+            String blockMacroProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, blockMacroProcessor);
+        this.asciidoctorModule.block_macro(
+                getClassName(blockMacroProcessor),
+                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
+    }
+
     public void blockMacro(BlockMacroProcessor blockMacroProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -182,6 +342,15 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.block_macro(
                 blockMacroProcessor,
                 RubyUtils.toSymbol(rubyRuntime, blockMacroProcessor.getName()));
+    }
+
+    public void blockMacro(BlockMacroProcessor blockMacroProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, blockMacroProcessor.getClass());
+        this.asciidoctorModule.block_macro(
+                blockMacroProcessor,
+                RubyUtils.toSymbol(rubyRuntime, blockMacroProcessor.getName()), registrationName);
     }
 
     public void inlineMacro(InlineMacroProcessor inlineMacroProcessor) {
@@ -194,6 +363,16 @@ public class JavaExtensionRegistry {
                 RubyUtils.toSymbol(rubyRuntime, inlineMacroProcessor.getName()));
     }
     
+    public void inlineMacro(InlineMacroProcessor inlineMacroProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, inlineMacroProcessor.getClass());
+
+        this.asciidoctorModule.inline_macro(
+        		inlineMacroProcessor,
+                RubyUtils.toSymbol(rubyRuntime, inlineMacroProcessor.getName()), registrationName);
+    }
+
     public void inlineMacro(String blockName,
             Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
         // this may change in future to external class to deal with dynamic
@@ -205,6 +384,17 @@ public class JavaExtensionRegistry {
                 RubyUtils.toSymbol(rubyRuntime, blockName));
     }
     
+    public void inlineMacro(String blockName,
+            Class<? extends InlineMacroProcessor> inlineMacroProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic
+        // imports
+        javaImport(rubyRuntime, inlineMacroProcessor);
+
+        this.asciidoctorModule.inline_macro(
+        		RubyUtils.toRubyClass(rubyRuntime, inlineMacroProcessor),
+                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
+    }
+
     public void inlineMacro(String blockName, String inlineMacroProcessor) {
         // this may change in future to external class to deal with dynamic imports
         javaImport(this.rubyRuntime, inlineMacroProcessor);
@@ -212,6 +402,15 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.inline_macro(
         		getClassName(inlineMacroProcessor),
                 RubyUtils.toSymbol(rubyRuntime, blockName));
+    }
+
+    public void inlineMacro(String blockName, String inlineMacroProcessor, String registrationName) {
+        // this may change in future to external class to deal with dynamic imports
+        javaImport(this.rubyRuntime, inlineMacroProcessor);
+
+        this.asciidoctorModule.inline_macro(
+        		getClassName(inlineMacroProcessor),
+                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
     }
 
     private void javaImport(Ruby ruby, Class<?> clazz) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
@@ -22,25 +22,11 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.docinfo_processor(RubyUtils.toRubyClass(rubyRuntime, docInfoProcessor));
     }
 
-    public void docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, docInfoProcessor);
-        this.asciidoctorModule.docinfo_processor(RubyUtils.toRubyClass(rubyRuntime, docInfoProcessor), registrationName);
-    }
-
     public void docinfoProcessor(DocinfoProcessor docInfoProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
         javaImport(rubyRuntime, docInfoProcessor.getClass());
         this.asciidoctorModule.docinfo_processor(docInfoProcessor);
-    }
-
-    public void docinfoProcessor(DocinfoProcessor docInfoProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, docInfoProcessor.getClass());
-        this.asciidoctorModule.docinfo_processor(docInfoProcessor, registrationName);
     }
 
     public void docinfoProcessor(String docInfoProcessor) {
@@ -50,25 +36,11 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.docinfo_processor(getClassName(docInfoProcessor));
     }
 
-    public void docinfoProcessor(String docInfoProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, docInfoProcessor);
-        this.asciidoctorModule.docinfo_processor(getClassName(docInfoProcessor), registrationName);
-    }
-
     public void preprocessor(Class<? extends Preprocessor> preprocessor) {
         // this may change in future to external class to deal with dynamic
         // imports
         javaImport(rubyRuntime, preprocessor);
         this.asciidoctorModule.preprocessor(RubyUtils.toRubyClass(rubyRuntime, preprocessor));
-    }
-
-    public void preprocessor(Class<? extends Preprocessor> preprocessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, preprocessor);
-        this.asciidoctorModule.preprocessor(RubyUtils.toRubyClass(rubyRuntime, preprocessor), registrationName);
     }
 
     public void preprocessor(Preprocessor preprocessor) {
@@ -78,13 +50,6 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.preprocessor(preprocessor);
     }
     
-    public void preprocessor(Preprocessor preprocessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, preprocessor.getClass());
-        this.asciidoctorModule.preprocessor(preprocessor, registrationName);
-    }
-
     public void preprocessor(String preprocessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -92,13 +57,6 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.preprocessor(getClassName(preprocessor));
     }
     
-    public void preprocessor(String preprocessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, preprocessor);
-        this.asciidoctorModule.preprocessor(getClassName(preprocessor), registrationName);
-    }
-
     public void postprocessor(String postprocessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -106,13 +64,6 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.postprocessor(getClassName(postprocessor));
     }
     
-    public void postprocessor(String postprocessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, postprocessor);
-        this.asciidoctorModule.postprocessor(getClassName(postprocessor), registrationName);
-    }
-
     public void postprocessor(Class<? extends Postprocessor> postprocessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -120,25 +71,11 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.postprocessor(RubyUtils.toRubyClass(rubyRuntime, postprocessor));
     }
     
-    public void postprocessor(Class<? extends Postprocessor> postprocessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, postprocessor);
-        this.asciidoctorModule.postprocessor(RubyUtils.toRubyClass(rubyRuntime, postprocessor), registrationName);
-    }
-
     public void postprocessor(Postprocessor postprocesor) {
         // this may change in future to external class to deal with dynamic
         // imports
         javaImport(rubyRuntime, postprocesor.getClass());
         this.asciidoctorModule.postprocessor(postprocesor);
-    }
-
-    public void postprocessor(Postprocessor postprocesor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, postprocesor.getClass());
-        this.asciidoctorModule.postprocessor(postprocesor, registrationName);
     }
 
     public void includeProcessor(String includeProcessor) {
@@ -148,13 +85,6 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.include_processor(getClassName(includeProcessor));
     }
     
-    public void includeProcessor(String includeProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, includeProcessor);
-        this.asciidoctorModule.include_processor(getClassName(includeProcessor), registrationName);
-    }
-
     public void includeProcessor(
             Class<? extends IncludeProcessor> includeProcessor) {
         // this may change in future to external class to deal with dynamic
@@ -163,36 +93,17 @@ public class JavaExtensionRegistry {
       this.asciidoctorModule.include_processor(RubyUtils.toRubyClass(rubyRuntime, includeProcessor));
     }
 
-    public void includeProcessor(
-            Class<? extends IncludeProcessor> includeProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, includeProcessor);
-      this.asciidoctorModule.include_processor(RubyUtils.toRubyClass(rubyRuntime, includeProcessor), registrationName);
-    }
-
     public void includeProcessor(IncludeProcessor includeProcessor) {
         String importLine = getImportLine(includeProcessor.getClass());
         javaImport(rubyRuntime, importLine);
         this.asciidoctorModule.include_processor(includeProcessor);
     }
     
-    public void includeProcessor(IncludeProcessor includeProcessor, String registrationName) {
-        String importLine = getImportLine(includeProcessor.getClass());
-        javaImport(rubyRuntime, importLine);
-        this.asciidoctorModule.include_processor(includeProcessor, registrationName);
-    }
-
     public void treeprocessor(Treeprocessor treeprocessor) {
         javaImport(rubyRuntime, treeprocessor.getClass());
         this.asciidoctorModule.treeprocessor(treeprocessor);
     }
     
-    public void treeprocessor(Treeprocessor treeprocessor, String registrationName) {
-        javaImport(rubyRuntime, treeprocessor.getClass());
-        this.asciidoctorModule.treeprocessor(treeprocessor, registrationName);
-    }
-
     public void treeprocessor(Class<? extends Treeprocessor> treeProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -200,25 +111,11 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.treeprocessor(RubyUtils.toRubyClass(rubyRuntime, treeProcessor));
     }
     
-    public void treeprocessor(Class<? extends Treeprocessor> treeProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, treeProcessor);
-        this.asciidoctorModule.treeprocessor(RubyUtils.toRubyClass(rubyRuntime, treeProcessor), registrationName);
-    }
-
     public void treeprocessor(String treeProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
         javaImport(rubyRuntime, treeProcessor);
         this.asciidoctorModule.treeprocessor(getClassName(treeProcessor));
-    }
-
-    public void treeprocessor(String treeProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, treeProcessor);
-        this.asciidoctorModule.treeprocessor(getClassName(treeProcessor), registrationName);
     }
 
     public void block(String blockName,
@@ -233,17 +130,6 @@ public class JavaExtensionRegistry {
     }
     
     public void block(String blockName,
-           String blockProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, blockProcessor);
-
-        this.asciidoctorModule.block_processor(
-                getClassName(blockProcessor),
-                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
-    }
-
-    public void block(String blockName,
             Class<? extends BlockProcessor> blockProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -254,25 +140,10 @@ public class JavaExtensionRegistry {
                 RubyUtils.toSymbol(rubyRuntime, blockName));
     }
 
-    public void block(String blockName,
-            Class<? extends BlockProcessor> blockProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, blockProcessor);
-
-        this.asciidoctorModule.block_processor(
-                RubyUtils.toRubyClass(rubyRuntime, blockProcessor),
-                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
-    }
-
     public void block(BlockProcessor blockProcessor) {
         block(blockProcessor.getName(), blockProcessor);
     }
     
-    public void block(BlockProcessor blockProcessor, String registrationName) {
-        block(blockProcessor.getName(), blockProcessor, registrationName);
-    }
-
     public void block(String blockName,
             BlockProcessor blockProcessor) {
         // this may change in future to external class to deal with dynamic
@@ -282,17 +153,6 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.block_processor(
                 blockProcessor,
                 RubyUtils.toSymbol(rubyRuntime, blockName));
-    }
-
-    public void block(String blockName,
-            BlockProcessor blockProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, blockProcessor.getClass());
-
-        this.asciidoctorModule.block_processor(
-                blockProcessor,
-                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
     }
 
     public void blockMacro(String blockName,
@@ -306,16 +166,6 @@ public class JavaExtensionRegistry {
     }
 
     public void blockMacro(String blockName,
-            Class<? extends BlockMacroProcessor> blockMacroProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, blockMacroProcessor);
-        this.asciidoctorModule.block_macro(
-                blockMacroProcessor.getSimpleName(),
-                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
-    }
-
-    public void blockMacro(String blockName,
             String blockMacroProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -325,16 +175,6 @@ public class JavaExtensionRegistry {
                 RubyUtils.toSymbol(rubyRuntime, blockName));
     }
     
-    public void blockMacro(String blockName,
-            String blockMacroProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, blockMacroProcessor);
-        this.asciidoctorModule.block_macro(
-                getClassName(blockMacroProcessor),
-                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
-    }
-
     public void blockMacro(BlockMacroProcessor blockMacroProcessor) {
         // this may change in future to external class to deal with dynamic
         // imports
@@ -342,15 +182,6 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.block_macro(
                 blockMacroProcessor,
                 RubyUtils.toSymbol(rubyRuntime, blockMacroProcessor.getName()));
-    }
-
-    public void blockMacro(BlockMacroProcessor blockMacroProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, blockMacroProcessor.getClass());
-        this.asciidoctorModule.block_macro(
-                blockMacroProcessor,
-                RubyUtils.toSymbol(rubyRuntime, blockMacroProcessor.getName()), registrationName);
     }
 
     public void inlineMacro(InlineMacroProcessor inlineMacroProcessor) {
@@ -363,16 +194,6 @@ public class JavaExtensionRegistry {
                 RubyUtils.toSymbol(rubyRuntime, inlineMacroProcessor.getName()));
     }
     
-    public void inlineMacro(InlineMacroProcessor inlineMacroProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, inlineMacroProcessor.getClass());
-
-        this.asciidoctorModule.inline_macro(
-        		inlineMacroProcessor,
-                RubyUtils.toSymbol(rubyRuntime, inlineMacroProcessor.getName()), registrationName);
-    }
-
     public void inlineMacro(String blockName,
             Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
         // this may change in future to external class to deal with dynamic
@@ -384,17 +205,6 @@ public class JavaExtensionRegistry {
                 RubyUtils.toSymbol(rubyRuntime, blockName));
     }
     
-    public void inlineMacro(String blockName,
-            Class<? extends InlineMacroProcessor> inlineMacroProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic
-        // imports
-        javaImport(rubyRuntime, inlineMacroProcessor);
-
-        this.asciidoctorModule.inline_macro(
-        		RubyUtils.toRubyClass(rubyRuntime, inlineMacroProcessor),
-                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
-    }
-
     public void inlineMacro(String blockName, String inlineMacroProcessor) {
         // this may change in future to external class to deal with dynamic imports
         javaImport(this.rubyRuntime, inlineMacroProcessor);
@@ -402,15 +212,6 @@ public class JavaExtensionRegistry {
         this.asciidoctorModule.inline_macro(
         		getClassName(inlineMacroProcessor),
                 RubyUtils.toSymbol(rubyRuntime, blockName));
-    }
-
-    public void inlineMacro(String blockName, String inlineMacroProcessor, String registrationName) {
-        // this may change in future to external class to deal with dynamic imports
-        javaImport(this.rubyRuntime, inlineMacroProcessor);
-
-        this.asciidoctorModule.inline_macro(
-        		getClassName(inlineMacroProcessor),
-                RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
     }
 
     private void javaImport(Ruby ruby, Class<?> clazz) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
@@ -33,8 +33,18 @@ public class RubyExtensionRegistry {
         return this;
     }
 
-    public RubyExtensionRegistry postprocessor(String postprocesor) {
-        this.asciidoctorModule.postprocessor(postprocesor);
+    public RubyExtensionRegistry preprocessor(String preprocessor, String registrationName) {
+        this.asciidoctorModule.preprocessor(preprocessor, registrationName);
+        return this;
+    }
+
+    public RubyExtensionRegistry postprocessor(String postprocessor) {
+        this.asciidoctorModule.postprocessor(postprocessor);
+        return this;
+    }
+
+    public RubyExtensionRegistry postprocessor(String postprocessor, String registrationName) {
+        this.asciidoctorModule.postprocessor(postprocessor, registrationName);
         return this;
     }
 
@@ -43,8 +53,18 @@ public class RubyExtensionRegistry {
         return this;
     }
 
+    public RubyExtensionRegistry docinfoProcessor(String docinfoProcessor, String registrationName) {
+        this.asciidoctorModule.docinfo_processor(docinfoProcessor, registrationName);
+        return this;
+    }
+
     public RubyExtensionRegistry includeProcessor(String includeProcessor) {
         this.asciidoctorModule.include_processor(includeProcessor);
+        return this;
+    }
+
+    public RubyExtensionRegistry includeProcessor(String includeProcessor, String registrationName) {
+        this.asciidoctorModule.include_processor(includeProcessor, registrationName);
         return this;
     }
 
@@ -53,9 +73,20 @@ public class RubyExtensionRegistry {
         return this;
     }
 
+    public RubyExtensionRegistry treeprocessor(String treeProcessor, String registrationName) {
+        this.asciidoctorModule.treeprocessor(treeProcessor, registrationName);
+        return this;
+    }
+
     public RubyExtensionRegistry block(String blockName, String blockProcessor) {
         this.asciidoctorModule.block_processor(
                 blockProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
+        return this;
+    }
+
+    public RubyExtensionRegistry block(String blockName, String blockProcessor, String registrationName) {
+        this.asciidoctorModule.block_processor(
+                blockProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
         return this;
     }
 
@@ -66,10 +97,24 @@ public class RubyExtensionRegistry {
         return this;
     }
 
+    public RubyExtensionRegistry blockMacro(String blockName, String blockMacroProcessor, String registrationName) {
+
+        this.asciidoctorModule.block_macro(
+                blockMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
+        return this;
+    }
+
     public RubyExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor) {
 
         this.asciidoctorModule.inline_macro(
                 inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
+        return this;
+    }
+
+    public RubyExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor, String registrationName) {
+
+        this.asciidoctorModule.inline_macro(
+                inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
         return this;
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
@@ -9,6 +9,7 @@ import org.jruby.Ruby;
 public class RubyExtensionRegistry {
 
     private AsciidoctorModule asciidoctorModule;
+
     private Ruby rubyRuntime;
 
     public RubyExtensionRegistry(AsciidoctorModule asciidoctorModule,
@@ -33,18 +34,8 @@ public class RubyExtensionRegistry {
         return this;
     }
 
-    public RubyExtensionRegistry preprocessor(String preprocessor, String registrationName) {
-        this.asciidoctorModule.preprocessor(preprocessor, registrationName);
-        return this;
-    }
-
     public RubyExtensionRegistry postprocessor(String postprocessor) {
         this.asciidoctorModule.postprocessor(postprocessor);
-        return this;
-    }
-
-    public RubyExtensionRegistry postprocessor(String postprocessor, String registrationName) {
-        this.asciidoctorModule.postprocessor(postprocessor, registrationName);
         return this;
     }
 
@@ -53,18 +44,8 @@ public class RubyExtensionRegistry {
         return this;
     }
 
-    public RubyExtensionRegistry docinfoProcessor(String docinfoProcessor, String registrationName) {
-        this.asciidoctorModule.docinfo_processor(docinfoProcessor, registrationName);
-        return this;
-    }
-
     public RubyExtensionRegistry includeProcessor(String includeProcessor) {
         this.asciidoctorModule.include_processor(includeProcessor);
-        return this;
-    }
-
-    public RubyExtensionRegistry includeProcessor(String includeProcessor, String registrationName) {
-        this.asciidoctorModule.include_processor(includeProcessor, registrationName);
         return this;
     }
 
@@ -73,20 +54,9 @@ public class RubyExtensionRegistry {
         return this;
     }
 
-    public RubyExtensionRegistry treeprocessor(String treeProcessor, String registrationName) {
-        this.asciidoctorModule.treeprocessor(treeProcessor, registrationName);
-        return this;
-    }
-
     public RubyExtensionRegistry block(String blockName, String blockProcessor) {
         this.asciidoctorModule.block_processor(
                 blockProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
-        return this;
-    }
-
-    public RubyExtensionRegistry block(String blockName, String blockProcessor, String registrationName) {
-        this.asciidoctorModule.block_processor(
-                blockProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
         return this;
     }
 
@@ -97,25 +67,10 @@ public class RubyExtensionRegistry {
         return this;
     }
 
-    public RubyExtensionRegistry blockMacro(String blockName, String blockMacroProcessor, String registrationName) {
-
-        this.asciidoctorModule.block_macro(
-                blockMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
-        return this;
-    }
-
     public RubyExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor) {
 
         this.asciidoctorModule.inline_macro(
                 inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
         return this;
     }
-
-    public RubyExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor, String registrationName) {
-
-        this.asciidoctorModule.inline_macro(
-                inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), registrationName);
-        return this;
-    }
-
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
@@ -69,7 +69,7 @@ public interface AsciidoctorModule {
     void docinfo_processor(DocinfoProcessor docInfoClassName, String registrationName);
 
     void unregister_all_extensions();
-    void unregister_extension(String registrationName);
+    void unregister_extension(String groupName);
 
     Object convert(String content, Map<String, Object> options);
     Object convertFile(String filename, Map<String, Object> options);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
@@ -13,38 +13,63 @@ import org.jruby.RubyHash;
 public interface AsciidoctorModule {
 
     void preprocessor(String preprocessorClassName);
+    void preprocessor(String preprocessorClassName, String registrationName);
     void preprocessor(RubyClass preprocessorClassName);
-	void preprocessor(Preprocessor preprocessor);
-	
+    void preprocessor(RubyClass preprocessorClassName, String registrationName);
+	  void preprocessor(Preprocessor preprocessor);
+	  void preprocessor(Preprocessor preprocessor, String registrationName);
+
     void postprocessor(String postprocessorClassName);
+    void postprocessor(String postprocessorClassName, String registrationName);
     void postprocessor(RubyClass postprocessorClassName);
+    void postprocessor(RubyClass postprocessorClassName, String registrationName);
     void postprocessor(Postprocessor postprocessor);
-    
+    void postprocessor(Postprocessor postprocessor, String registrationName);
+
     void treeprocessor(String treeprocessor);
+    void treeprocessor(String treeprocessor, String registrationName);
     void treeprocessor(RubyClass treeprocessorClassName);
+    void treeprocessor(RubyClass treeprocessorClassName, String registrationName);
     void treeprocessor(Treeprocessor treeprocessorClassName);
-    
+    void treeprocessor(Treeprocessor treeprocessorClassName, String registrationName);
+
     void include_processor(String includeProcessorClassName);
+    void include_processor(String includeProcessorClassName, String registrationName);
     void include_processor(RubyClass includeProcessorClassName);
+    void include_processor(RubyClass includeProcessorClassName, String registrationName);
     void include_processor(IncludeProcessor includeProcessor);
-    
+    void include_processor(IncludeProcessor includeProcessor, String registrationName);
+
     void block_processor(String blockClassName, Object blockName);
+    void block_processor(String blockClassName, Object blockName, String registrationName);
     void block_processor(RubyClass blockClass, Object blockName);
+    void block_processor(RubyClass blockClass, Object blockName, String registrationName);
     void block_processor(BlockProcessor blockInstance, Object blockName);
-    
+    void block_processor(BlockProcessor blockInstance, Object blockName, String registrationName);
+
     void block_macro(String blockMacroClassName, Object blockName);
+    void block_macro(String blockMacroClassName, Object blockName, String registrationName);
     void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName);
+    void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName, String registrationName);
     void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName);
-    
+    void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName, String registrationName);
+
     void inline_macro(String blockClassName, Object blockSymbol);
+    void inline_macro(String blockClassName, Object blockSymbol, String registrationName);
     void inline_macro(RubyClass blockClassName, Object blockSymbol);
+    void inline_macro(RubyClass blockClassName, Object blockSymbol, String registrationName);
     void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol);
-    
+    void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol, String registrationName);
+
     void docinfo_processor(String docInfoClassName);
+    void docinfo_processor(String docInfoClassName, String registrationName);
     void docinfo_processor(RubyClass docInfoClassName);
+    void docinfo_processor(RubyClass docInfoClassName, String registrationName);
     void docinfo_processor(DocinfoProcessor docInfoClassName);
-    
+    void docinfo_processor(DocinfoProcessor docInfoClassName, String registrationName);
+
     void unregister_all_extensions();
+    void unregister_extension(String registrationName);
 
     Object convert(String content, Map<String, Object> options);
     Object convertFile(String filename, Map<String, Object> options);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/ExtensionGroupImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/ExtensionGroupImpl.java
@@ -1,0 +1,506 @@
+package org.asciidoctor.internal;
+
+import org.asciidoctor.extension.BlockMacroProcessor;
+import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.DocinfoProcessor;
+import org.asciidoctor.extension.ExtensionGroup;
+import org.asciidoctor.extension.IncludeProcessor;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Postprocessor;
+import org.asciidoctor.extension.Preprocessor;
+import org.asciidoctor.extension.Treeprocessor;
+import org.jruby.Ruby;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by robertpanzer on 21.07.17.
+ */
+public class ExtensionGroupImpl implements ExtensionGroup {
+
+  private final JRubyAsciidoctor asciidoctor;
+
+  private final Ruby rubyRuntime;
+
+  private final AsciidoctorModule asciidoctorModule;
+
+  private final String groupName;
+
+  private final List<Runnable> registrations = new ArrayList<Runnable>();
+
+  public ExtensionGroupImpl(String groupName, JRubyAsciidoctor asciidoctor) {
+    this.groupName = groupName;
+    this.asciidoctor = asciidoctor;
+    this.rubyRuntime = asciidoctor.getRubyRuntime();
+    asciidoctorModule = asciidoctor.getAsciidoctorModule();
+  }
+
+  @Override
+  public void register() {
+    for (Runnable r: registrations) {
+      r.run();
+    }
+  }
+
+  @Override
+  public void unregister() {
+    asciidoctorModule.unregister_extension(groupName);
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final Class<? extends DocinfoProcessor> docInfoProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, docInfoProcessor);
+        asciidoctorModule.docinfo_processor(RubyUtils.toRubyClass(rubyRuntime, docInfoProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final DocinfoProcessor docInfoProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, docInfoProcessor.getClass());
+        asciidoctorModule.docinfo_processor(docInfoProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final String docInfoProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, docInfoProcessor);
+        asciidoctorModule.docinfo_processor(getClassName(docInfoProcessor), groupName);
+
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final Class<? extends Preprocessor> preprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, preprocessor);
+        asciidoctorModule.preprocessor(RubyUtils.toRubyClass(rubyRuntime, preprocessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final Preprocessor preprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, preprocessor.getClass());
+        asciidoctorModule.preprocessor(preprocessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final String preprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, preprocessor);
+        asciidoctorModule.preprocessor(getClassName(preprocessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final String postprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, postprocessor);
+        asciidoctorModule.postprocessor(getClassName(postprocessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final Class<? extends Postprocessor> postprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, postprocessor);
+        asciidoctorModule.postprocessor(RubyUtils.toRubyClass(rubyRuntime, postprocessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final Postprocessor postprocesor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, postprocesor.getClass());
+        asciidoctorModule.postprocessor(postprocesor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final String includeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, includeProcessor);
+        asciidoctorModule.include_processor(getClassName(includeProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final Class<? extends IncludeProcessor> includeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, includeProcessor);
+        asciidoctorModule.include_processor(RubyUtils.toRubyClass(rubyRuntime, includeProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final IncludeProcessor includeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        String importLine = getImportLine(includeProcessor.getClass());
+        javaImport(rubyRuntime, importLine);
+        asciidoctorModule.include_processor(includeProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final Treeprocessor treeprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, treeprocessor.getClass());
+        asciidoctorModule.treeprocessor(treeprocessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final Class<? extends Treeprocessor> treeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, treeProcessor);
+        asciidoctorModule.treeprocessor(RubyUtils.toRubyClass(rubyRuntime, treeProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final String treeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, treeProcessor);
+        asciidoctorModule.treeprocessor(getClassName(treeProcessor), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final String blockProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockProcessor);
+
+        asciidoctorModule.block_processor(
+            getClassName(blockProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final Class<? extends BlockProcessor> blockProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockProcessor);
+
+        asciidoctorModule.block_processor(
+            RubyUtils.toRubyClass(rubyRuntime, blockProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final BlockProcessor blockProcessor) {
+    block(blockProcessor.getName(), blockProcessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final BlockProcessor blockProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockProcessor.getClass());
+
+        asciidoctorModule.block_processor(
+            blockProcessor,
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final String blockName, final Class<? extends BlockMacroProcessor> blockMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockMacroProcessor);
+        asciidoctorModule.block_macro(
+            blockMacroProcessor.getSimpleName(),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final String blockName, final String blockMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockMacroProcessor);
+        asciidoctorModule.block_macro(
+            getClassName(blockMacroProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final BlockMacroProcessor blockMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, blockMacroProcessor.getClass());
+        asciidoctorModule.block_macro(
+            blockMacroProcessor,
+            RubyUtils.toSymbol(rubyRuntime, blockMacroProcessor.getName()), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final InlineMacroProcessor inlineMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, inlineMacroProcessor.getClass());
+
+        asciidoctorModule.inline_macro(
+            inlineMacroProcessor,
+            RubyUtils.toSymbol(rubyRuntime, inlineMacroProcessor.getName()), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final String blockName, final Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, inlineMacroProcessor);
+
+        asciidoctorModule.inline_macro(
+            RubyUtils.toRubyClass(rubyRuntime, inlineMacroProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final String blockName, final String inlineMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        javaImport(rubyRuntime, inlineMacroProcessor);
+
+        asciidoctorModule.inline_macro(
+            getClassName(inlineMacroProcessor),
+            RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup requireRubyLibrary(final String requiredLibrary) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        RubyUtils.requireLibrary(rubyRuntime, requiredLibrary);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup loadRubyClass(final InputStream rubyClassStream) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        RubyUtils.loadRubyClass(rubyRuntime, rubyClassStream);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyPreprocessor(final String preprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.preprocessor(preprocessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyPostprocessor(final String postprocessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.postprocessor(postprocessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyDocinfoProcessor(final String docinfoProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.docinfo_processor(docinfoProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyIncludeProcessor(final String includeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.include_processor(includeProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyTreeprocessor(final String treeProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.treeprocessor(treeProcessor, groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyBlock(final String blockName, final String blockProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.block_processor(
+            blockProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyBlockMacro(final String blockName, final String blockMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.block_macro(
+            blockMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyInlineMacro(final String blockName, final String inlineMacroProcessor) {
+    registrations.add(new Runnable() {
+      @Override
+      public void run() {
+        asciidoctorModule.inline_macro(
+            inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName), groupName);
+      }
+    });
+    return this;
+  }
+
+  private void javaImport(Ruby ruby, Class<?> clazz) {
+    ruby.evalScriptlet(String.format("java_import '%s'", getImportLine(clazz)));
+  }
+
+  private void javaImport(Ruby ruby, String className) {
+    ruby.evalScriptlet(String.format("java_import '%s'", className));
+  }
+
+  private String getImportLine(Class<?> extensionClass) {
+    int dollarPosition = -1;
+    String className = extensionClass.getName();
+    if ((dollarPosition = className.indexOf("$")) != -1) {
+      className = className.substring(0, dollarPosition);
+    }
+    return className;
+  }
+
+  private String getClassName(String clazz) {
+    return clazz.substring(clazz.lastIndexOf(".")+1);
+  }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -498,6 +498,11 @@ public class JRubyAsciidoctor implements Asciidoctor {
     }
 
     @Override
+    public void unregisterExtension(String registrationName) {
+        this.asciidoctorModule.unregister_extension(registrationName);
+    }
+
+    @Override
     public void shutdown() {
         this.rubyRuntime.tearDown();
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -498,11 +498,6 @@ public class JRubyAsciidoctor implements Asciidoctor {
     }
 
     @Override
-    public void unregisterExtension(String registrationName) {
-        this.asciidoctorModule.unregister_extension(registrationName);
-    }
-
-    @Override
     public void shutdown() {
         this.rubyRuntime.tearDown();
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -14,6 +14,7 @@ import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.ast.Title;
 import org.asciidoctor.converter.JavaConverterRegistry;
 import org.asciidoctor.converter.internal.ConverterRegistryExecutor;
+import org.asciidoctor.extension.ExtensionGroup;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.extension.internal.ExtensionRegistryExecutor;
@@ -28,7 +29,6 @@ import org.jruby.javasupport.JavaEmbedUtils;
 
 import java.io.*;
 import java.util.*;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class JRubyAsciidoctor implements Asciidoctor {
@@ -597,6 +597,23 @@ public class JRubyAsciidoctor implements Asciidoctor {
     public Document loadFile(File file, Map<String, Object> options) {
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
         return new Document(this.asciidoctorModule.load_file(file.getAbsolutePath(), rubyHash), this.rubyRuntime);
+    }
 
+    Ruby getRubyRuntime() {
+        return this.rubyRuntime;
+    }
+
+    AsciidoctorModule getAsciidoctorModule() {
+        return asciidoctorModule;
+    }
+
+    @Override
+    public ExtensionGroup createGroup() {
+        return new ExtensionGroupImpl(UUID.randomUUID().toString(), this);
+    }
+
+    @Override
+    public ExtensionGroup createGroup(String groupName) {
+        return new ExtensionGroupImpl(groupName, this);
     }
 }

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -25,50 +25,50 @@ class AsciidoctorModule
         Asciidoctor::Extensions.unregister name
     end
 
-    def docinfo_processor(extensionName, registrationName = nil)
-        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
+    def docinfo_processor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
             docinfo_processor extensionName
         end
     end
 
-    def treeprocessor(extensionName, registrationName = nil)
-        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
+    def treeprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
             treeprocessor extensionName
         end
     end
     
-    def include_processor(extensionName, registrationName = nil)
-        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
+    def include_processor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
             include_processor extensionName
         end
     end
 
-    def preprocessor(extensionName, registrationName = nil)
-        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
+    def preprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
             preprocessor extensionName
         end
     end
     
-    def postprocessor(extensionName, registrationName = nil)
-        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
+    def postprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
             postprocessor extensionName
         end
     end
 
-    def block_processor(extensionName, blockSymbol, registrationName = nil)
-        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
+    def block_processor(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
             block extensionName, blockSymbol
         end
     end
 
-    def block_macro(extensionName, blockSymbol, registrationName = nil)
-        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
+    def block_macro(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
             block_macro extensionName, blockSymbol
         end
     end
 
-    def inline_macro(extensionName, blockSymbol, registrationName = nil)
-        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
+    def inline_macro(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
             inline_macro extensionName, blockSymbol
         end
     end

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -24,49 +24,49 @@ class AsciidoctorModule
     end
 
     def docinfo_processor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register groupName do
             docinfo_processor extensionName
         end
     end
 
     def treeprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register groupName do
             treeprocessor extensionName
         end
     end
     
     def include_processor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register groupName do
             include_processor extensionName
         end
     end
 
     def preprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register groupName do
             preprocessor extensionName
         end
     end
     
     def postprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register groupName do
             postprocessor extensionName
         end
     end
 
     def block_processor(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register groupName do
             block extensionName, blockSymbol
         end
     end
 
     def block_macro(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register groupName do
             block_macro extensionName, blockSymbol
         end
     end
 
     def inline_macro(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register groupName do
             inline_macro extensionName, blockSymbol
         end
     end

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -4,9 +4,7 @@ module AsciidoctorJ
         include_package 'org.asciidoctor.extension'
         # Treeprocessor was renamed in to TreeProcessor in https://github.com/asciidoctor/asciidoctor/commit/f1dd816ade9db457b899581841e4cf7b788aa26d
         # This is necessary to run against both Asciidoctor 1.5.5 and 1.5.6
-        if !defined? TreeProcessor
-            TreeProcessor = Treeprocessor
-        end
+        TreeProcessor = Treeprocessor unless defined? TreeProcessor
     end
 end
 
@@ -26,49 +24,49 @@ class AsciidoctorModule
     end
 
     def docinfo_processor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
             docinfo_processor extensionName
         end
     end
 
     def treeprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
             treeprocessor extensionName
         end
     end
     
     def include_processor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
             include_processor extensionName
         end
     end
 
     def preprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
             preprocessor extensionName
         end
     end
     
     def postprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
             postprocessor extensionName
         end
     end
 
     def block_processor(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
             block extensionName, blockSymbol
         end
     end
 
     def block_macro(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
             block_macro extensionName, blockSymbol
         end
     end
 
     def inline_macro(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register (groupName != nil ? groupName.to_sym : nil) do
+        Asciidoctor::Extensions.register(groupName != nil ? groupName.to_sym : nil) do
             inline_macro extensionName, blockSymbol
         end
     end

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -4,7 +4,9 @@ module AsciidoctorJ
         include_package 'org.asciidoctor.extension'
         # Treeprocessor was renamed in to TreeProcessor in https://github.com/asciidoctor/asciidoctor/commit/f1dd816ade9db457b899581841e4cf7b788aa26d
         # This is necessary to run against both Asciidoctor 1.5.5 and 1.5.6
-        TreeProcessor = Treeprocessor
+        if !defined? TreeProcessor
+            TreeProcessor = Treeprocessor
+        end
     end
 end
 
@@ -19,50 +21,54 @@ class AsciidoctorModule
         Asciidoctor::Extensions.unregister_all
     end
 
-    def docinfo_processor(extensionName)
-        Asciidoctor::Extensions.register do
+    def unregister_extension name
+        Asciidoctor::Extensions.unregister name
+    end
+
+    def docinfo_processor(extensionName, registrationName = nil)
+        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
             docinfo_processor extensionName
         end
     end
 
-    def treeprocessor(extensionName)
-        Asciidoctor::Extensions.register do 
+    def treeprocessor(extensionName, registrationName = nil)
+        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
             treeprocessor extensionName
         end
     end
     
-    def include_processor(extensionName)
-        Asciidoctor::Extensions.register do
+    def include_processor(extensionName, registrationName = nil)
+        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
             include_processor extensionName
         end
     end
 
-    def preprocessor(extensionName)
-        Asciidoctor::Extensions.register do
+    def preprocessor(extensionName, registrationName = nil)
+        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
             preprocessor extensionName
         end
     end
     
-    def postprocessor(extensionName)
-        Asciidoctor::Extensions.register do
+    def postprocessor(extensionName, registrationName = nil)
+        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
             postprocessor extensionName
         end
     end
 
-    def block_processor(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def block_processor(extensionName, blockSymbol, registrationName = nil)
+        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
             block extensionName, blockSymbol
         end
     end
 
-    def block_macro(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def block_macro(extensionName, blockSymbol, registrationName = nil)
+        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
             block_macro extensionName, blockSymbol
         end
     end
 
-    def inline_macro(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def inline_macro(extensionName, blockSymbol, registrationName = nil)
+        Asciidoctor::Extensions.register (registrationName != nil ? registrationName.to_sym : nil) do
             inline_macro extensionName, blockSymbol
         end
     end

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -1,27 +1,5 @@
 package org.asciidoctor.extension;
 
-import static org.asciidoctor.OptionsBuilder.options;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.Options;
@@ -37,6 +15,28 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.asciidoctor.OptionsBuilder.options;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class WhenJavaExtensionIsRegistered {
 
@@ -705,64 +705,94 @@ public class WhenJavaExtensionIsRegistered {
      public void should_unregister_postprocessor() throws IOException {
 
         // Given: A registered Postprocessor
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-        final String registrationName = UUID.randomUUID().toString();
-        javaExtensionRegistry.postprocessor(CustomFooterPostProcessor.class, registrationName);
+        ExtensionGroup extensionGroup = asciidoctor.createGroup(UUID.randomUUID().toString())
+            .postprocessor(CustomFooterPostProcessor.class);
 
-        // When: I render a document
-        Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
-            .safe(SafeMode.UNSAFE).get();
+        // When: I render a document without registering the ExtensionGroup
+        {
+            Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
+                .safe(SafeMode.UNSAFE).get();
 
-        asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options);
+            asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options);
 
-        // Then: it is invoked
-        File renderedFile = new File(testFolder.getRoot(), "rendersample.html");
-        org.jsoup.nodes.Document doc = Jsoup.parse(renderedFile, "UTF-8");
-        Element footer = doc.getElementById("footer-text");
-        assertThat(footer.text(), containsString("Copyright Acme, Inc."));
+            // Then: it is invoked
+            File renderedFile = new File(testFolder.getRoot(), "rendersample.html");
+            org.jsoup.nodes.Document doc = Jsoup.parse(renderedFile, "UTF-8");
+            Element footer = doc.getElementById("footer-text");
+            assertThat(footer.text(), not(containsString("Copyright Acme, Inc.")));
+        }
 
+        // When: I register the ExtensionGroup and render a document
+        {
+            extensionGroup.register();
+            Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
+                .safe(SafeMode.UNSAFE).get();
+
+            asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options);
+
+            // Then: it is invoked
+            File renderedFile = new File(testFolder.getRoot(), "rendersample.html");
+            org.jsoup.nodes.Document doc = Jsoup.parse(renderedFile, "UTF-8");
+            Element footer = doc.getElementById("footer-text");
+            assertThat(footer.text(), containsString("Copyright Acme, Inc."));
+        }
         // When: I unregister the Postprocessor and render again with the same Asciidoctor instance
-        asciidoctor.unregisterExtension(registrationName);
+        {
+            extensionGroup.unregister();;
 
-        Options options2 = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample2.html"))
-            .safe(SafeMode.UNSAFE).get();
-        asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options2);
-        File renderedFile2 = new File(testFolder.getRoot(), "rendersample2.html");
-        org.jsoup.nodes.Document doc2 = Jsoup.parse(renderedFile2, "UTF-8");
+            Options options2 = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample2.html"))
+                .safe(SafeMode.UNSAFE).get();
+            asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options2);
+            File renderedFile2 = new File(testFolder.getRoot(), "rendersample2.html");
+            org.jsoup.nodes.Document doc2 = Jsoup.parse(renderedFile2, "UTF-8");
 
-        Element footer2 = doc2.getElementById("footer-text");
-        assertThat(footer2.text(), not(containsString("Copyright Acme, Inc.")));
+            Element footer2 = doc2.getElementById("footer-text");
+            assertThat(footer2.text(), not(containsString("Copyright Acme, Inc.")));
+        }
     }
 
     @Test
     public void should_unregister_block_processor()
         throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-        final String registrationName = UUID.randomUUID().toString();
-
         Map<String, Object> config = new HashMap<String, Object>();
         config.put("contexts", Arrays.asList(":paragraph"));
         config.put("content_model", ":simple");
         YellBlock yellBlock = new YellBlock("yell", config);
-        javaExtensionRegistry.block(yellBlock, registrationName);
-        String content = asciidoctor.renderFile(
-            classpath.getResource("sample-with-yell-block.ad"),
-            options().toFile(false).get());
-        Document doc = Jsoup.parse(content, "UTF-8");
-        Elements elements = doc.getElementsByClass("paragraph");
-        assertThat(elements.size(), is(1));
-        assertThat(elements.get(0).text(), is("THE TIME IS NOW. GET A MOVE ON."));
 
-        asciidoctor.unregisterExtension(registrationName);
-        String contentWithoutBlock = asciidoctor.renderFile(
-            classpath.getResource("sample-with-yell-block.ad"),
-            options().toFile(false).get());
-        Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
-        Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
-        assertThat(elementsWithoutBlock.size(), is(1));
-        assertThat(elementsWithoutBlock.get(0).text(), not(is("THE TIME IS NOW. GET A MOVE ON.")));
+        ExtensionGroup extensionGroup = this.asciidoctor.createGroup().block(yellBlock);
 
+        {
+            String contentWithoutBlock = asciidoctor.renderFile(
+                classpath.getResource("sample-with-yell-block.ad"),
+                options().toFile(false).get());
+            Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
+            Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
+            assertThat(elementsWithoutBlock.size(), is(1));
+            assertThat(elementsWithoutBlock.get(0).text(), not(is("THE TIME IS NOW. GET A MOVE ON.")));
+        }
+
+        {
+            extensionGroup.register();
+            String content = asciidoctor.renderFile(
+                classpath.getResource("sample-with-yell-block.ad"),
+                options().toFile(false).get());
+            Document doc = Jsoup.parse(content, "UTF-8");
+            Elements elements = doc.getElementsByClass("paragraph");
+            assertThat(elements.size(), is(1));
+            assertThat(elements.get(0).text(), is("THE TIME IS NOW. GET A MOVE ON."));
+        }
+
+        {
+            extensionGroup.unregister();
+            String contentWithoutBlock = asciidoctor.renderFile(
+                classpath.getResource("sample-with-yell-block.ad"),
+                options().toFile(false).get());
+            Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
+            Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
+            assertThat(elementsWithoutBlock.size(), is(1));
+            assertThat(elementsWithoutBlock.get(0).text(), not(is("THE TIME IS NOW. GET A MOVE ON.")));
+        }
     }
 
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
@@ -1,10 +1,5 @@
 package org.asciidoctor.extension;
 
-import static org.asciidoctor.OptionsBuilder.options;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
-
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.util.ClasspathResources;
@@ -14,7 +9,10 @@ import org.jsoup.select.Elements;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.UUID;
+import static org.asciidoctor.OptionsBuilder.options;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 public class WhenRubyExtensionIsRegistered {
 
@@ -43,31 +41,43 @@ public class WhenRubyExtensionIsRegistered {
     @Test
     public void ruby_extension_should_be_unregistered() {
 
-        RubyExtensionRegistry rubyExtensionRegistry = this.asciidoctor.rubyExtensionRegistry();
-        String registrationName = UUID.randomUUID().toString();
+        ExtensionGroup extensionGroup = this.asciidoctor.createGroup()
+            .loadRubyClass(Class.class.getResourceAsStream("/YellRubyBlock.rb"))
+            .rubyBlock("rubyyell", "YellRubyBlock");
 
-        rubyExtensionRegistry.loadClass(Class.class.getResourceAsStream("/YellRubyBlock.rb")).block("rubyyell", "YellRubyBlock", registrationName);
-
-        String content = asciidoctor.renderFile(
+        {
+            String contentWithoutBlock = asciidoctor.renderFile(
                 classpath.getResource("sample-with-ruby-yell-block.ad"),
                 options().toFile(false).get());
 
-        Document doc = Jsoup.parse(content, "UTF-8");
-        Elements elements = doc.getElementsByClass("paragraph");
-        assertThat(elements.size(), is(2));
-        assertThat(elements.get(1).text(), is("THE TIME IS NOW! GET A MOVE ON!"));
-
-        asciidoctor.unregisterExtension(registrationName);
-
-        String contentWithoutBlock = asciidoctor.renderFile(
+            Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
+            Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
+            assertThat(elementsWithoutBlock.size(), is(2));
+            assertThat(elementsWithoutBlock.get(1).text(), not(is("THE TIME IS NOW! GET A MOVE ON!")));
+        }
+        {
+            extensionGroup.register();
+            String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-ruby-yell-block.ad"),
                 options().toFile(false).get());
 
-        Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
-        Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
-        assertThat(elementsWithoutBlock.size(), is(2));
-        assertThat(elementsWithoutBlock.get(1).text(), not(is("THE TIME IS NOW! GET A MOVE ON!")));
+            Document doc = Jsoup.parse(content, "UTF-8");
+            Elements elements = doc.getElementsByClass("paragraph");
+            assertThat(elements.size(), is(2));
+            assertThat(elements.get(1).text(), is("THE TIME IS NOW! GET A MOVE ON!"));
+        }
+        {
+            extensionGroup.unregister();
 
+            String contentWithoutBlock = asciidoctor.renderFile(
+                classpath.getResource("sample-with-ruby-yell-block.ad"),
+                options().toFile(false).get());
+
+            Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
+            Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
+            assertThat(elementsWithoutBlock.size(), is(2));
+            assertThat(elementsWithoutBlock.get(1).text(), not(is("THE TIME IS NOW! GET A MOVE ON!")));
+        }
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
@@ -2,6 +2,7 @@ package org.asciidoctor.extension;
 
 import static org.asciidoctor.OptionsBuilder.options;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
 import org.asciidoctor.Asciidoctor;
@@ -12,6 +13,8 @@ import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.UUID;
 
 public class WhenRubyExtensionIsRegistered {
 
@@ -35,6 +38,36 @@ public class WhenRubyExtensionIsRegistered {
         assertThat(elements.size(), is(2));
         assertThat(elements.get(1).text(), is("THE TIME IS NOW! GET A MOVE ON!"));
         
+    }
+
+    @Test
+    public void ruby_extension_should_be_unregistered() {
+
+        RubyExtensionRegistry rubyExtensionRegistry = this.asciidoctor.rubyExtensionRegistry();
+        String registrationName = UUID.randomUUID().toString();
+
+        rubyExtensionRegistry.loadClass(Class.class.getResourceAsStream("/YellRubyBlock.rb")).block("rubyyell", "YellRubyBlock", registrationName);
+
+        String content = asciidoctor.renderFile(
+                classpath.getResource("sample-with-ruby-yell-block.ad"),
+                options().toFile(false).get());
+
+        Document doc = Jsoup.parse(content, "UTF-8");
+        Elements elements = doc.getElementsByClass("paragraph");
+        assertThat(elements.size(), is(2));
+        assertThat(elements.get(1).text(), is("THE TIME IS NOW! GET A MOVE ON!"));
+
+        asciidoctor.unregisterExtension(registrationName);
+
+        String contentWithoutBlock = asciidoctor.renderFile(
+                classpath.getResource("sample-with-ruby-yell-block.ad"),
+                options().toFile(false).get());
+
+        Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
+        Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
+        assertThat(elementsWithoutBlock.size(), is(2));
+        assertThat(elementsWithoutBlock.get(1).text(), not(is("THE TIME IS NOW! GET A MOVE ON!")));
+
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
   xmlMatchersVersion = '1.0-RC1'
 
   // gem versions
-  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.5'
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.6'
   asciidoctorEpub3GemVersion = project(':asciidoctorj-epub3').version.replace('-', '.')
 
   asciidoctorDiagramGemVersion = project(':asciidoctorj-diagram').version.replace('-', '.')

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
   xmlMatchersVersion = '1.0-RC1'
 
   // gem versions
-  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.6'
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.6.1'
   asciidoctorEpub3GemVersion = project(':asciidoctorj-epub3').version.replace('-', '.')
 
   asciidoctorDiagramGemVersion = project(':asciidoctorj-diagram').version.replace('-', '.')


### PR DESCRIPTION
A second approach to unregistering extensions.
Now it is completely explicit.
Instead of getting a registration handle from the registration, a registration name has to be passed to the registration methods explicitly.

Basically all registration methods are overloaded with an additional version that takes a string as the registration name.

Note that this PR is for master.