### PR TITLE
#523 Add explicit test for updating table cell source

### DIFF
--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/TableUpdaterTreeProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/TableUpdaterTreeProcessor.groovy
@@ -1,0 +1,32 @@
+package org.asciidoctor.extension
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.ast.Cell
+import org.asciidoctor.ast.Document
+import org.asciidoctor.ast.StructuralNode
+import org.asciidoctor.ast.Table
+
+@CompileStatic
+class TableUpdaterTreeProcessor extends Treeprocessor {
+
+    @Override
+    Document process(Document document) {
+        processNode(document)
+        document
+    }
+
+    static void processNode(StructuralNode node) {
+        if (node instanceof Table) {
+            processTable(node)
+        } else {
+            node.blocks.each { processNode it }
+        }
+    }
+
+    static void processTable(Table table) {
+        def cells = table.body.collectMany { it.cells } as List<Cell>
+        cells.each { cell ->
+            cell.source = '*Replaced*'
+        }
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorWorksOnTables.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorWorksOnTables.groovy
@@ -59,4 +59,26 @@ class WhenATreeProcessorWorksOnTables extends Specification {
 
     }
 
+    def 'then it should be able to update the text of a cell'() {
+
+        given: 'an document with a table and a tree processor that updates tables'
+        asciidoctor.javaExtensionRegistry().treeprocessor(TableUpdaterTreeProcessor)
+
+        when: 'the document is rendered'
+        String content = asciidoctor.convert('''=== Test
+
+|===
+| Hello | World
+| World | Hello 
+|===
+
+''', OptionsBuilder.options().headerFooter(false))
+
+        def htmlDocument = Jsoup.parse(content)
+
+        then:
+        def replacedElements = htmlDocument.select('td p strong')
+        replacedElements.size() == 4
+        replacedElements.every { it.text() == 'Replaced' }
+    }
 }


### PR DESCRIPTION
This PR adds an explicit test that updating a table cell from a Treeprocessor works.
See questions to #523 