### PR TITLE
Add Chocolatey packaging.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.adoc		eol=lf

--- a/README.adoc
+++ b/README.adoc
@@ -33,6 +33,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-tilt: https://github.com/rtomayko/tilt
 :uri-font-awesome: http://fortawesome.github.io/Font-Awesome
 :uri-gradle: https://gradle.org
+:uri-chocolatey: https://chocolatey.org
 
 {uri-repo}[AsciidoctorJ] is the official library for running {uri-asciidoctor}[Asciidoctor] on the JVM.
 Using AsciidoctorJ, you can convert AsciiDoc content or analyze the structure of a parsed AsciiDoc document from Java and other JVM languages.
@@ -153,6 +154,20 @@ In addition to using AsciidoctorJ directly, you can invoke it as part of your bu
 - {uri-maven-guide}[How to Install and Use the Asciidoctor Maven Plugin]
 - {uri-gradle-guide}[How to Install and Use the Asciidoctor Gradle Plugin]
 ====
+
+=== Windows Installation
+
+A {uri-chocolatey}[Chocolatey] package is available which installs the
+ascidoctorj-{artifact-version}-bin.zip Bintray artifact along with a
+binary shim in %ChocolateyInstall%\bin which lets you run AsciidoctorJ
+from the command line.
+
+----
+C:\> choco install asciidoctorj
+C:\> where asciidoctorj
+C:\ProgramData\chocolatey\bin\asciidoctorj.exe
+C:\> asciidoctorj -b pdf README.adoc
+----
 
 == Converting documents
 
