### PR TITLE
fixes #575 - forces TravisCI to use precise image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Just sets the `precise` as image.
Still uses JDK available for that image, note that oraclejdk7 is not compatible with new `trusty` image.