### PR TITLE
Fixes #604. Implement containsKey() and keySet().contains() consisten…

### DIFF
--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/internal/RubyAttributesMapDecoratorSpecification.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/internal/RubyAttributesMapDecoratorSpecification.groovy
@@ -1,0 +1,84 @@
+package org.asciidoctor.internal
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.ast.Block
+import org.asciidoctor.ast.Document
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+@RunWith(ArquillianSputnik)
+class RubyAttributesMapDecoratorSpecification extends Specification {
+
+    public static final String ATTR_ONE = '1'
+
+    public static final String ATTR_NAME_ROLE = 'role'
+    public static final String ATTR_NAME_ID = 'id'
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+
+    String attrValue = '''#idname.rolename'''
+
+    String documentWithPositionalAttribute = """
+[${attrValue}]
+Lorem ipsum dolor
+"""
+
+    def "should consistently show positional attributes as string keys"() {
+
+        when:
+        Document document = asciidoctor.load(documentWithPositionalAttribute, new HashMap<String, Object>())
+
+        Block block = (Block) document.getBlocks().get(0)
+        Map<String, Object> attributes = block.getAttributes()
+
+        then:
+        !attributes.containsKey(1L)
+        attributes.containsKey(ATTR_ONE)
+        attributes.keySet().contains(ATTR_ONE)
+        attributes.get(ATTR_ONE) == attrValue
+
+    }
+
+    def "should remove positional attributes by string keys"() {
+
+        given: 'a block with a positional attribute'
+        Document document = asciidoctor.load(documentWithPositionalAttribute, new HashMap<String, Object>())
+
+        Block block = (Block) document.getBlocks().get(0)
+
+        when: 'I remove the attribute with the name "1"'
+        Map<String, Object> attributes = block.getAttributes()
+        def oldValue = attributes.remove(ATTR_ONE)
+
+        then: 'The key with the positional attribute is gone'
+        !attributes.containsKey(ATTR_ONE)
+
+        and: 'remove returned the previous attribute value'
+        oldValue == attrValue
+
+        and: 'The attributes derived from the positional attribute are still there'
+        attributes.containsKey(ATTR_NAME_ROLE)
+        attributes.containsKey(ATTR_NAME_ID)
+    }
+
+    def "should return previous value on put"() {
+        given: 'a block with a positional attribute'
+        Document document = asciidoctor.load(documentWithPositionalAttribute, new HashMap<String, Object>())
+
+        Block block = (Block) document.getBlocks().get(0)
+
+        when: 'I put another value for the positional attribute 1'
+        def attributes = block.getAttributes()
+        def newValue = 42
+        def previousValue = attributes.put(ATTR_ONE, newValue)
+
+        then: 'put returned the previous value'
+        previousValue == attrValue
+
+        and: 'the block has the new attribute value'
+        attributes.get(ATTR_ONE) == newValue
+    }
+}


### PR DESCRIPTION
…tly for the attributes maps.

Positional attributes are represented by numbers (or Java Longs) in the `Map<String, Object>` attributes map.
This PR tries to ensure that these keys make these keys correctly appear as strings.

Java client code should never use attribute names that are string representations of numbers! That would collide with the behavior of this map implementation.

Note that the methods `keySet()`, `entrySet()` and `values()` don't follow the contract defined in `java.util.Map`, the results of these methods are not backed by the corresponding map so that changes are not reflected.
Does anybody think that it would make sense to invest time in this?