### PR TITLE
Fixes #686. Add sources of asciidoctorj-api to javadocs of asciidoctorj

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -38,6 +38,8 @@ jrubyPrepare {
 
 javadoc {
   classpath = sourceSets.main.output + sourceSets.main.compileClasspath + project(':asciidoctorj-test-support').sourceSets.test.output
+
+  source(project(':asciidoctorj-api').sourceSets.main.allJava)
 }
 
 //jruby {


### PR DESCRIPTION
This PR adds the sources of asciidoctorj-api to the sources for generating the javadocs of asciidoctorj.
With this the AST interfaces should be visible again in  http://www.javadoc.io/doc/org.asciidoctor/asciidoctorj/1.6.0-alpha.8 (once we release this version)

I guess if we manage to fully migrate everything "dev-facing" or "user-facing" into the API module, it would make more sense to only have the javadocs for this instead of the asciidoctorj module. But we're not there yet.