### PR TITLE
Adds LogHandler documentation to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1501,6 +1501,105 @@ org.asciidoctor.extension.ArrowsAndBoxesExtension
 And that's all.
 Now when a `.jar` file containing the previous structure is dropped inside classpath of AsciidoctorJ, the `register` method will be executed automatically and the extensions will be registered.
 
+== Logs handling API
+
+[NOTE]
+====
+This API is inspired by Java Logging API (JUL).
+If you are familiar with `java.util.logging.*` you will see familiar analogies with some of its components.
+====
+
+AciidoctorJ (v1.5.7+) offers the possibility to capture messages generated during document rendering.
+These messages correspond to logging information and are organized in 6 severity levels:
+
+. DEBUG
+. INFO
+. WARN
+. ERROR
+. FATAL
+. UNKNOWN
+
+The easiest way to capture messages is registering a `LogHandler` through the `Asciidoctor` instance.
+
+[source,java]
+.Registering a LogHandler
+----
+Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+asciidoctor.registerLogHandler(new LogHandler() { // <1>
+    @Override
+    public void log(LogRecord logRecord) {
+        System.out.println(logRecord.getMessage());
+    }
+});
+----
+<1> Use `registerLogHandler` to register one or more handlers.
+
+The `log` method in the `org.asciidoctor.log.LogHandler` interface provides a `org.asciidoctor.log.LogRecord` that exposes the following information:
+
+[horizontal]
+Severity severity::
+Severity level of the current record.
+
+Cursor cursor::
+Information about the location of the event, contains:
+* LineNumber: relative to the file where the message occurred.
+* Path: source file simple name, or `<stdin>` value when rending from a String.
+* Dir: absolute path to the source file parent directory, or the execution path when rending from a String.
+* File: absolute path to the source file, or `null` when rending from a String. +
+These will point to the correct source file, even when this is included from another.
+
+String message::
+Descriptive message about the event.
+
+String sourceFileName::
+Contains the value `<script>`. +
+For the source filename see `Cursor` above.
+
+String sourceMethodName::
+The Asciidoctor Ruby engine method used to render the file; `convertFile` or `convert` whether you are rending a File or a String.
+
+=== Logs Handling SPI
+
+Similarly to AsciidoctorJ extensions, the Log Handling API provides an alternate method to register Handlers without accessing `Asciidoctor` instance.
+
+Start creating a normal LogHandler implementation.
+
+[source,Java]
+----
+package my.asciidoctor.log.MemoryLogHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.asciidoctor.log.LogHandler;
+import org.asciidoctor.log.LogRecord;
+
+/**
+ * Stores LogRecords in memory for later analysis.
+ */
+public class MemoryLogHandler extends LogHandler {
+
+  private List<LogRecord> logRecords = new ArrayList<>();
+
+  @Override
+  public void log(LogRecord logRecord) {
+    logRecords.add(record);
+  }
+
+  public List<LogRecord> getLogRecords() {
+    return logRecords;
+  }
+}
+----
+
+Next, create a file called `org.asciidoctor.log.LogHandler` inside `META-INF/services` with the implementation’s full qualified name.
+
+.META-INF/services/org.asciidoctor.log.LogHandler
+ my.asciidoctor.log.MemoryLogHandler
+
+And that’s all.
+Now when a .jar file containing the previous structure is dropped inside classpath of AsciidoctorJ, the handler will be registered automatically.
+
 == Converting to EPUB3
 
 The Asciidoctor EPUB3 gem (asciidoctor-epub3) is bundled inside the AsciidoctorJ EPUB3 jar (asciidoctorj-epub3).


### PR DESCRIPTION
This PR adds a small documentation to explain how to register custom LogHandlers.

**This is WIP and before merge** I'd like to understand a couple of things I found in my tests in order to document them properly.

* paths in the `Cursor` are absolute always, I tried with relative Files and Strings. Is that expected?
* Some names are confusing to me: check the docs for the use of cursor.path, cursor.file and sourceFilename. Specially the latests. Is that also normal? If `sourceFilename` is always <script>, does it make sense to expose it?

