### PR TITLE
Add ExtensionGroup API and fix registration of multiple extensions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1374,6 +1374,30 @@ String content = asciidoctor.convertFile(new File(
 
 You can unregister all extensions by calling the `org.asciidoctor.Asciidoctor.unregisterAllExtensions()` method.
 
+Additionally, since AsciidoctorJ 1.5.6.1 it is possible to unregister specific extensions when using the ExtensionGroup API.
+This allows to register and unregister a group of extensions as a whole:
+
+[source,java]
+----
+BlockProcessor extension1 = ...
+Treeprocessor extension2 = ...
+ExtensionGroup extensionGroup =
+  asciidoctor.createGroup()
+    .block(extension1)
+    .treeprocessor(extension2);
+
+asciidoctor.convert(...) // <1>
+
+extensionGroup.register();
+asciidoctor.convert(); // <2>
+
+extensionGroup.register();
+asciidoctor.convert(); // <3>
+----
+<1> Convert a document without the extensions active because they were not registered yet.
+<2> Convert with extensions active after registration.
+<3> Convert without extensions active after the extensions were unregistered.
+
 === Ruby extensions
 
 You can even register extensions written in Ruby using AsciidoctorJ.

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -12,6 +12,7 @@ import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.converter.JavaConverterRegistry;
+import org.asciidoctor.extension.ExtensionGroup;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.internal.JRubyAsciidoctor;
@@ -774,12 +775,23 @@ public interface Asciidoctor {
      * @return Converter Registry object.
      */
     JavaConverterRegistry javaConverterRegistry();
-    
+
+    /**
+     * Creates an ExtensionGroup that can be used to register and unregister a group of extensions.
+     * @return
+     */
+    ExtensionGroup createGroup();
+
+    /**
+     * Creates an ExtensionGroup that can be used to register and unregister a group of extensions.
+     * @return
+     */
+    ExtensionGroup createGroup(String groupName);
     /**
      * Unregister all registered extensions.
      */
     void unregisterAllExtensions();
-    
+
     /**
      * This method frees all resources consumed by asciidoctorJ module. Keep in mind that if this method is called, instance becomes unusable and you should create another instance.
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionGroup.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionGroup.java
@@ -1,0 +1,80 @@
+package org.asciidoctor.extension;
+
+
+import java.io.InputStream;
+
+/**
+ * An ExtensionGroup allows to collectively register and unregister extensions.
+ * All extensions are registered lazily and are not effective before a call to {@link #register()}.
+ *
+ * <p>Example:
+ * <code><pre>
+ * ExtensionGroup group = asciidoctor.createGroup();
+ * group.block(myBlock).preprocessor(mypreprocessor);
+ *
+ * // Convert with extensions
+ * group.register();
+ * asciidoctor.convert(...);
+ * group.unregister();
+ *
+ * // Convert without extensions
+ * asciidoctor.convert(...);
+ * </pre></code></p>
+ */
+public interface ExtensionGroup {
+
+  public void register();
+
+  public void unregister();
+
+  public ExtensionGroup docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor);
+  public ExtensionGroup docinfoProcessor(DocinfoProcessor docInfoProcessor);
+  public ExtensionGroup docinfoProcessor(String docInfoProcessor);
+
+  public ExtensionGroup preprocessor(Class<? extends Preprocessor> preprocessor);
+  public ExtensionGroup preprocessor(Preprocessor preprocessor);
+  public ExtensionGroup preprocessor(String preprocessor);
+
+  public ExtensionGroup postprocessor(String postprocessor);
+  public ExtensionGroup postprocessor(Class<? extends Postprocessor> postprocessor);
+  public ExtensionGroup postprocessor(Postprocessor postprocesor);
+
+  public ExtensionGroup includeProcessor(String includeProcessor);
+  public ExtensionGroup includeProcessor(Class<? extends IncludeProcessor> includeProcessor);
+  public ExtensionGroup includeProcessor(IncludeProcessor includeProcessor);
+
+  public ExtensionGroup treeprocessor(Treeprocessor treeprocessor);
+  public ExtensionGroup treeprocessor(Class<? extends Treeprocessor> treeProcessor);
+  public ExtensionGroup treeprocessor(String treeProcessor);
+
+  public ExtensionGroup block(String blockName, String blockProcessor);
+  public ExtensionGroup block(String blockProcessor);
+  public ExtensionGroup block(String blockName, Class<? extends BlockProcessor> blockProcessor);
+  public ExtensionGroup block(Class<? extends BlockProcessor> blockProcessor);
+  public ExtensionGroup block(String blockName, BlockProcessor blockProcessor);
+  public ExtensionGroup block(BlockProcessor blockProcessor);
+
+  public ExtensionGroup blockMacro(String blockName, Class<? extends BlockMacroProcessor> blockMacroProcessor);
+  public ExtensionGroup blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor);
+  public ExtensionGroup blockMacro(String blockName, String blockMacroProcessor);
+  public ExtensionGroup blockMacro(String blockMacroProcessor);
+  public ExtensionGroup blockMacro(BlockMacroProcessor blockMacroProcessor);
+
+  public ExtensionGroup inlineMacro(InlineMacroProcessor inlineMacroProcessor);
+  public ExtensionGroup inlineMacro(String name, Class<? extends InlineMacroProcessor> inlineMacroProcessor);
+  public ExtensionGroup inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor);
+  public ExtensionGroup inlineMacro(String name, String inlineMacroProcessor);
+  public ExtensionGroup inlineMacro(String inlineMacroProcessor);
+
+  public ExtensionGroup requireRubyLibrary(String requiredLibrary);
+  public ExtensionGroup loadRubyClass(InputStream rubyClassStream);
+
+  public ExtensionGroup rubyPreprocessor(String preprocessor);
+  public ExtensionGroup rubyPostprocessor(String postprocessor);
+  public ExtensionGroup rubyDocinfoProcessor(String docinfoProcessor);
+  public ExtensionGroup rubyIncludeProcessor(String includeProcessor);
+  public ExtensionGroup rubyTreeprocessor(String treeProcessor);
+  public ExtensionGroup rubyBlock(String blockName, String blockProcessor);
+  public ExtensionGroup rubyBlockMacro(String blockName, String blockMacroProcessor);
+  public ExtensionGroup rubyInlineMacro(String blockName, String inlineMacroProcessor);
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
@@ -147,6 +147,10 @@ public class Processor {
         this.config = config;
     }
 
+    public final void updateConfig(Map<String, Object> config) {
+        this.config.putAll(config);
+    }
+
     /**
      * Lock the config of this processor so that it is no longer allowed to invoke {@link #setConfig(Map)}.
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
@@ -9,6 +9,7 @@ import org.jruby.Ruby;
 public class RubyExtensionRegistry {
 
     private AsciidoctorModule asciidoctorModule;
+
     private Ruby rubyRuntime;
 
     public RubyExtensionRegistry(AsciidoctorModule asciidoctorModule,
@@ -33,8 +34,8 @@ public class RubyExtensionRegistry {
         return this;
     }
 
-    public RubyExtensionRegistry postprocessor(String postprocesor) {
-        this.asciidoctorModule.postprocessor(postprocesor);
+    public RubyExtensionRegistry postprocessor(String postprocessor) {
+        this.asciidoctorModule.postprocessor(postprocessor);
         return this;
     }
 
@@ -72,5 +73,4 @@ public class RubyExtensionRegistry {
                 inlineMacroProcessor, RubyUtils.toSymbol(rubyRuntime, blockName));
         return this;
     }
-
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/AbstractProcessorProxy.java
@@ -10,13 +10,16 @@ import org.asciidoctor.extension.Location;
 import org.asciidoctor.extension.Name;
 import org.asciidoctor.extension.PositionalAttributes;
 import org.asciidoctor.extension.Processor;
+import org.asciidoctor.internal.RubyHashMapDecorator;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.RubyObject;
 import org.jruby.RubyRegexp;
+import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaEmbedUtils;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.RegexpOptions;
 
@@ -251,4 +254,11 @@ public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
         return RubyRegexp.newRegexp(runtime, regexp.toString(), RegexpOptions.NULL_OPTIONS);
     }
 
+    public static String getName(Class<? extends Processor> processor) {
+        if (processor.isAnnotationPresent(Name.class)) {
+            Name name = processor.getAnnotation(Name.class);
+            return name.value();
+        }
+        throw new IllegalArgumentException("Processor " + processor + " has no @Name annotation!");
+    }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -75,7 +75,7 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
                             RubyHashUtil.convertMapToRubyHashWithSymbols(getRuntime(), getProcessor().getConfig())},
                     Block.NULL_BLOCK);
             // The extension config in the Java extension is just a view on the @config member of the Ruby part
-            getProcessor().setConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
+            getProcessor().updateConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
 
             String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
@@ -11,64 +11,39 @@ import org.jruby.RubyClass;
 public interface AsciidoctorModule {
 
     void preprocessor(String preprocessorClassName);
-    void preprocessor(String preprocessorClassName, String registrationName);
     void preprocessor(RubyClass preprocessorClassName);
-    void preprocessor(RubyClass preprocessorClassName, String registrationName);
-	  void preprocessor(Preprocessor preprocessor);
-	  void preprocessor(Preprocessor preprocessor, String registrationName);
+    void preprocessor(Preprocessor preprocessor);
 
     void postprocessor(String postprocessorClassName);
-    void postprocessor(String postprocessorClassName, String registrationName);
     void postprocessor(RubyClass postprocessorClassName);
-    void postprocessor(RubyClass postprocessorClassName, String registrationName);
     void postprocessor(Postprocessor postprocessor);
-    void postprocessor(Postprocessor postprocessor, String registrationName);
 
     void treeprocessor(String treeprocessor);
-    void treeprocessor(String treeprocessor, String registrationName);
     void treeprocessor(RubyClass treeprocessorClassName);
-    void treeprocessor(RubyClass treeprocessorClassName, String registrationName);
     void treeprocessor(Treeprocessor treeprocessorClassName);
-    void treeprocessor(Treeprocessor treeprocessorClassName, String registrationName);
 
     void include_processor(String includeProcessorClassName);
-    void include_processor(String includeProcessorClassName, String registrationName);
     void include_processor(RubyClass includeProcessorClassName);
-    void include_processor(RubyClass includeProcessorClassName, String registrationName);
     void include_processor(IncludeProcessor includeProcessor);
-    void include_processor(IncludeProcessor includeProcessor, String registrationName);
 
     void block_processor(String blockClassName, Object blockName);
-    void block_processor(String blockClassName, Object blockName, String registrationName);
     void block_processor(RubyClass blockClass, Object blockName);
-    void block_processor(RubyClass blockClass, Object blockName, String registrationName);
     void block_processor(BlockProcessor blockInstance, Object blockName);
-    void block_processor(BlockProcessor blockInstance, Object blockName, String registrationName);
 
     void block_macro(String blockMacroClassName, Object blockName);
-    void block_macro(String blockMacroClassName, Object blockName, String registrationName);
     void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName);
-    void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName, String registrationName);
     void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName);
-    void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName, String registrationName);
     void block_macro(RubyClass blockClassName, Object blockSymbol);
-    void block_macro(RubyClass blockClassName, Object blockSymbol, String registrationName);
 
     void inline_macro(String blockClassName, Object blockSymbol);
-    void inline_macro(String blockClassName, Object blockSymbol, String registrationName);
     void inline_macro(RubyClass blockClassName, Object blockSymbol);
-    void inline_macro(RubyClass blockClassName, Object blockSymbol, String registrationName);
     void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol);
-    void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol, String registrationName);
 
     void docinfo_processor(String docInfoClassName);
-    void docinfo_processor(String docInfoClassName, String registrationName);
     void docinfo_processor(RubyClass docInfoClassName);
-    void docinfo_processor(RubyClass docInfoClassName, String registrationName);
     void docinfo_processor(DocinfoProcessor docInfoClassName);
-    void docinfo_processor(DocinfoProcessor docInfoClassName, String registrationName);
 
-    void register_extension_group(ExtensionGroupImpl extensionGroup);
+    void register_extension_group(final String groupName, ExtensionGroupImpl extensionGroup);
 
     void unregister_all_extensions();
     void unregister_extension(String groupName);
@@ -85,6 +60,6 @@ public interface AsciidoctorModule {
     RubyArray converters();
     void unregister_all_converters();
 
-	String asciidoctorRuntimeEnvironmentVersion();
-	
+    String asciidoctorRuntimeEnvironmentVersion();
+
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/AsciidoctorModule.java
@@ -11,39 +11,67 @@ import org.jruby.RubyClass;
 public interface AsciidoctorModule {
 
     void preprocessor(String preprocessorClassName);
+    void preprocessor(String preprocessorClassName, String registrationName);
     void preprocessor(RubyClass preprocessorClassName);
-	void preprocessor(Preprocessor preprocessor);
-	
+    void preprocessor(RubyClass preprocessorClassName, String registrationName);
+	  void preprocessor(Preprocessor preprocessor);
+	  void preprocessor(Preprocessor preprocessor, String registrationName);
+
     void postprocessor(String postprocessorClassName);
+    void postprocessor(String postprocessorClassName, String registrationName);
     void postprocessor(RubyClass postprocessorClassName);
+    void postprocessor(RubyClass postprocessorClassName, String registrationName);
     void postprocessor(Postprocessor postprocessor);
-    
+    void postprocessor(Postprocessor postprocessor, String registrationName);
+
     void treeprocessor(String treeprocessor);
+    void treeprocessor(String treeprocessor, String registrationName);
     void treeprocessor(RubyClass treeprocessorClassName);
+    void treeprocessor(RubyClass treeprocessorClassName, String registrationName);
     void treeprocessor(Treeprocessor treeprocessorClassName);
-    
+    void treeprocessor(Treeprocessor treeprocessorClassName, String registrationName);
+
     void include_processor(String includeProcessorClassName);
+    void include_processor(String includeProcessorClassName, String registrationName);
     void include_processor(RubyClass includeProcessorClassName);
+    void include_processor(RubyClass includeProcessorClassName, String registrationName);
     void include_processor(IncludeProcessor includeProcessor);
-    
+    void include_processor(IncludeProcessor includeProcessor, String registrationName);
+
     void block_processor(String blockClassName, Object blockName);
+    void block_processor(String blockClassName, Object blockName, String registrationName);
     void block_processor(RubyClass blockClass, Object blockName);
+    void block_processor(RubyClass blockClass, Object blockName, String registrationName);
     void block_processor(BlockProcessor blockInstance, Object blockName);
-    
+    void block_processor(BlockProcessor blockInstance, Object blockName, String registrationName);
+
     void block_macro(String blockMacroClassName, Object blockName);
+    void block_macro(String blockMacroClassName, Object blockName, String registrationName);
     void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName);
+    void block_macro(Class<BlockMacroProcessor> blockMacroClass, Object blockName, String registrationName);
     void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName);
+    void block_macro(BlockMacroProcessor blockMacroInstance, Object blockName, String registrationName);
     void block_macro(RubyClass blockClassName, Object blockSymbol);
+    void block_macro(RubyClass blockClassName, Object blockSymbol, String registrationName);
 
     void inline_macro(String blockClassName, Object blockSymbol);
+    void inline_macro(String blockClassName, Object blockSymbol, String registrationName);
     void inline_macro(RubyClass blockClassName, Object blockSymbol);
+    void inline_macro(RubyClass blockClassName, Object blockSymbol, String registrationName);
     void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol);
-    
+    void inline_macro(InlineMacroProcessor blockClassName, Object blockSymbol, String registrationName);
+
     void docinfo_processor(String docInfoClassName);
+    void docinfo_processor(String docInfoClassName, String registrationName);
     void docinfo_processor(RubyClass docInfoClassName);
+    void docinfo_processor(RubyClass docInfoClassName, String registrationName);
     void docinfo_processor(DocinfoProcessor docInfoClassName);
-    
+    void docinfo_processor(DocinfoProcessor docInfoClassName, String registrationName);
+
+    void register_extension_group(ExtensionGroupImpl extensionGroup);
+
     void unregister_all_extensions();
+    void unregister_extension(String groupName);
 
     Object convert(String content, Map<String, Object> options);
     Object convertFile(String filename, Map<String, Object> options);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/ExtensionGroupImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/ExtensionGroupImpl.java
@@ -20,12 +20,11 @@ import org.asciidoctor.extension.processorproxies.PreprocessorProxy;
 import org.asciidoctor.extension.processorproxies.TreeprocessorProxy;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubySymbol;
 
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by robertpanzer on 21.07.17.
@@ -38,15 +37,7 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   private final String groupName;
 
-  private List<Object> docinfoProcessors = new ArrayList<>();
-  private List<Object> preprocessors = new ArrayList<>();
-  private List<Object> postprocessors = new ArrayList<>();
-  private List<Object> includeProcessors = new ArrayList<>();
-  private List<Object> treeProcessors = new ArrayList<>();
-  private Map<String, Object> blockprocessors = new HashMap<>();
-  private Map<String, Object> blockMacros = new HashMap<>();
-  private Map<String, Object> inlineMacros = new HashMap<>();
-  private List<String> requiredRubyLibraries = new ArrayList<>();
+  private List<Registrator> registrators = new ArrayList<>();
 
   public ExtensionGroupImpl(String groupName, JRubyAsciidoctor asciidoctor) {
     this.groupName = groupName;
@@ -60,43 +51,13 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public void register() {
-    asciidoctorModule.register_extension_group(this);
+    asciidoctorModule.register_extension_group(this.groupName, this);
   }
 
-  public List<Object> getDocinfoProcessors() {
-    return docinfoProcessors;
-  }
-
-  public List<Object> getPreprocessors() {
-    return preprocessors;
-  }
-
-  public List<Object> getPostprocessors() {
-    return postprocessors;
-  }
-
-  public List<Object> getIncludeProcessors() {
-    return includeProcessors;
-  }
-
-  public List<Object> getTreeProcessors() {
-    return treeProcessors;
-  }
-
-  public Map<String, Object> getBlockprocessors() {
-    return blockprocessors;
-  }
-
-  public Map<String, Object> getBlockMacros() {
-    return blockMacros;
-  }
-
-  public Map<String, Object> getInlineMacros() {
-    return inlineMacros;
-  }
-
-  public List<String> getRequiredRubyLibraries() {
-    return requiredRubyLibraries;
+  public void registerExtensions(Registry registry) {
+    for (Registrator registrator: registrators) {
+      registrator.register(registry);
+    }
   }
 
   @Override
@@ -106,15 +67,25 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public ExtensionGroup docinfoProcessor(final Class<? extends DocinfoProcessor> docInfoProcessor) {
-    RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
-    docinfoProcessors.add(rubyClass);
+    final RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.docinfo_processor(rubyClass);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup docinfoProcessor(final DocinfoProcessor docInfoProcessor) {
-    RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
-    docinfoProcessors.add(rubyClass);
+    final RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.docinfo_processor(rubyClass);
+      }
+    });
     return this;
   }
 
@@ -131,15 +102,25 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public ExtensionGroup preprocessor(final Class<? extends Preprocessor> preprocessor) {
-    RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
-    preprocessors.add(rubyClass);
+    final RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.preprocessor(rubyClass);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup preprocessor(final Preprocessor preprocessor) {
-    RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
-    preprocessors.add(rubyClass);
+    final RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.preprocessor(rubyClass);
+      }
+    });
     return this;
   }
 
@@ -167,15 +148,25 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public ExtensionGroup postprocessor(final Class<? extends Postprocessor> postprocessor) {
-    RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
-    postprocessors.add(rubyClass);
+    final RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.postprocessor(rubyClass);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup postprocessor(final Postprocessor postprocessor) {
-    RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
-    postprocessors.add(rubyClass);
+    final RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.postprocessor(rubyClass);
+      }
+    });
     return this;
   }
 
@@ -192,29 +183,49 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public ExtensionGroup includeProcessor(final Class<? extends IncludeProcessor> includeProcessor) {
-    RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
-    includeProcessors.add(rubyClass);
+    final RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.include_processor(rubyClass);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup includeProcessor(final IncludeProcessor includeProcessor) {
-    RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
-    includeProcessors.add(rubyClass);
+    final RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.include_processor(rubyClass);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup treeprocessor(final Treeprocessor treeprocessor) {
-    RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeprocessor);
-    treeProcessors.add(rubyClass);
+    final RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeprocessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.tree_processor(rubyClass);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup treeprocessor(final Class<? extends Treeprocessor> treeProcessor) {
-    RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeProcessor);
-    treeProcessors.add(rubyClass);
+    final RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.tree_processor(rubyClass);
+      }
+    });
     return this;
   }
 
@@ -251,43 +262,73 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public ExtensionGroup block(final String blockName, final Class<? extends BlockProcessor> blockProcessor) {
-    RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-    blockprocessors.put(blockName, rubyClass);
+    final RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block(rubyClass, rubyRuntime.newSymbol(blockName));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup block(final Class<? extends BlockProcessor> blockProcessor) {
-    RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-    blockprocessors.put(BlockProcessorProxy.getName(blockProcessor), rubyClass);
+    final RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block(rubyClass, rubyRuntime.newSymbol(BlockProcessorProxy.getName(blockProcessor)));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup block(final BlockProcessor blockProcessor) {
-    RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-    blockprocessors.put(blockProcessor.getName(), rubyClass);
+    final RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block(rubyClass, rubyRuntime.newSymbol(blockProcessor.getName()));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup block(final String blockName, final BlockProcessor blockProcessor) {
-    RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-    blockprocessors.put(blockName, rubyClass);
+    final RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block(rubyClass, rubyRuntime.newSymbol(blockName));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup blockMacro(final String blockName, final Class<? extends BlockMacroProcessor> blockMacroProcessor) {
-    RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-    blockMacros.put(blockName, rubyClass);
+    final RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block_macro(rubyClass, rubyRuntime.newSymbol(blockName));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup blockMacro(final Class<? extends BlockMacroProcessor> blockMacroProcessor) {
-    RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-    blockMacros.put(AbstractProcessorProxy.getName(blockMacroProcessor), rubyClass);
+    final RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block_macro(rubyClass, rubyRuntime.newSymbol(AbstractProcessorProxy.getName(blockMacroProcessor)));
+      }
+    });
     return this;
   }
 
@@ -313,29 +354,49 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public ExtensionGroup blockMacro(final BlockMacroProcessor blockMacroProcessor) {
-    RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-    blockMacros.put(blockMacroProcessor.getName(), rubyClass);
+    final RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block_macro(rubyClass, rubyRuntime.newSymbol(blockMacroProcessor.getName()));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup inlineMacro(final InlineMacroProcessor inlineMacroProcessor) {
-    RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-    inlineMacros.put(inlineMacroProcessor.getName(), rubyClass);
+    final RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.inline_macro(rubyClass, rubyRuntime.newSymbol(inlineMacroProcessor.getName()));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup inlineMacro(final String name, final Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
-    RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-    inlineMacros.put(name, rubyClass);
+    final RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.inline_macro(rubyClass, rubyRuntime.newSymbol(name));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup inlineMacro(final Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
-    RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-    inlineMacros.put(AbstractProcessorProxy.getName(inlineMacroProcessor), rubyClass);
+    final RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.inline_macro(rubyClass, rubyRuntime.newSymbol(AbstractProcessorProxy.getName(inlineMacroProcessor)));
+      }
+    });
     return this;
   }
 
@@ -361,7 +422,7 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public ExtensionGroup requireRubyLibrary(final String requiredLibrary) {
-    requiredRubyLibraries.add(requiredLibrary);
+    RubyUtils.requireLibrary(rubyRuntime, requiredLibrary);
     return this;
   }
 
@@ -373,63 +434,120 @@ public class ExtensionGroupImpl implements ExtensionGroup {
 
   @Override
   public ExtensionGroup rubyPreprocessor(final String preprocessor) {
-    preprocessors.add(preprocessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.preprocessor(preprocessor);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup rubyPostprocessor(final String postprocessor) {
-    postprocessors.add(postprocessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.postprocessor(postprocessor);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup rubyDocinfoProcessor(final String docinfoProcessor) {
-    docinfoProcessors.add(docinfoProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.docinfo_processor(docinfoProcessor);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup rubyIncludeProcessor(final String includeProcessor) {
-    includeProcessors.add(includeProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.include_processor(includeProcessor);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup rubyTreeprocessor(final String treeProcessor) {
-    treeProcessors.add(treeProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.tree_processor(treeProcessor);
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup rubyBlock(final String blockName, final String blockProcessor) {
-    blockprocessors.put(blockName, blockProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block(blockProcessor, rubyRuntime.newSymbol(blockName));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup rubyBlockMacro(final String blockName, final String blockMacroProcessor) {
-    blockMacros.put(blockName, blockMacroProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.block_macro(blockMacroProcessor, rubyRuntime.newSymbol(blockName));
+      }
+    });
     return this;
   }
 
   @Override
   public ExtensionGroup rubyInlineMacro(final String macroName, final String inlineMacroProcessor) {
-    inlineMacros.put(macroName, inlineMacroProcessor);
+    registrators.add(new Registrator() {
+      @Override
+      public void register(Registry registry) {
+        registry.inline_macro(inlineMacroProcessor, rubyRuntime.newSymbol(macroName));
+      }
+    });
     return this;
   }
 
-  private String getImportLine(Class<?> extensionClass) {
-    int dollarPosition = -1;
-    String className = extensionClass.getName();
-    if ((dollarPosition = className.indexOf("$")) != -1) {
-      className = className.substring(0, dollarPosition);
-    }
-    return className;
+  public interface Registry {
+
+    void docinfo_processor(RubyClass rubyClass);
+    void docinfo_processor(String className);
+
+    void preprocessor(RubyClass rubyClass);
+    void preprocessor(String className);
+
+    void postprocessor(RubyClass rubyClass);
+    void postprocessor(String className);
+
+    void include_processor(RubyClass rubyClass);
+    void include_processor(String className);
+
+    void tree_processor(RubyClass rubyClass);
+    void tree_processor(String className);
+
+    void block(RubyClass rubyClass, RubySymbol name);
+    void block(String className, RubySymbol name);
+
+    void block_macro(RubyClass rubyClass, RubySymbol name);
+    void block_macro(String className, RubySymbol name);
+
+    void inline_macro(RubyClass rubyClass, RubySymbol name);
+    void inline_macro(String className, RubySymbol name);
   }
 
-  private String getClassName(String clazz) {
-    return clazz.substring(clazz.lastIndexOf(".")+1);
+  public interface Registrator {
+    void register(Registry registry);
   }
-
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/ExtensionGroupImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/ExtensionGroupImpl.java
@@ -1,0 +1,435 @@
+package org.asciidoctor.internal;
+
+import org.asciidoctor.extension.BlockMacroProcessor;
+import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.DocinfoProcessor;
+import org.asciidoctor.extension.ExtensionGroup;
+import org.asciidoctor.extension.IncludeProcessor;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Postprocessor;
+import org.asciidoctor.extension.Preprocessor;
+import org.asciidoctor.extension.Treeprocessor;
+import org.asciidoctor.extension.processorproxies.AbstractProcessorProxy;
+import org.asciidoctor.extension.processorproxies.BlockMacroProcessorProxy;
+import org.asciidoctor.extension.processorproxies.BlockProcessorProxy;
+import org.asciidoctor.extension.processorproxies.DocinfoProcessorProxy;
+import org.asciidoctor.extension.processorproxies.IncludeProcessorProxy;
+import org.asciidoctor.extension.processorproxies.InlineMacroProcessorProxy;
+import org.asciidoctor.extension.processorproxies.PostprocessorProxy;
+import org.asciidoctor.extension.processorproxies.PreprocessorProxy;
+import org.asciidoctor.extension.processorproxies.TreeprocessorProxy;
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by robertpanzer on 21.07.17.
+ */
+public class ExtensionGroupImpl implements ExtensionGroup {
+
+  private final Ruby rubyRuntime;
+
+  private final AsciidoctorModule asciidoctorModule;
+
+  private final String groupName;
+
+  private List<Object> docinfoProcessors = new ArrayList<>();
+  private List<Object> preprocessors = new ArrayList<>();
+  private List<Object> postprocessors = new ArrayList<>();
+  private List<Object> includeProcessors = new ArrayList<>();
+  private List<Object> treeProcessors = new ArrayList<>();
+  private Map<String, Object> blockprocessors = new HashMap<>();
+  private Map<String, Object> blockMacros = new HashMap<>();
+  private Map<String, Object> inlineMacros = new HashMap<>();
+  private List<String> requiredRubyLibraries = new ArrayList<>();
+
+  public ExtensionGroupImpl(String groupName, JRubyAsciidoctor asciidoctor) {
+    this.groupName = groupName;
+    this.rubyRuntime = asciidoctor.getRubyRuntime();
+    asciidoctorModule = asciidoctor.getAsciidoctorModule();
+  }
+
+  public String getGroupName() {
+    return groupName;
+  }
+
+  @Override
+  public void register() {
+    asciidoctorModule.register_extension_group(this);
+  }
+
+  public List<Object> getDocinfoProcessors() {
+    return docinfoProcessors;
+  }
+
+  public List<Object> getPreprocessors() {
+    return preprocessors;
+  }
+
+  public List<Object> getPostprocessors() {
+    return postprocessors;
+  }
+
+  public List<Object> getIncludeProcessors() {
+    return includeProcessors;
+  }
+
+  public List<Object> getTreeProcessors() {
+    return treeProcessors;
+  }
+
+  public Map<String, Object> getBlockprocessors() {
+    return blockprocessors;
+  }
+
+  public Map<String, Object> getBlockMacros() {
+    return blockMacros;
+  }
+
+  public Map<String, Object> getInlineMacros() {
+    return inlineMacros;
+  }
+
+  public List<String> getRequiredRubyLibraries() {
+    return requiredRubyLibraries;
+  }
+
+  @Override
+  public void unregister() {
+    asciidoctorModule.unregister_extension(groupName);
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final Class<? extends DocinfoProcessor> docInfoProcessor) {
+    RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
+    docinfoProcessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final DocinfoProcessor docInfoProcessor) {
+    RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
+    docinfoProcessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup docinfoProcessor(final String docInfoProcessor) {
+    try {
+      final Class<? extends DocinfoProcessor>  docinfoProcessorClass = (Class<? extends DocinfoProcessor>) Class.forName(docInfoProcessor);
+      docinfoProcessor(docinfoProcessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final Class<? extends Preprocessor> preprocessor) {
+    RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
+    preprocessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final Preprocessor preprocessor) {
+    RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
+    preprocessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup preprocessor(final String preprocessor) {
+    try {
+      final Class<? extends Preprocessor>  preprocessorClass = (Class<? extends Preprocessor>) Class.forName(preprocessor);
+      preprocessor(preprocessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final String postprocessor) {
+    try {
+        Class<? extends Postprocessor>  postprocessorClass = (Class<? extends Postprocessor>) Class.forName(postprocessor);
+        postprocessor(postprocessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final Class<? extends Postprocessor> postprocessor) {
+    RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
+    postprocessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup postprocessor(final Postprocessor postprocessor) {
+    RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
+    postprocessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final String includeProcessor) {
+    try {
+      Class<? extends IncludeProcessor>  includeProcessorClass = (Class<? extends IncludeProcessor>) Class.forName(includeProcessor);
+      includeProcessor(includeProcessorClass);
+      return this;
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final Class<? extends IncludeProcessor> includeProcessor) {
+    RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
+    includeProcessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup includeProcessor(final IncludeProcessor includeProcessor) {
+    RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
+    includeProcessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final Treeprocessor treeprocessor) {
+    RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeprocessor);
+    treeProcessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final Class<? extends Treeprocessor> treeProcessor) {
+    RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeProcessor);
+    treeProcessors.add(rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup treeprocessor(final String treeProcessor) {
+    try {
+      Class<? extends Treeprocessor>  treeProcessorClass = (Class<? extends Treeprocessor>) Class.forName(treeProcessor);
+      treeprocessor(treeProcessorClass);
+      return this;
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final String blockProcessor) {
+    try {
+      Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
+      return block(blockName, blockProcessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockProcessor) {
+    try {
+      Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
+      return block(blockProcessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final Class<? extends BlockProcessor> blockProcessor) {
+    RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+    blockprocessors.put(blockName, rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final Class<? extends BlockProcessor> blockProcessor) {
+    RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+    blockprocessors.put(BlockProcessorProxy.getName(blockProcessor), rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final BlockProcessor blockProcessor) {
+    RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+    blockprocessors.put(blockProcessor.getName(), rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup block(final String blockName, final BlockProcessor blockProcessor) {
+    RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+    blockprocessors.put(blockName, rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final String blockName, final Class<? extends BlockMacroProcessor> blockMacroProcessor) {
+    RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+    blockMacros.put(blockName, rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final Class<? extends BlockMacroProcessor> blockMacroProcessor) {
+    RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+    blockMacros.put(AbstractProcessorProxy.getName(blockMacroProcessor), rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final String blockName, final String blockMacroProcessor) {
+    try {
+      Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
+      return blockMacro(blockName, blockMacroProcessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final String blockMacroProcessor) {
+    try {
+      Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
+      return blockMacro(blockMacroProcessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ExtensionGroup blockMacro(final BlockMacroProcessor blockMacroProcessor) {
+    RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+    blockMacros.put(blockMacroProcessor.getName(), rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final InlineMacroProcessor inlineMacroProcessor) {
+    RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+    inlineMacros.put(inlineMacroProcessor.getName(), rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final String name, final Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
+    RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+    inlineMacros.put(name, rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
+    RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+    inlineMacros.put(AbstractProcessorProxy.getName(inlineMacroProcessor), rubyClass);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final String name, final String inlineMacroProcessor) {
+    try {
+      Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
+      return inlineMacro(name, inlineMacroProcessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ExtensionGroup inlineMacro(final String inlineMacroProcessor) {
+    try {
+      Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
+      return inlineMacro(inlineMacroProcessorClass);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public ExtensionGroup requireRubyLibrary(final String requiredLibrary) {
+    requiredRubyLibraries.add(requiredLibrary);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup loadRubyClass(final InputStream rubyClassStream) {
+    RubyUtils.loadRubyClass(rubyRuntime, rubyClassStream);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyPreprocessor(final String preprocessor) {
+    preprocessors.add(preprocessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyPostprocessor(final String postprocessor) {
+    postprocessors.add(postprocessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyDocinfoProcessor(final String docinfoProcessor) {
+    docinfoProcessors.add(docinfoProcessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyIncludeProcessor(final String includeProcessor) {
+    includeProcessors.add(includeProcessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyTreeprocessor(final String treeProcessor) {
+    treeProcessors.add(treeProcessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyBlock(final String blockName, final String blockProcessor) {
+    blockprocessors.put(blockName, blockProcessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyBlockMacro(final String blockName, final String blockMacroProcessor) {
+    blockMacros.put(blockName, blockMacroProcessor);
+    return this;
+  }
+
+  @Override
+  public ExtensionGroup rubyInlineMacro(final String macroName, final String inlineMacroProcessor) {
+    inlineMacros.put(macroName, inlineMacroProcessor);
+    return this;
+  }
+
+  private String getImportLine(Class<?> extensionClass) {
+    int dollarPosition = -1;
+    String className = extensionClass.getName();
+    if ((dollarPosition = className.indexOf("$")) != -1) {
+      className = className.substring(0, dollarPosition);
+    }
+    return className;
+  }
+
+  private String getClassName(String clazz) {
+    return clazz.substring(clazz.lastIndexOf(".")+1);
+  }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -5,15 +5,16 @@ import org.asciidoctor.Attributes;
 import org.asciidoctor.DirectoryWalker;
 import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.ContentPart;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.NodeConverter;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.StructuredDocument;
 import org.asciidoctor.ast.Title;
 import org.asciidoctor.converter.JavaConverterRegistry;
 import org.asciidoctor.converter.internal.ConverterRegistryExecutor;
+import org.asciidoctor.extension.ExtensionGroup;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.extension.internal.ExtensionRegistryExecutor;
@@ -24,8 +25,18 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 public class JRubyAsciidoctor implements Asciidoctor {
@@ -587,6 +598,19 @@ public class JRubyAsciidoctor implements Asciidoctor {
     public Document loadFile(File file, Map<String, Object> options) {
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
         return (Document) NodeConverter.createASTNode(this.asciidoctorModule.load_file(file.getAbsolutePath(), rubyHash));
+    }
 
+    AsciidoctorModule getAsciidoctorModule() {
+        return asciidoctorModule;
+    }
+
+    @Override
+    public ExtensionGroup createGroup() {
+        return new ExtensionGroupImpl(UUID.randomUUID().toString(), this);
+    }
+
+    @Override
+    public ExtensionGroup createGroup(String groupName) {
+        return new ExtensionGroupImpl(groupName, this);
     }
 }

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -4,7 +4,7 @@ module AsciidoctorJ
         include_package 'org.asciidoctor.extension'
         # Treeprocessor was renamed in to TreeProcessor in https://github.com/asciidoctor/asciidoctor/commit/f1dd816ade9db457b899581841e4cf7b788aa26d
         # This is necessary to run against both Asciidoctor 1.5.5 and 1.5.6
-        TreeProcessor = Treeprocessor
+        TreeProcessor = Treeprocessor unless defined? TreeProcessor
     end
 end
 
@@ -19,51 +19,84 @@ class AsciidoctorModule
         Asciidoctor::Extensions.unregister_all
     end
 
-    def docinfo_processor(extensionName)
-        Asciidoctor::Extensions.register do
+    def unregister_extension name
+        Asciidoctor::Extensions.unregister name
+    end
+
+    def docinfo_processor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             docinfo_processor extensionName
         end
     end
 
-    def treeprocessor(extensionName)
-        Asciidoctor::Extensions.register do 
+    def treeprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             treeprocessor extensionName
         end
     end
     
-    def include_processor(extensionName)
-        Asciidoctor::Extensions.register do
+    def include_processor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             include_processor extensionName
         end
     end
 
-    def preprocessor(extensionName)
-        Asciidoctor::Extensions.register do
+    def preprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             preprocessor extensionName
         end
     end
     
-    def postprocessor(extensionName)
-        Asciidoctor::Extensions.register do
+    def postprocessor(extensionName, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             postprocessor extensionName
         end
     end
 
-    def block_processor(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def block_processor(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             block extensionName, blockSymbol
         end
     end
 
-    def block_macro(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def block_macro(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             block_macro extensionName, blockSymbol
         end
     end
 
-    def inline_macro(extensionName, blockSymbol)
-        Asciidoctor::Extensions.register do
+    def inline_macro(extensionName, blockSymbol, groupName = nil)
+        Asciidoctor::Extensions.register groupName do
             inline_macro extensionName, blockSymbol
+        end
+    end
+
+    def register_extension_group(extensionGroupImpl)
+        Asciidoctor::Extensions.register extensionGroupImpl.groupName do
+            extensionGroupImpl.docinfoProcessors.each {|p|
+                docinfo_processor p
+            }
+            extensionGroupImpl.preprocessors.each {|p|
+                preprocessor p
+            }
+            extensionGroupImpl.postprocessors.each {|p|
+                postprocessor p
+            }
+            extensionGroupImpl.includeProcessors.each {|p|
+                include_processor p
+            }
+            extensionGroupImpl.treeProcessors.each {|p|
+                tree_processor p
+            }
+            extensionGroupImpl.blockprocessors.entrySet().each {|p|
+                block p.value, p.key.to_sym
+            }
+            extensionGroupImpl.blockMacros.entrySet().each {|p|
+                block_macro p.value, p.key.to_sym
+            }
+            extensionGroupImpl.inlineMacros.entrySet().each {|p|
+                inline_macro p.value, p.key.to_sym
+            }
         end
     end
 

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -23,80 +23,57 @@ class AsciidoctorModule
         Asciidoctor::Extensions.unregister name
     end
 
-    def docinfo_processor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register groupName do
+    def docinfo_processor(extensionName)
+        Asciidoctor::Extensions.register do
             docinfo_processor extensionName
         end
     end
 
-    def treeprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register groupName do
+    def treeprocessor(extensionName)
+        Asciidoctor::Extensions.register do
             treeprocessor extensionName
         end
     end
     
-    def include_processor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register groupName do
+    def include_processor(extensionName)
+        Asciidoctor::Extensions.register do
             include_processor extensionName
         end
     end
 
-    def preprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register groupName do
+    def preprocessor(extensionName)
+        Asciidoctor::Extensions.register do
             preprocessor extensionName
         end
     end
     
-    def postprocessor(extensionName, groupName = nil)
-        Asciidoctor::Extensions.register groupName do
+    def postprocessor(extensionName)
+        Asciidoctor::Extensions.register do
             postprocessor extensionName
         end
     end
 
-    def block_processor(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register groupName do
+    def block_processor(extensionName, blockSymbol)
+        Asciidoctor::Extensions.register do
             block extensionName, blockSymbol
         end
     end
 
-    def block_macro(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register groupName do
+    def block_macro(extensionName, blockSymbol)
+        Asciidoctor::Extensions.register do
             block_macro extensionName, blockSymbol
         end
     end
 
-    def inline_macro(extensionName, blockSymbol, groupName = nil)
-        Asciidoctor::Extensions.register groupName do
+    def inline_macro(extensionName, blockSymbol)
+        Asciidoctor::Extensions.register do
             inline_macro extensionName, blockSymbol
         end
     end
 
-    def register_extension_group(extensionGroupImpl)
-        Asciidoctor::Extensions.register extensionGroupImpl.groupName do
-            extensionGroupImpl.docinfoProcessors.each {|p|
-                docinfo_processor p
-            }
-            extensionGroupImpl.preprocessors.each {|p|
-                preprocessor p
-            }
-            extensionGroupImpl.postprocessors.each {|p|
-                postprocessor p
-            }
-            extensionGroupImpl.includeProcessors.each {|p|
-                include_processor p
-            }
-            extensionGroupImpl.treeProcessors.each {|p|
-                tree_processor p
-            }
-            extensionGroupImpl.blockprocessors.entrySet().each {|p|
-                block p.value, p.key.to_sym
-            }
-            extensionGroupImpl.blockMacros.entrySet().each {|p|
-                block_macro p.value, p.key.to_sym
-            }
-            extensionGroupImpl.inlineMacros.entrySet().each {|p|
-                inline_macro p.value, p.key.to_sym
-            }
+    def register_extension_group(groupName, callback)
+        Asciidoctor::Extensions.register groupName do
+            callback.registerExtensions self
         end
     end
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesASection.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesASection.groovy
@@ -14,6 +14,11 @@ import spock.lang.Specification
 class WhenABlockMacroProcessorCreatesASection extends Specification {
 
     public static final String BLOCKMACRO_NAME = 'section'
+    public static final String UTF_8 = 'UTF-8'
+    public static final String H2 = 'h2'
+    public static final String HELLO_WORLD = '1. HelloWorld'
+    public static final String SECT1_SELECTOR = 'div.sect1'
+    public static final String PARAGRAPH_SELECTOR = 'div.paragraph'
 
     @ArquillianResource
     private Asciidoctor asciidoctor
@@ -34,11 +39,28 @@ section::HelloWorld[]
 
         then:
         noExceptionThrown()
-        Document htmlDocument = Jsoup.parse(result, 'UTF-8')
+        Document htmlDocument = Jsoup.parse(result, UTF_8)
 
-        htmlDocument.select('h2').text() == '1. HelloWorld'
+        htmlDocument.select(H2).text() == HELLO_WORLD
 
-        htmlDocument.select('div.sect1').select('div.paragraph').text() == SectionCreatorBlockMacro.CONTENT
+        htmlDocument.select(SECT1_SELECTOR).select(PARAGRAPH_SELECTOR).text() == SectionCreatorBlockMacro.CONTENT
+    }
+
+    def "the section should appear in the resulting document when the extension is registered with an extension group"() {
+
+        given:
+        asciidoctor.createGroup().blockMacro(BLOCKMACRO_NAME, SectionCreatorBlockMacro).register()
+
+        when:
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).headerFooter(true))
+
+        then:
+        noExceptionThrown()
+        Document htmlDocument = Jsoup.parse(result, UTF_8)
+
+        htmlDocument.select(H2).text() == HELLO_WORLD
+
+        htmlDocument.select(SECT1_SELECTOR).select(PARAGRAPH_SELECTOR).text() == SectionCreatorBlockMacro.CONTENT
     }
 
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionGroupIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionGroupIsRegisteredWithAnnotations.groovy
@@ -1,0 +1,195 @@
+package org.asciidoctor.extension
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.SafeMode
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.junit.runner.RunWith
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue('https://github.com/asciidoctor/asciidoctorj/issues/196')
+@RunWith(ArquillianSputnik)
+class WhenAJavaExtensionGroupIsRegisteredWithAnnotations extends Specification {
+
+    public static final String UTF8 = 'UTF-8'
+    public static final String TAG_HEAD = 'head'
+    public static final String ELEMENTID_FOOTER = 'footer'
+    public static final String ATTR_KEY_NAME = 'name'
+    public static final String ATTR_VALUE_ROBOTS = 'robots'
+    public static final String DO_NOT_TOUCH_THIS = 'Do not touch this'
+    public static final String THIS_SHOULD_BE_UPPERCASE = 'This should be uppercase'
+    public static final String THIS_SHOULD_ALSO_BE_UPPERCASE = 'This should also be uppercase'
+    public static final String HREF = 'href'
+    public static final String ANCHOR_TAG = 'a'
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    private static final String DOCUMENT = '''= Test document
+'''
+
+    private static final String BLOCK_MACRO_DOCUMENT = '''= Test document
+
+testmacro::target[]
+
+'''
+
+    private static final String BLOCK_DOCUMENT = '''= Test document
+
+[yell]
+Do not touch this
+
+[yell]
+----
+This should be uppercase
+----
+
+[yell]
+--
+This should also be uppercase
+--
+
+'''
+
+    private static final String BLOCK_DOCUMENT_2 = '''= Test document
+
+[yell2]
+Do not touch this
+
+[yell2]
+----
+This should be uppercase
+----
+
+[yell2]
+--
+This should also be uppercase
+--
+
+'''
+
+    private static final String INLINE_MACRO_DOCUMENT = '''= Test document
+
+You can find infos on man:gittutorial[7] or man:git[8, 1].
+
+'''
+
+    private static final String INLINE_MACRO_REGEXP_DOCUMENT = '''= Test document
+
+You can find infos on man:gittutorial[7].
+
+And even more infos on manpage:git[7].
+
+'''
+
+
+    def "a docinfoprocessor should be configurable via the Location annotation"() {
+        when:
+        asciidoctor.createGroup().docinfoProcessor(AnnotatedDocinfoProcessor).register()
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element footer = doc.getElementById(ELEMENTID_FOOTER)
+        footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
+    }
+
+    def "a docinfoprocessor instance should be configurable via the Location annotation"() {
+        when:
+        asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor()).register()
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element footer = doc.getElementById(ELEMENTID_FOOTER)
+        footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
+    }
+
+    @spock.lang.Ignore('Option for docinfo in header changed from :header to :head in AsciidoctorJ. Ignore as long as these tests have to run on both Asciidoctor 1.5.2 as well as 1.5.3.dev')
+    def "a docinfoprocessor instance can override the annotation from footer to header"() {
+        when:
+        asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.HEADER)).register()
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        !doc.getElementsByTag(TAG_HEAD)[0].getElementsByAttributeValueContaining(ATTR_KEY_NAME, ATTR_VALUE_ROBOTS).empty
+    }
+
+    def "a docinfoprocessor instance can override the annotation from footer to footer"() {
+        when:
+        asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.FOOTER)).register()
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element footer = doc.getElementById(ELEMENTID_FOOTER)
+        footer.nextElementSibling().attr(ATTR_KEY_NAME) == ATTR_VALUE_ROBOTS
+    }
+
+    def "when registering a BlockMacroProcessor class it should be configurable via annotations"() {
+
+        when:
+        asciidoctor.createGroup().blockMacro(AnnotatedBlockMacroProcessor).register()
+        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        result.contains(AnnotatedBlockMacroProcessor.RESULT)
+    }
+
+    // TODO: What about the macro name when passing an instance? Do we really need BlockMacroProcessor.getName()?
+
+    def "when registering a BlockProcessor class it should be configurable via annotations"() {
+
+        when:
+        asciidoctor.createGroup().block(AnnotatedBlockProcessor).register()
+        String result = asciidoctor.convert(BLOCK_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        result.contains(DO_NOT_TOUCH_THIS)
+        result.contains(THIS_SHOULD_BE_UPPERCASE.toUpperCase())
+        result.contains(THIS_SHOULD_ALSO_BE_UPPERCASE.toUpperCase())
+    }
+
+    // TODO: What about the block name when passing an instance? Do we really need BlockMacroProcessor.getName()?
+
+    def "when registering a BlockProcessor instance it should be configurable via annotations"() {
+
+        when:
+        asciidoctor.createGroup().block(new AnnotatedBlockProcessor('dummy', 'yell2')).register()
+        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        result.contains(DO_NOT_TOUCH_THIS)
+        result.contains(THIS_SHOULD_BE_UPPERCASE.toUpperCase())
+        result.contains(THIS_SHOULD_ALSO_BE_UPPERCASE.toUpperCase())
+    }
+
+    def "when registering an InlineMacroProcessor class with long format it should be configurable via annotations"() {
+        when:
+        asciidoctor.createGroup().inlineMacro(AnnotatedLongInlineMacroProcessor).register()
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element link = doc.getElementsByTag(ANCHOR_TAG).first()
+        link.attr(HREF) == 'gittutorial.html'
+    }
+
+    def "when registering an InlineMacroProcessor class with regexp it should be configurable via annotations"() {
+        when:
+        asciidoctor.createGroup().inlineMacro(AnnotatedRegexpInlineMacroProcessor).register()
+        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+
+        then:
+        Document doc = Jsoup.parse(result, UTF8)
+        Element link = doc.getElementsByTag(ANCHOR_TAG).first()
+        link.attr(HREF) == 'git.html'
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
-public class WhenJavaExtensionIsRegistered {
+public class WhenJavaExtensionGroupIsRegistered {
 
     @ArquillianResource
     private ClasspathResources classpath;
@@ -118,9 +118,9 @@ public class WhenJavaExtensionIsRegistered {
 
         TestHttpServer.start(Collections.singletonMap("http://example.com/asciidoctorclass.rb", classpath.getResource("org/asciidoctor/internal/asciidoctorclass.rb")));
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.includeProcessor(new RubyIncludeSource(new HashMap<String, Object>()));
+        this.asciidoctor.createGroup()
+            .includeProcessor(new RubyIncludeSource(new HashMap<String, Object>()))
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-uri-include.ad"),
@@ -139,9 +139,8 @@ public class WhenJavaExtensionIsRegistered {
 
         TestHttpServer.start(Collections.singletonMap("http://example.com/asciidoctorclass.rb", classpath.getResource("org/asciidoctor/internal/asciidoctorclass.rb")));
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.includeProcessor(new IncludeProcessor(new HashMap<String, Object>()) {
+        this.asciidoctor.createGroup()
+            .includeProcessor(new IncludeProcessor(new HashMap<String, Object>()) {
 
             @Override
             public void process(Document document, PreprocessorReader reader, String target,
@@ -180,7 +179,8 @@ public class WhenJavaExtensionIsRegistered {
             public boolean handles(String target) {
                 return target.startsWith("http://") || target.startsWith("https://");
             }
-        });
+        })
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-uri-include.ad"),
@@ -196,9 +196,9 @@ public class WhenJavaExtensionIsRegistered {
 
     @Test
     public void a_docinfoprocessor_should_be_executed_and_add_meta_in_header_by_default() {
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.docinfoProcessor(MetaRobotsDocinfoProcessor.class.getCanonicalName());
+        asciidoctor.createGroup()
+            .docinfoProcessor(MetaRobotsDocinfoProcessor.class.getCanonicalName())
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("simple.adoc"),
@@ -212,13 +212,14 @@ public class WhenJavaExtensionIsRegistered {
 
     @Test
     public void a_docinfoprocessor_should_be_executed_and_add_meta_in_footer() {
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("location", ":footer");
         MetaRobotsDocinfoProcessor metaRobotsDocinfoProcessor = new MetaRobotsDocinfoProcessor(options);
 
-        javaExtensionRegistry.docinfoProcessor(metaRobotsDocinfoProcessor);
+        this.asciidoctor.createGroup()
+            .docinfoProcessor(metaRobotsDocinfoProcessor)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("simple.adoc"),
@@ -234,9 +235,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_preprocessor_should_be_executed_before_document_is_rendered() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.preprocessor(ChangeAttributeValuePreprocessor.class);
+        this.asciidoctor.createGroup()
+            .preprocessor(ChangeAttributeValuePreprocessor.class)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("changeattribute.adoc"),
@@ -251,9 +252,10 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_preprocessor_as_string_should_be_executed_before_document_is_rendered() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.preprocessor("org.asciidoctor.extension.ChangeAttributeValuePreprocessor");
+        this.asciidoctor.createGroup()
+            .preprocessor("org.asciidoctor.extension.ChangeAttributeValuePreprocessor")
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("changeattribute.adoc"),
@@ -268,9 +270,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_preprocessor_instance_should_be_executed_before_document_is_rendered() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.preprocessor(new ChangeAttributeValuePreprocessor(new HashMap<String, Object>()));
+        this.asciidoctor.createGroup()
+            .preprocessor(new ChangeAttributeValuePreprocessor(new HashMap<String, Object>()))
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("changeattribute.adoc"),
@@ -285,9 +287,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_postprocessor_as_string_should_be_executed_after_document_is_rendered() throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.postprocessor("org.asciidoctor.extension.CustomFooterPostProcessor");
+        this.asciidoctor.createGroup()
+            .postprocessor("org.asciidoctor.extension.CustomFooterPostProcessor")
+            .register();
 
         Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
                 .safe(SafeMode.UNSAFE).get();
@@ -304,9 +306,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_postprocessor_should_be_executed_after_document_is_rendered() throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.postprocessor(CustomFooterPostProcessor.class);
+        this.asciidoctor.createGroup()
+            .postprocessor(CustomFooterPostProcessor.class)
+            .register();
 
         Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
                 .safe(SafeMode.UNSAFE).get();
@@ -323,9 +325,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_postprocessor_instance_should_be_executed_after_document_is_rendered() throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.postprocessor(new CustomFooterPostProcessor(new HashMap<String, Object>()));
+        this.asciidoctor.createGroup()
+            .postprocessor(new CustomFooterPostProcessor(new HashMap<String, Object>()))
+            .register();
 
         Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
                 .safe(SafeMode.UNSAFE).get();
@@ -344,9 +346,9 @@ public class WhenJavaExtensionIsRegistered {
 
         TestHttpServer.start(Collections.singletonMap("http://example.com/asciidoctorclass.rb", classpath.getResource("org/asciidoctor/internal/asciidoctorclass.rb")));
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.includeProcessor("org.asciidoctor.extension.UriIncludeProcessor");
+        this.asciidoctor.createGroup()
+            .includeProcessor("org.asciidoctor.extension.UriIncludeProcessor")
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-uri-include.ad"),
@@ -365,9 +367,9 @@ public class WhenJavaExtensionIsRegistered {
 
         TestHttpServer.start(Collections.singletonMap("http://example.com/asciidoctorclass.rb", classpath.getResource("org/asciidoctor/internal/asciidoctorclass.rb")));
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.includeProcessor(UriIncludeProcessor.class);
+        this.asciidoctor.createGroup()
+            .includeProcessor(UriIncludeProcessor.class)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-uri-include.ad"),
@@ -386,9 +388,9 @@ public class WhenJavaExtensionIsRegistered {
 
         TestHttpServer.start(Collections.singletonMap("http://example.com/asciidoctorclass.rb", classpath.getResource("org/asciidoctor/internal/asciidoctorclass.rb")));
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.includeProcessor(new UriIncludeProcessor(new HashMap<String, Object>()));
+        this.asciidoctor.createGroup()
+            .includeProcessor(new UriIncludeProcessor(new HashMap<String, Object>()))
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-uri-include.ad"),
@@ -405,9 +407,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_include_processor_should_only_handle_its_handles() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.includeProcessor(UriIncludeProcessor.class);
+        this.asciidoctor.createGroup()
+            .includeProcessor(UriIncludeProcessor.class)
+            .register();
 
         String content = asciidoctor.renderFile(classpath.getResource("sample-with-include.ad"),
                 options().toFile(false).get());
@@ -423,9 +425,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_include_processor_can_handle_positional_attrs() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.includeProcessor(PositionalAttrsIncludeProcessor.class);
+        this.asciidoctor.createGroup()
+            .includeProcessor(PositionalAttrsIncludeProcessor.class)
+            .register();
 
         String content = asciidoctor.renderFile(classpath.getResource("sample-with-include-pos-attrs.ad"),
                 options().toFile(false).get());
@@ -441,37 +443,43 @@ public class WhenJavaExtensionIsRegistered {
 	@Test
     public void a_treeprocessor_should_be_executed_in_document() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+      this.asciidoctor.createGroup()
+          .treeprocessor(TerminalCommandTreeprocessor.class)
+          .register();
 
-        javaExtensionRegistry.treeprocessor(TerminalCommandTreeprocessor.class);
+      String content = asciidoctor.renderFile(
+          classpath.getResource("sample-with-terminal-command.ad"),
+          options().toFile(false).get());
 
-        String content = asciidoctor.renderFile(
-                classpath.getResource("sample-with-terminal-command.ad"),
-                options().toFile(false).get());
+      org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
-        org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
+      Element contentElement = doc.getElementsByAttributeValue("class", "command").first();
+      assertThat(contentElement.text(), is("echo \"Hello, World!\""));
 
-        Element contentElement = doc.getElementsByAttributeValue("class", "command").first();
-        assertThat(contentElement.text(), is("echo \"Hello, World!\""));
-
-        contentElement = doc.getElementsByAttributeValue("class", "command").last();
-        assertThat(contentElement.text(), is("gem install asciidoctor"));
+      contentElement = doc.getElementsByAttributeValue("class", "command").last();
+      assertThat(contentElement.text(), is("gem install asciidoctor"));
 
     }
 
     @Test
     public void a_treeprocessor_and_blockmacroprocessor_should_be_executed_in_document() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.treeprocessor(TerminalCommandTreeprocessor.class);
-        javaExtensionRegistry.blockMacro("gist", GistMacro.class);
+        this.asciidoctor.createGroup()
+            .treeprocessor(TerminalCommandTreeprocessor.class)
+            .blockMacro("gist", GistMacro.class)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-terminal-command-and-gist-macro.ad"),
                 options().toFile(false).get());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
+        System.out.println(content);
+
+        Element script = doc.getElementsByTag("script").first();
+
+        assertThat(script.attr("src"), is("https://gist.github.com/42.js"));
+
 
         Element contentElement = doc.getElementsByAttributeValue("class", "command").first();
         assertThat(contentElement.text(), is("echo \"Hello, World!\""));
@@ -479,18 +487,15 @@ public class WhenJavaExtensionIsRegistered {
         contentElement = doc.getElementsByAttributeValue("class", "command").last();
         assertThat(contentElement.text(), is("gem install asciidoctor"));
 
-        Element script = doc.getElementsByTag("script").first();
-
-        assertThat(script.attr("src"), is("https://gist.github.com/42.js"));
 
     }
 
     @Test
     public void a_treeprocessor_as_string_should_be_executed_in_document() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.treeprocessor("org.asciidoctor.extension.TerminalCommandTreeprocessor");
+        this.asciidoctor.createGroup()
+            .treeprocessor("org.asciidoctor.extension.TerminalCommandTreeprocessor")
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-terminal-command.ad"),
@@ -509,9 +514,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_treeprocessor_instance_should_be_executed_in_document() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.treeprocessor(new TerminalCommandTreeprocessor(new HashMap<String, Object>()));
+        this.asciidoctor.createGroup()
+            .treeprocessor(new TerminalCommandTreeprocessor(new HashMap<String, Object>()))
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-terminal-command.ad"),
@@ -533,7 +538,10 @@ public class WhenJavaExtensionIsRegistered {
 
         // To avoid registering the same extension over and over for all tests,
         // service is instantiated manually.
-        new ArrowsAndBoxesExtension().register(asciidoctor);
+        this.asciidoctor.createGroup()
+            .postprocessor(ArrowsAndBoxesIncludesPostProcessor.class)
+            .block("arrowsAndBoxes", ArrowsAndBoxesBlock.class)
+            .register();
 
         Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
                 .safe(SafeMode.UNSAFE).get();
@@ -557,9 +565,10 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_block_macro_extension_should_be_executed_when_macro_is_detected() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.blockMacro("gist", GistMacro.class);
+        this.asciidoctor.createGroup()
+            .blockMacro("gist", GistMacro.class)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-gist-macro.ad"),
@@ -574,9 +583,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_block_macro_extension_instance_should_be_executed_when_macro_is_detected() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.blockMacro(new GistMacro("gist", new HashMap<String, Object>()));
+        this.asciidoctor.createGroup()
+            .blockMacro(new GistMacro("gist", new HashMap<String, Object>()))
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-gist-macro.ad"),
@@ -591,9 +600,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_block_macro_as_string_extension_should_be_executed_when_macro_is_detected() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.blockMacro("gist", "org.asciidoctor.extension.GistMacro");
+        this.asciidoctor.createGroup()
+            .blockMacro("gist", "org.asciidoctor.extension.GistMacro")
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-gist-macro.ad"),
@@ -608,12 +617,12 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_block_macro_as_instance_extension_should_be_executed_when_macro_is_detected() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
         Map<String, Object> options = new HashMap<String, Object>();
         options.put(BlockMacroProcessor.CONTENT_MODEL, BlockMacroProcessor.CONTENT_MODEL_RAW);
 
-        javaExtensionRegistry.blockMacro(new GistMacro("gist", options));
+        this.asciidoctor.createGroup()
+            .blockMacro(new GistMacro("gist", options))
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-gist-macro.ad"),
@@ -628,9 +637,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void an_inline_macro_as_string_extension_should_be_executed_when_an_inline_macro_is_detected() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.inlineMacro("man", "org.asciidoctor.extension.ManpageMacro");
+        this.asciidoctor.createGroup()
+            .inlineMacro("man", "org.asciidoctor.extension.ManpageMacro")
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-man-link.ad"),
@@ -644,9 +653,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void an_inline_macro_extension_should_be_executed_when_an_inline_macro_is_detected() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.inlineMacro("man", ManpageMacro.class);
+        this.asciidoctor.createGroup()
+            .inlineMacro("man", ManpageMacro.class)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-man-link.ad"),
@@ -661,13 +670,13 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void an_inline_macro_as_instance_extension_should_be_executed_when_regexp_is_set_as_option_inline_macro_is_detected() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
         Map<String, Object> options = new HashMap<String, Object>();
         options.put(InlineMacroProcessor.REGEXP, "man(?:page)?:(\\S+?)\\[(.*?)\\]");
 
         ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
-        javaExtensionRegistry.inlineMacro(inlineMacroProcessor);
+        this.asciidoctor.createGroup()
+            .inlineMacro(inlineMacroProcessor)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-man-link.ad"),
@@ -683,13 +692,13 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void an_inline_macro_as_instance_extension_should_not_be_executed_when_regexp_is_set_and_does_not_match() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
         Map<String, Object> options = new HashMap<String, Object>();
         options.put(InlineMacroProcessor.REGEXP, "man(?:page)?:(ThisDoesNotMatch)\\[(.*?)\\]");
 
         ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
-        javaExtensionRegistry.inlineMacro(inlineMacroProcessor);
+        this.asciidoctor.createGroup()
+            .inlineMacro(inlineMacroProcessor)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-man-link.ad"),
@@ -703,12 +712,12 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void an_inline_macro_as_instance_extension_should_be_executed_when_an_inline_macro_is_detected() {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
         Map<String, Object> options = new HashMap<String, Object>();
 
         ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
-        javaExtensionRegistry.inlineMacro(inlineMacroProcessor);
+        this.asciidoctor.createGroup()
+            .inlineMacro(inlineMacroProcessor)
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-man-link.ad"),
@@ -724,9 +733,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void should_unregister_all_current_registered_extensions() throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.postprocessor(CustomFooterPostProcessor.class);
+        this.asciidoctor.createGroup()
+            .postprocessor(CustomFooterPostProcessor.class)
+            .register();
 
         Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
                 .safe(SafeMode.UNSAFE).get();
@@ -745,9 +754,9 @@ public class WhenJavaExtensionIsRegistered {
     public void a_block_processor_as_string_should_be_executed_when_registered_block_is_found_in_document()
             throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.block("yell", "org.asciidoctor.extension.YellStaticBlock");
+        this.asciidoctor.createGroup()
+            .block("yell", "org.asciidoctor.extension.YellStaticBlock")
+            .register();
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-yell-block.ad"),
                 options().toFile(false).get());
@@ -762,9 +771,9 @@ public class WhenJavaExtensionIsRegistered {
     @Test
     public void a_block_processor_should_be_executed_when_registered_block_is_found_in_document() throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.block("yell", YellStaticBlock.class);
+        this.asciidoctor.createGroup()
+            .block("yell", YellStaticBlock.class)
+            .register();
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-yell-block.ad"),
                 options().toFile(false).get());
@@ -774,37 +783,19 @@ public class WhenJavaExtensionIsRegistered {
         assertThat(elements.size(), is(1));
         assertThat(elements.get(0).text(), is("THE TIME IS NOW. GET A MOVE ON."));
 
-    }
-
-    @Test
-    public void a_block_processor_class_should_be_executed_twice() throws IOException {
-
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.block("yell", YellStaticBlock.class);
-        for (int i = 0; i < 2; i++) {
-            String content = asciidoctor.renderFile(
-                classpath.getResource("sample-with-yell-block.ad"),
-                options().toFile(false).get());
-
-            org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
-            Elements elements = doc.getElementsByClass("paragraph");
-            assertThat(elements.size(), is(1));
-            assertThat(elements.get(0).text(), is("THE TIME IS NOW. GET A MOVE ON."));
-        }
     }
 
     @Test
     public void a_block_processor_instance_should_be_executed_when_registered_block_is_found_in_document()
             throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
         Map<String, Object> config = new HashMap<String, Object>();
         config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_PARAGRAPH));
         config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
-        javaExtensionRegistry.block(yellBlock);
+        this.asciidoctor.createGroup()
+            .block(yellBlock)
+            .register();
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-yell-block.ad"),
                 options().toFile(false).get());
@@ -816,34 +807,11 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_block_processor_instance_should_be_executed_twice()
-            throws IOException {
-
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        Map<String, Object> config = new HashMap<String, Object>();
-        config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_PARAGRAPH));
-        config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
-        YellBlock yellBlock = new YellBlock("yell", config);
-        javaExtensionRegistry.block(yellBlock);
-
-        for (int i = 0; i < 2; i++){
-            String content = asciidoctor.renderFile(
-                classpath.getResource("sample-with-yell-block.ad"),
-                options().toFile(false).get());
-            org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
-            Elements elements = doc.getElementsByClass("paragraph");
-            assertThat(elements.size(), is(1));
-            assertThat(elements.get(0).text(), is("THE TIME IS NOW. GET A MOVE ON."));
-        }
-    }
-
-    @Test
     public void a_block_processor_should_be_executed_when_registered_listing_block_is_found_in_document() throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
-        javaExtensionRegistry.block("yell", YellStaticListingBlock.class);
+        this.asciidoctor.createGroup()
+            .block("yell", YellStaticListingBlock.class)
+            .register();
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-yell-listing-block.ad"),
                 options().toFile(false).get());
@@ -859,13 +827,13 @@ public class WhenJavaExtensionIsRegistered {
     public void a_block_processor_instance_should_be_executed_when_registered_listing_block_is_found_in_document()
             throws IOException {
 
-        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
-
         Map<String, Object> config = new HashMap<String, Object>();
         config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_LISTING));
         config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
-        javaExtensionRegistry.block(yellBlock);
+        this.asciidoctor.createGroup()
+            .block(yellBlock)
+            .register();
         String content = asciidoctor.renderFile(
                 classpath.getResource("sample-with-yell-listing-block.ad"),
                 options().toFile(false).get());
@@ -878,19 +846,21 @@ public class WhenJavaExtensionIsRegistered {
 
     @Test
     public void should_create_toc_with_treeprocessor() throws Exception {
-        asciidoctor.javaExtensionRegistry().treeprocessor(new Treeprocessor() {
-            @Override
-            public org.asciidoctor.ast.Document process(org.asciidoctor.ast.Document document) {
-                List<StructuralNode> blocks=document.getBlocks();
-                for (StructuralNode block : blocks) {
-                    for (StructuralNode block2 : block.getBlocks()) {
-                        if(block2 instanceof Section)
-                            System.out.println(((Section) block2).id());
+        this.asciidoctor.createGroup()
+            .treeprocessor(new Treeprocessor() {
+                @Override
+                public Document process(Document document) {
+                    List<StructuralNode> blocks=document.getBlocks();
+                    for (StructuralNode block : blocks) {
+                        for (StructuralNode block2 : block.getBlocks()) {
+                            if(block2 instanceof Section)
+                                System.out.println(((Section) block2).id());
+                        }
                     }
+                    return document;
                 }
-                return document;
-            }
-        });
+            })
+            .register();
 
         String content = asciidoctor.renderFile(
                 classpath.getResource("documentwithtoc.adoc"),

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionGroupIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionGroupIsRegistered.java
@@ -1,0 +1,88 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.asciidoctor.OptionsBuilder.options;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Arquillian.class)
+public class WhenRubyExtensionGroupIsRegistered {
+
+    @ArquillianResource
+    private ClasspathResources classpath;
+
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
+
+    @Test
+    public void ruby_extension_should_be_registered() {
+        
+        this.asciidoctor.createGroup()
+            .loadRubyClass(Class.class.getResourceAsStream("/YellRubyBlock.rb")).rubyBlock("rubyyell", "YellRubyBlock")
+            .register();
+
+        String content = asciidoctor.renderFile(
+                classpath.getResource("sample-with-ruby-yell-block.ad"),
+                options().toFile(false).get());
+
+        Document doc = Jsoup.parse(content, "UTF-8");
+        Elements elements = doc.getElementsByClass("paragraph");
+        assertThat(elements.size(), is(2));
+        assertThat(elements.get(1).text(), is("THE TIME IS NOW! GET A MOVE ON!"));
+        
+    }
+
+    @Test
+    public void ruby_extension_should_be_unregistered() {
+
+        ExtensionGroup extensionGroup = this.asciidoctor.createGroup()
+            .loadRubyClass(Class.class.getResourceAsStream("/YellRubyBlock.rb"))
+            .rubyBlock("rubyyell", "YellRubyBlock");
+
+        {
+            String contentWithoutBlock = asciidoctor.renderFile(
+                classpath.getResource("sample-with-ruby-yell-block.ad"),
+                options().toFile(false).get());
+
+            Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
+            Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
+            assertThat(elementsWithoutBlock.size(), is(2));
+            assertThat(elementsWithoutBlock.get(1).text(), not(is("THE TIME IS NOW! GET A MOVE ON!")));
+        }
+        {
+            extensionGroup.register();
+            String content = asciidoctor.renderFile(
+                classpath.getResource("sample-with-ruby-yell-block.ad"),
+                options().toFile(false).get());
+
+            Document doc = Jsoup.parse(content, "UTF-8");
+            Elements elements = doc.getElementsByClass("paragraph");
+            assertThat(elements.size(), is(2));
+            assertThat(elements.get(1).text(), is("THE TIME IS NOW! GET A MOVE ON!"));
+        }
+        {
+            extensionGroup.unregister();
+
+            String contentWithoutBlock = asciidoctor.renderFile(
+                classpath.getResource("sample-with-ruby-yell-block.ad"),
+                options().toFile(false).get());
+
+            Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
+            Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
+            assertThat(elementsWithoutBlock.size(), is(2));
+            assertThat(elementsWithoutBlock.get(1).text(), not(is("THE TIME IS NOW! GET A MOVE ON!")));
+        }
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
@@ -1,9 +1,5 @@
 package org.asciidoctor.extension;
 
-import static org.asciidoctor.OptionsBuilder.options;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
@@ -14,6 +10,11 @@ import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.asciidoctor.OptionsBuilder.options;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class WhenRubyExtensionIsRegistered {
@@ -40,5 +41,4 @@ public class WhenRubyExtensionIsRegistered {
         assertThat(elements.get(1).text(), is("THE TIME IS NOW! GET A MOVE ON!"));
         
     }
-
 }


### PR DESCRIPTION
This PR brings the ExtensionGroup API to the 1.6.0 branch.

It seems that I got it wrong on the current master by assuming that I can do multiple executions of `Asciidoctor::Extensions.register` with the same groupName.
If I didn't get it wrong it overwrites a previous registration.
Therefore I hopefully fixed it here by collecting all extensions in list or maps per type and the registering them in one go in the Ruby code (asciidoctorclass.rb).

There was also an error with multiple executions of extensions that were registered as instances.
For these it was tried to call `setConfig` twice which was rejected with an IllegalStateException. I fixed this by adding a method `updateConfig` that can be executed multiple times and add to the existing config.
In such a case it is probably not clever to use the same Asciidoctor instance concurrently to render documents.

I copied many of the existing extension tests and migrated them to the group API to get a better coverage.