### PR TITLE
Bump JRuby version for the distribution to 9.1.13.0

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   compile("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
     transitive = false
   }
-  compile 'org.jruby:jruby-complete:9.1.8.0'
+  compile 'org.jruby:jruby-complete:9.1.13.0'
 }
 
 jar.enabled = false


### PR DESCRIPTION
Manual tests on Windows showed that 9.1.13.0 seems to run fine.
Therefore upgrade the version in the distribution from 9.1.8.0 to 9.1.13.0.