@@ -1063,7 +1078,7 @@ String content = asciidoctor.convertFile(new File(
 
 === DocinfoProcessor
 
-This extension inserts custom content on header or footer of the document. 
+This extension inserts custom content on header or footer of the document.
 For example can be used for adding `meta` tags on `<head>` tags.
 
 [source]
@@ -1717,8 +1732,8 @@ Follow the steps below:
     </dependencies>
 </module>
 ----
-. Copy the jar files into the same folder as the _module.xml_ file. 
-. Make sure the version numbers of the jar files agree with what's in the current set. 
+. Copy the jar files into the same folder as the _module.xml_ file.
+. Make sure the version numbers of the jar files agree with what's in the current set.
 Restart WildFly for the new module to take effect.
 
 . Add a dependency on your Java archive to this WildFly module using one of the following options:

--- a/chocolatey/README.adoc
+++ b/chocolatey/README.adoc
@@ -1,0 +1,32 @@
+= AsciidoctorJ Chocolatey package.
+
+This directory contains the necessary configuration files for
+creating a https://chocolatey.org/[Chocolatey] package based on a
+designated "asciidoctorj-x.y.z-bin.zip" bintray file.
+
+Complete instructions on creating Chocolatey packages can be found at
+https://chocolatey.org/docs/create-packages .
+
+== Quick Instructions
+
+. Set the desired package version in 'asciidoctorj.nuspec' and
+  'tools\chocolateyinstall.ps1'.
+
+. Run the following commands:
+
+----
+# Create the package
+> cd c:\to\this\directory
+> cpack
+
+# Test the package. You'll probably have to run this as administrator.
+> choco install .\asciidoctorj.x.y.z.nupkg -dv -s .
+> where asciidoctorj
+> asciidoctorj --help
+> asciidoctorj ...other test commands
+
+# Log into https://chocolatey.org/account and copy your API key.
+# (This assumes you don't have a key set in your Chocolatey config.)
+# Push the package to chocolatey.org.
+> choco push --api-key=you-api-key asciidoctorj.x.y.z.nupkg
+----

--- a/chocolatey/asciidoctorj.nuspec
+++ b/chocolatey/asciidoctorj.nuspec
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
+    <id>asciidoctorj</id>
+    <title>AsciidoctorJ (Install)</title>
+    <version>1.5.6</version>
+    <!--
+      https://github.com/asciidoctor/asciidoctorj/graphs/contributors
+      https://github.com/asciidoctor/asciidoctor/graphs/contributors
+    -->
+    <authors>Dan Allen, Alex Soto, Ryan Waldron, et al</authors>
+    <owners>Gerald Combs</owners>
+    <summary>Java wrapper for AsciiDoctor.</summary>
+    <description>Java wrapper and bindings for the Asciidoctor markup processor.
+    Converts AsciiDoc to HTML5, EPUB3, PDF, DocBook, and other formats. To use, run
+    "asciidoctorj" along with any Asciidoctor command line flags, e.g. "asciidoctorj
+    -b pdf mydocument.adoc".
+    </description>
+    <projectUrl>http://asciidoctor.org/</projectUrl>
+    <packageSourceUrl>https://github.com/geraldcombs/chocolatey-packages</packageSourceUrl>
+    <projectSourceUrl>https://github.com/asciidoctor/asciidoctorj</projectSourceUrl>
+    <docsUrl>http://asciidoctor.org/docs/user-manual/</docsUrl>
+    <mailingListUrl>http://discuss.asciidoctor.org/</mailingListUrl>
+    <bugTrackerUrl>https://github.com/asciidoctor/asciidoctorj/issues</bugTrackerUrl>
+    <tags>asciidoctor asciidoc docbook pdf</tags>
+    <copyright>2012-2017 Dan Allen, Ryan Waldron and the Asciidoctor Project</copyright>
+    <licenseUrl>https://raw.githubusercontent.com/asciidoctor/asciidoctorj/master/LICENSE.txt</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- https://github.com/asciidoctor/asciidoctor/issues/48
+    <iconUrl></iconUrl>
+    -->
+    <dependencies>
+      <dependency id="jre8" />
+    </dependencies>
+    <releaseNotes>Initial Chocolatey package</releaseNotes>
+    <!--<provides></provides>-->
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,32 @@
+﻿# IMPORTANT: Before releasing this package, copy/paste the next 2 lines into PowerShell to remove all comments from this file:
+#   $f='c:\path\to\thisFile.ps1'
+#   gc $f | ? {$_ -notmatch "^\s*#"} | % {$_ -replace '(^.*?)\s*?[^``]#.*','$1'} | Out-File $f+".~" -en utf8; mv -fo $f+".~" $f
+
+$ErrorActionPreference = 'Stop'; # stop on all errors
+
+$adocjVersion = '1.5.6'
+$packageName= 'asciidoctorj' # arbitrary name for the package, used in messages
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+# Which is the preferred mirror? There are many listed at
+# http://www.apache.org/dyn/closer.cgi/xmlgraphics/fop
+$url        = "https://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/$($adocjVersion)/asciidoctorj-$($adocjVersion)-bin.zip" # download url
+#$url64      = '' # 64bit URL here or remove - if installer is both, use $url
+#$fileLocation = Join-Path $toolsDir 'NAME_OF_EMBEDDED_INSTALLER_FILE'
+#$fileLocation = Join-Path $toolsDir 'SHARE_LOCATION_OF_INSTALLER_FILE'
+
+$packageArgs = @{
+  packageName   = $packageName
+  unzipLocation = $toolsDir
+  url           = $url
+  checksum      = 'f2ca8f525c8dea71acd0df6405cd143690b1db78'
+  checksumType  = 'sha1' #default is md5, can also be sha1
+  #checksum64    = ''
+  #checksumType64= 'md5' #default is checksumType
+}
+
+## Main helper functions - these have error handling tucked into them already
+## see https://github.com/chocolatey/choco/wiki/HelpersReference
+
+Install-ChocolateyZipPackage @packageArgs
+
+Install-BinFile -name 'asciidoctorj' -path "$toolsDir\asciidoctorj-$($adocjVersion)\bin\asciidoctorj.bat"

--- a/chocolatey/tools/chocolateyuninstall.ps1
+++ b/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,0 +1,11 @@
+﻿# IMPORTANT: Before releasing this package, copy/paste the next 2 lines into PowerShell to remove all comments from this file:
+#   $f='c:\path\to\thisFile.ps1'
+#   gc $f | ? {$_ -notmatch "^\s*#"} | % {$_ -replace '(^.*?)\s*?[^``]#.*','$1'} | Out-File $f+".~" -en utf8; mv -fo $f+".~" $f
+
+Uninstall-BinFile -name 'asciidoctorj' -path "$toolsDir\asciidoctorj-$($adocjVersion)\bin\asciidoctorj.bat"
+
+## OTHER HELPERS
+## https://github.com/chocolatey/choco/wiki/HelpersReference
+#Uninstall-ChocolateyZipPackage
+#Uninstall-BinFile # Only needed if you added one in the installer script, choco will remove the ones it added automatically.
+#remove any shortcuts you added


### PR DESCRIPTION
A while back I created a [Chocolatey package for AsciidoctorJ](https://chocolatey.org/packages/asciidoctorj/), which makes getting Asciidoctor up and running on Windows much easier (for me at least). It installs the asciidoctorj-x.y.z-bin.zip bintray package as well as a wrapper for asciidoctorj.bat in %ChocolateyInstall%\bin

This PR contains the files I used to create the package.