### PR TITLE
Fix start error for asciidoctorj tool on OpenJDK 10

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -39,7 +39,7 @@ startScripts {
   mainClassName = 'org.asciidoctor.cli.AsciidoctorInvoker'
   defaultJvmOpts = [
     '-client', '-Xmn128m', '-Xms256m', '-Xmx256m',
-    '-Xverify:none', '-XX:+UseFastAccessorMethods', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC',
+    '-Xverify:none', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC',
     '-Djruby.compile.mode=OFF', '-Djruby.compat.version=RUBY2_0'
   ]
   classpath = configurations.getByName('compile').asFileTree


### PR DESCRIPTION
As reported by Russel Winder on Twitter the AsciidoctorJ tool crashes right after the start on OpenJDK 10 due to the JVM option `-XX:+UseFastAccessorMethods`.
This PR simply removes this flag.
While it might make AsciidoctorJ a bit slower when started from the command line, it's still better than not starting at all.
And it shouldn't hurt, because this flag isn't set anyway when running for example as part of the Maven plugin.