### PR TITLE
Remove setting verbose mode to prevent logging of JRuby warnings

### DIFF
--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -1,5 +1,5 @@
 # Set the global variable VERBOSE to true to get invalid refs into the log
-$VERBOSE=true
+#$VERBOSE=true
 
 module AsciidoctorJ
     include_package 'org.asciidoctor'

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/QandATest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/QandATest.java
@@ -1,0 +1,46 @@
+package org.asciidoctor;
+
+//import org.asciidoctor.ast.DescriptionList;
+import org.asciidoctor.ast.Document;
+//import org.asciidoctor.ast.StructuralNode;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+public class QandATest {
+/*
+    private static final String DOC = "== Test\n" +
+        "\n" +
+        ".Q & A block\n"+
+        "[qanda]\n"+
+        "What is Asciidoctor?::\n"+
+        "  An implementation of the AsciiDoc processor in Ruby.\n"+
+        "\n"+
+        "What is the answer to the Ultimate Question?:: 42";
+
+    @Test
+    public void shouldParseTitle() {
+        final Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        final Document doc = asciidoctor.load(DOC, OptionsBuilder.options().asMap());
+        final DescriptionList dl = findDescriptionList(doc);
+        assertThat(dl.getTitle(), is("Q &amp; A block"));
+        assertThat(dl.getStyle(), is("qanda"));
+    }
+
+    private DescriptionList findDescriptionList(StructuralNode node) {
+        if (node instanceof DescriptionList) {
+            return (DescriptionList) node;
+        } else {
+            for (StructuralNode structuralNode : node.getBlocks()) {
+                DescriptionList dl = findDescriptionList(structuralNode);
+                if (dl != null) {
+                    return dl;
+                }
+            }
+            return null;
+        }
+    }
+    */
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -8,6 +8,7 @@ import org.asciidoctor.log.TestLogHandlerService;
 import org.asciidoctor.util.ClasspathResources;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -121,6 +122,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
+    @Ignore("Until invalid refs are logged by default")
     public void shouldLogInvalidRefs() throws Exception {
 
         final List<LogRecord> logRecords = new ArrayList<>();


### PR DESCRIPTION
As discussed in #667 this PR removes setting the global variable `$VERBOSE` to true again.
This avoids the warnings produced by JRuby when loading the prawn and ttfunk gems:
```
uri:classloader:/gems/prawn-svg-0.27.1/lib/prawn/svg/color.rb:212: warning: shadowing outer local variable - result
uri:classloader:/gems/prawn-svg-0.27.1/lib/prawn/svg/properties.rb:50: warning: `*' interpreted as argument prefix
Aug 18, 2018 7:14:58 PM <script> convertFile
WARNUNG: invalid reference: foo
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/prawn-2.2.2/lib/prawn/font/ttf.rb:118: warning: instance variable @italic_angle not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/prawn-2.2.2/lib/prawn/font/ttf.rb:118: warning: instance variable @italic_angle not initialized
```

At the same time it also removes the warnings from Asciidoctor about invalid references because it is coupled to the same global variable.
To enable logging of invalid refs à la
```
Aug 18, 2018 7:14:58 PM <script> convertFile
WARNUNG: invalid reference: foo
```
again the user can simply require a file that sets this variable.
That means the user can create a file `verbose.rb` with this content:
```ruby
$VERBOSE=true
```
and then invoke asciidoctorj like this:
```
$ asciidoctorj --load-path <path to verbose.rb> -r verbose.rb file.adoc
```

For the asciidoctor-maven-plugin I am unsure atm about the best way to do this.
But it should work to package `verbose.rb` in an own jar and to add a dependency to this jar to the plugin configuration of the asciidoctor-maven-plugin and require verbose.rb.

I'll create a similar PR for the 1.6.0 branch.