### PR TITLE
Bump asciidoctor-diagram to 1.5.10

### DIFF
--- a/asciidoctorj-diagram/gradle.properties
+++ b/asciidoctorj-diagram/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Diagram
 description=AsciidoctorJ Diagram bundles the Asciidoctor Diagram RubyGem (asciidoctor-diagram) so it can be loaded into the JVM using JRuby.
-version=1.5.9
+version=1.5.10
 gem_name=asciidoctor-diagram


### PR DESCRIPTION
This PR bumps asciidoctor-diagram to 1.5.10.
If the CI build is green I'll try to create a release of this module next week.