### PR TITLE
Upgrade asciidoctor-diagram to 1.5.9

### DIFF
--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=1.5.4.1
+version=1.5.9
 gem_name=asciidoctor-diagram


### PR DESCRIPTION
Simply upgrades asciidoctor-diagram to the latest version 1.5.9