### PR TITLE
Try to install graphviz msi instead of graphviz.portable on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - echo %PATH%
   - java -version
   - gradlew.bat --version
-  - cinst graphviz.portable
+  - cinst graphviz
 build_script:
   - gradlew.bat -u -i assemble
 test_script:


### PR DESCRIPTION
The Graphviz binaries have moved to a new location, letting the installation of the chocolatey packages fail on Appveyor.
Let's check if the installation of the "normal" graphviz chocolatey package succeeds which already seems to use the new location: https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/automatic/graphviz/update.ps1