### PR TITLE
Bump version of JRuby to 9.1.17.0 for 1.5.x

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   compile("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
     transitive = false
   }
-  compile 'org.jruby:jruby-complete:9.1.16.0'
+  compile 'org.jruby:jruby-complete:9.1.17.0'
 }
 
 jar.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '9.1.16.0'
+  jrubyVersion = '9.1.17.0'
   jsoupVersion = '1.8.3'
   junitVersion = '4.12'
   saxonVersion = '9.5.1-6'


### PR DESCRIPTION
#680 indicates that there's a problem with JRuby 9.1.16.0 that lets AsciidoctorJ fail when the same document is rendered 100's of times.
It looks like 9.1.17.0 fixed this.
Therefore this PR bumps the version of JRuby to 9.1.17.0 for the 1.5.x branch
The 1.6 branch is already on 9.2.0.0, which is incompatible with 1.5.x.