### PR TITLE
Chocolatey: Update to AsciidoctorJ 1.5.7.

### DIFF
--- a/chocolatey/README.adoc
+++ b/chocolatey/README.adoc
@@ -5,7 +5,7 @@ creating a https://chocolatey.org/[Chocolatey] package based on a
 designated "asciidoctorj-x.y.z-bin.zip" bintray file.
 
 Complete instructions on creating Chocolatey packages can be found at
-https://chocolatey.org/docs/create-packages .
+https://chocolatey.org/docs/create-packages.
 
 == Quick Instructions
 
@@ -28,5 +28,5 @@ https://chocolatey.org/docs/create-packages .
 # Log into https://chocolatey.org/account and copy your API key.
 # (This assumes you don't have a key set in your Chocolatey config.)
 # Push the package to chocolatey.org.
-> choco push --api-key=you-api-key asciidoctorj.x.y.z.nupkg
+> choco push --api-key=your-api-key asciidoctorj.x.y.z.nupkg
 ----

--- a/chocolatey/asciidoctorj.nuspec
+++ b/chocolatey/asciidoctorj.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>asciidoctorj</id>
     <title>AsciidoctorJ (Install)</title>
-    <version>1.5.6</version>
+    <version>1.5.7</version>
     <!--
       https://github.com/asciidoctor/asciidoctorj/graphs/contributors
       https://github.com/asciidoctor/asciidoctor/graphs/contributors
@@ -24,17 +24,18 @@
     <docsUrl>http://asciidoctor.org/docs/user-manual/</docsUrl>
     <mailingListUrl>http://discuss.asciidoctor.org/</mailingListUrl>
     <bugTrackerUrl>https://github.com/asciidoctor/asciidoctorj/issues</bugTrackerUrl>
-    <tags>asciidoctor asciidoc docbook pdf</tags>
+    <tags>asciidoctor asciidoc docbook markup pdf cli</tags>
     <copyright>2012-2017 Dan Allen, Ryan Waldron and the Asciidoctor Project</copyright>
     <licenseUrl>https://raw.githubusercontent.com/asciidoctor/asciidoctorj/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!-- https://github.com/asciidoctor/asciidoctor/issues/48
-    <iconUrl></iconUrl>
-    -->
+    <!-- https://github.com/asciidoctor/asciidoctor/issues/48 -->
+    <!-- Chocolatey wants a 128 x 128 px .png. Do we have one? -->
+    <!-- https://github.com/chocolatey/choco/wiki/CreatePackages#package-icon-guidelines -->
+    <iconUrl>https://cdn.rawgit.com/asciidoctor/brand/master/logo/logo-color.svg</iconUrl>
     <dependencies>
       <dependency id="jre8" />
     </dependencies>
-    <releaseNotes>Initial Chocolatey package</releaseNotes>
+    <releaseNotes>Update to Asciidoctor 1.5.7</releaseNotes>
     <!--<provides></provides>-->
   </metadata>
   <files>

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -4,24 +4,18 @@
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
 
-$adocjVersion = '1.5.6'
+$adocjVersion = '1.5.7'
 $packageName= 'asciidoctorj' # arbitrary name for the package, used in messages
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-# Which is the preferred mirror? There are many listed at
-# http://www.apache.org/dyn/closer.cgi/xmlgraphics/fop
 $url        = "https://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/$($adocjVersion)/asciidoctorj-$($adocjVersion)-bin.zip" # download url
-#$url64      = '' # 64bit URL here or remove - if installer is both, use $url
-#$fileLocation = Join-Path $toolsDir 'NAME_OF_EMBEDDED_INSTALLER_FILE'
-#$fileLocation = Join-Path $toolsDir 'SHARE_LOCATION_OF_INSTALLER_FILE'
 
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   url           = $url
-  checksum      = 'f2ca8f525c8dea71acd0df6405cd143690b1db78'
-  checksumType  = 'sha1' #default is md5, can also be sha1
-  #checksum64    = ''
-  #checksumType64= 'md5' #default is checksumType
+  # curl -I https://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/1.5.7/asciidoctorj-1.5.7-bin.zip
+  checksum      = 'b0295bb73589f389a6b62563e2fd018b0aa6095feacb5acfa7f534b1265e67d1'
+  checksumType  = 'sha256'
 }
 
 ## Main helper functions - these have error handling tucked into them already


### PR DESCRIPTION
Use a stronger hash and add an iconUrl while we're here.