### PR TITLE
Fixes #616. Fix handling of showTitle attribute

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Attributes.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Attributes.java
@@ -41,6 +41,7 @@ public class Attributes {
     public static final String LINK_ATTRS = "linkattrs";
     public static final String EXPERIMENTAL = "experimental";
     public static final String SHOW_TITLE = "showtitle";
+    public static final String NOTITLE = "notitle";
     public static final String ALLOW_URI_READ = "allow-uri-read";
     public static final String TOC_POSITION = "toc-position";
     public static final String TOC_2 = "toc2";
@@ -332,7 +333,13 @@ public class Attributes {
      *            value.
      */
     public void setShowTitle(boolean showTitle) {
-        this.attributes.put(SHOW_TITLE, showTitle);
+        if (showTitle) {
+            this.attributes.put(SHOW_TITLE, true);
+            this.attributes.remove(NOTITLE);
+        } else {
+            this.attributes.put(NOTITLE, true);
+            this.attributes.remove(SHOW_TITLE);
+        }
     }
 
     /**

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.xmlmatchers.xpath.HasXPath.hasXPath;
 
@@ -181,6 +182,103 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
     }
     
+    @Test
+    public void show_title_true_attribute_should_show_title_on_embedded_document() {
+        final Options options = options()
+            .attributes(attributes().showTitle(true).get())
+            .toFile(false)
+            .headerFooter(false)
+            .get();
+
+        final Document doc = Jsoup.parse(asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options));
+
+        assertEquals(1, doc.getElementsByTag("h1").size());
+        assertEquals("Document Title", doc.getElementsByTag("h1").get(0).text());
+    }
+
+    @Test
+    public void show_title_false_then_true_attribute_should_show_title_on_embedded_document() {
+        final Options options = options()
+            .attributes(attributes().showTitle(false).showTitle(true).get())
+            .toFile(false)
+            .headerFooter(false)
+            .get();
+
+        final Document doc = Jsoup.parse(asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options));
+
+        assertEquals(1, doc.getElementsByTag("h1").size());
+        assertEquals("Document Title", doc.getElementsByTag("h1").get(0).text());
+    }
+
+    @Test
+    public void show_title_false_attribute_should_hide_title_on_embedded_document() {
+        final Options options = options()
+            .attributes(attributes().showTitle(false).get())
+            .toFile(false)
+            .headerFooter(false)
+            .get();
+
+        final Document doc = Jsoup.parse(asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options));
+
+        assertEquals(0, doc.getElementsByTag("h1").size());
+    }
+
+    @Test
+    public void show_title_true_then_false_attribute_should_hide_title_on_embedded_document() {
+        final Options options = options()
+            .attributes(attributes().showTitle(true).showTitle(false).get())
+            .toFile(false)
+            .headerFooter(false)
+            .get();
+
+        final Document doc = Jsoup.parse(asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options));
+
+        assertEquals(0, doc.getElementsByTag("h1").size());
+    }
+
+    @Test
+    public void show_title_true_attribute_should_show_title_on_standalone_document() {
+
+        final Options options = options()
+            .attributes(attributes().showTitle(true).get())
+            .toFile(false)
+            .headerFooter(true)
+            .get();
+
+        final Document doc = Jsoup.parse(asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options));
+
+        assertEquals(1, doc.getElementsByTag("h1").size());
+        assertEquals("Document Title", doc.getElementsByTag("h1").get(0).text());
+    }
+
+    @Test
+    public void show_title_false_attribute_should_hide_title_on_standalone_document() {
+
+        final Options options = options()
+            .attributes(attributes().showTitle(false).get())
+            .toFile(false)
+            .headerFooter(true)
+            .get();
+
+        final Document doc = Jsoup.parse(asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options));
+
+        assertEquals(0, doc.getElementsByTag("h1").size());
+    }
+
+    @Test
+    public void show_title_true_then_false_attribute_should_hide_title_on_standalone_document() {
+
+        final Options options = options()
+            .attributes(attributes().showTitle(false).get())
+            .toFile(false)
+            .headerFooter(true)
+            .get();
+
+        final Document doc = Jsoup.parse(asciidoctor.renderFile(classpath.getResource("rendersample.asciidoc"), options));
+
+        assertEquals(0, doc.getElementsByTag("h1").size());
+    }
+
     @Test
     public void source_highlighter_attribute_should_add_required_javascript_libraries_as_highlighter() throws IOException {
         


### PR DESCRIPTION
Fixes #616 on master.
The handling of the showTitle attribute wasn't correct.
When showTitle is true, the `showtitle` attribute has to be set to any value.
When showTitle is false, the `notitle` attribute has to be set to any value. 
If this is ok I will propose another PR on asciidoctorj-1.6.0.