### PR TITLE
Fix upstream build failing due to changes in behavior of creating dirs

### DIFF
--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -457,7 +457,9 @@ public class WhenAttributesAreUsedInAsciidoctor {
         Attributes attributes = attributes().stylesDir("./styles")
                 .linkCss(true).styleSheetName("mycustom.css").get();
         Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(testFolder.getRoot()).attributes(attributes).get();
+                .toDir(testFolder.getRoot())
+                .mkDirs(true)
+                .attributes(attributes).get();
 
         asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options);
 


### PR DESCRIPTION
The upstream build fails due after the changes to Asciidoctor wrt mkdir.
This PR fixes the test by explicitly setting the mkDirs option to true for that test.