### PR TITLE
Remove setting  again to avoid JRuby warnings

### DIFF
--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -1,6 +1,3 @@
-# Set the global variable VERBOSE to true to get invalid refs into the log
-$VERBOSE=true
-
 module AsciidoctorJ
     include_package 'org.asciidoctor'
     module Extensions

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -48,6 +49,7 @@ public class WhenAsciidoctorLogsToConsole {
     @Before
     public void before() {
         asciidoctor = JRubyAsciidoctor.create();
+        TestLogHandlerService.clear();
     }
 
     @After
@@ -127,6 +129,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
+    @Ignore("Until logging of invalid refs is enabled by default")
     public void shouldLogInvalidRefs() throws Exception {
 
         final List<LogRecord> logRecords = new ArrayList<>();

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Arquillian.class)
 public class WhenJavaExtensionGroupIsRegistered {
 
-    public static final String ASCIIDOCTORCLASS_PREFIX = "# Set the global variable VERBOSE to true to get invalid refs into the log";
+    public static final String ASCIIDOCTORCLASS_PREFIX = "module AsciidoctorJ    include_package 'org.asciidoctor'";
 
     @ArquillianResource
     private ClasspathResources classpath;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Arquillian.class)
 public class WhenJavaExtensionIsRegistered {
 
-    public static final String ASCIIDOCTORCLASS_PREFIX = "# Set the global variable VERBOSE to true to get invalid refs into the log";
+    public static final String ASCIIDOCTORCLASS_PREFIX = "module AsciidoctorJ    include_package 'org.asciidoctor'";
 
     @ArquillianResource
     private ClasspathResources classpath;


### PR DESCRIPTION
Same as #676 for the 1.6.0 branch:

As discussed in #667 this PR removes setting the global variable `$VERBOSE` to true again.
This avoids the warnings produced by JRuby when loading the prawn and ttfunk gems:
```
uri:classloader:/gems/prawn-svg-0.27.1/lib/prawn/svg/color.rb:212: warning: shadowing outer local variable - result
uri:classloader:/gems/prawn-svg-0.27.1/lib/prawn/svg/properties.rb:50: warning: `*' interpreted as argument prefix
Aug 18, 2018 7:14:58 PM <script> convertFile
WARNUNG: invalid reference: foo
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/prawn-2.2.2/lib/prawn/font/ttf.rb:118: warning: instance variable @italic_angle not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:26: warning: instance variable @offset not initialized
uri:classloader:/gems/prawn-2.2.2/lib/prawn/font/ttf.rb:118: warning: instance variable @italic_angle not initialized
```

At the same time it also removes the warnings from Asciidoctor about invalid references because it is coupled to the same global variable.
To enable logging of invalid refs à la
```
Aug 18, 2018 7:14:58 PM <script> convertFile
WARNUNG: invalid reference: foo
```
again the user can simply require a file that sets this variable.
That means the user can create a file `verbose.rb` with this content:
```ruby
$VERBOSE=true
```
and then invoke asciidoctorj like this:
```
$ asciidoctorj --load-path <path to verbose.rb> -r verbose.rb file.adoc
```

For the asciidoctor-maven-plugin I am unsure atm about the best way to do this.
But it should work to package `verbose.rb` in an own jar and to add a dependency to this jar to the plugin configuration of the asciidoctor-maven-plugin and require verbose.rb.
