### PR TITLE
Fixes #593. Handle nil result from node methods correctly

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/NodeConverter.java
@@ -126,15 +126,16 @@ public final class NodeConverter {
 
         if (object instanceof IRubyObject || object instanceof RubyObjectHolderProxy) {
             IRubyObject rubyObject = asRubyObject(object);
+            if (rubyObject.isNil()) {
+                return null;
+            }
             NodeCache nodeCache = NodeCache.get(rubyObject);
             ContentNode cachedNode = nodeCache.getASTNode();
             if (cachedNode != null) {
                 return cachedNode;
             }
 
-            Ruby runtime = rubyObject.getRuntime();
-
-            ContentNode ret = null;
+            ContentNode ret;
 
             switch (NodeType.getNodeType(rubyObject)) {
                 case BLOCK_CLASS:

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -1,13 +1,15 @@
 package org.asciidoctor;
 
-import static org.hamcrest.Matchers.either;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsMapContaining.hasKey;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertThat;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.Section;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.internal.IOUtils;
+import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -16,16 +18,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.asciidoctor.arquillian.api.Unshared;
-import org.asciidoctor.ast.StructuralNode;
-import org.asciidoctor.ast.Document;
-import org.asciidoctor.ast.Section;
-import org.asciidoctor.internal.IOUtils;
-import org.asciidoctor.util.ClasspathResources;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.collection.IsMapContaining.hasKey;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 @RunWith(Arquillian.class)
 public class WhenAsciiDocIsRenderedToDocument {
@@ -341,4 +341,15 @@ public class WhenAsciiDocIsRenderedToDocument {
         assertThat(section.getContentModel(), is("compound"));
         assertThat(section.getBlocks().get(0).getContentModel(), is("simple"));
     }
+
+    @Test
+    public void should_be_able_to_get_parent_from_document() {
+        String s = "== A small Example\n" +
+            "\n" +
+            "Lorem ipsum dolor sit amet:\n";
+
+        Document document = asciidoctor.load(s, new HashMap<String, Object>());
+        assertNull(document.getParent());
+    }
+
 }


### PR DESCRIPTION
The reported bug was due to a node method returning nil.
The NodeConverter didn't properly distinguish this result and tried to convert it instead of simply returning null.