### PR TITLE
Remove Java VM options from the distribution start script that are no…

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -4,7 +4,6 @@ dependencies {
   compile project(':asciidoctorj')
   compile project(':asciidoctorj-epub3')
   compile project(':asciidoctorj-diagram')
-  compile "org.jruby:jruby-complete:9.1.13.0"
 
   compile("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
     transitive = false
@@ -36,7 +35,7 @@ startScripts {
   mainClassName = 'org.asciidoctor.cli.AsciidoctorInvoker'
   defaultJvmOpts = [
     '-client', '-Xmn128m', '-Xms256m', '-Xmx256m',
-    '-Xverify:none', '-XX:+UseFastAccessorMethods', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC'
+    '-Xverify:none', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC', '-Djruby.compile.mode=OFF'
   ]
 }
 

--- a/asciidoctorj-distribution/src/test/groovy/org/asciidoctor/diagram/WhenAPdfDocumentIsRenderedToStream.groovy
+++ b/asciidoctorj-distribution/src/test/groovy/org/asciidoctor/diagram/WhenAPdfDocumentIsRenderedToStream.groovy
@@ -74,6 +74,7 @@ c
         def attrs = AttributesBuilder.attributes()
                 .attribute('docdatetime', dateTimeFormatter.format(now))
                 .attribute('localdatetime', dateTimeFormatter.format(now))
+                .attribute('reproducible', 'true')
 
         when:
         asciidoctor.convert(testDoc,


### PR DESCRIPTION
…t support on OpenJDK10

This PR adds the fix for OpenJDK10 that was still missing.

Also removed the extra dependency on JRuby from the distribution as JRuby 9.2.0.0 is already in the lib path.