### PR TITLE
reenable CI notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,3 @@ before_install:
   - sudo apt-get install -y graphviz
 install: ./gradlew -S -Pskip.signing assemble
 script: ./gradlew -S -Pskip.signing check && bash test-asciidoctor-upstream.sh
-notifications:
-  email: false
-  irc:
-    channels:
-      - "irc.freenode.org#asciidoctor"


### PR DESCRIPTION
At one time, the defaults for the notifications were annoying. Now they are reasonable and we depend on them being sent.

I reverted to the default, though I'm not sure if we need to set anything to get notifications in the gitter channel. Here's the template if we do need that:

```yml
notifications:
  webhooks:
    urls:
    - https://webhooks.gitter.im/e/3b53badb62267d16b33a
```