### PR TITLE
Disable automatic logging of invalid refs and enable it via verbose m…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
@@ -39,7 +39,11 @@ public class AsciidoctorInvoker {
                 System.out.println("Asciidoctor " + asciidoctor.asciidoctorVersion() + " [http://asciidoctor.org]");
                 return;
             }
-            
+
+            if (asciidoctorCliOptions.isVerbose()) {
+                JRubyRuntimeContext.get().evalScriptlet("$VERBOSE=true");
+            }
+
             List<File> inputFiles = getInputFiles(asciidoctorCliOptions);
 
             if (inputFiles.isEmpty()) {

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -1,6 +1,3 @@
-# Set the global variable VERBOSE to true to get invalid refs into the log
-#$VERBOSE=true
-
 module AsciidoctorJ
     include_package 'org.asciidoctor'
     module Extensions

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -9,10 +9,12 @@ import org.asciidoctor.log.TestLogHandlerService;
 import org.asciidoctor.util.ClasspathResources;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runners.MethodSorters;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,6 +33,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WhenAsciidoctorLogsToConsole {
 
     @Rule
@@ -123,7 +126,6 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    @Ignore("Until invalid refs are logged by default")
     public void shouldLogInvalidRefs() throws Exception {
 
         final List<LogRecord> logRecords = new ArrayList<>();
@@ -153,6 +155,32 @@ public class WhenAsciidoctorLogsToConsole {
         assertThat(logRecords.get(0).getMessage(), containsString("invalid reference: invalidref"));
         final Cursor cursor = logRecords.get(0).getCursor();
         assertThat(cursor, is(nullValue()));
+    }
+
+    @Test
+    public void shouldNotLogInvalidRefsWithoutVerbose() throws Exception {
+
+        final List<LogRecord> logRecords = new ArrayList<>();
+
+        final LogHandler logHandler = new LogHandler() {
+            @Override
+            public void log(LogRecord logRecord) {
+                logRecords.add(logRecord);
+            }
+        };
+        asciidoctor.registerLogHandler(logHandler);
+
+        File inputFile = classpath.getResource("documentwithinvalidrefs.adoc");
+        String renderContent = asciidoctor.renderFile(inputFile,
+            options()
+                .inPlace(true)
+                .safe(SafeMode.SERVER)
+                .toFile(false)
+                .attributes(
+                    AttributesBuilder.attributes().allowUriRead(true))
+                .asMap());
+
+        assertThat(logRecords, hasSize(0));
     }
 
     @Test

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -2,6 +2,7 @@ package org.asciidoctor;
 
 import org.asciidoctor.ast.Cursor;
 import org.asciidoctor.internal.JRubyAsciidoctor;
+import org.asciidoctor.internal.JRubyRuntimeContext;
 import org.asciidoctor.log.LogHandler;
 import org.asciidoctor.log.LogRecord;
 import org.asciidoctor.log.TestLogHandlerService;
@@ -135,6 +136,9 @@ public class WhenAsciidoctorLogsToConsole {
         };
         asciidoctor.registerLogHandler(logHandler);
 
+        // Asciidoctor currently only logs invalid refs if this global var is set
+        JRubyRuntimeContext.get().evalScriptlet("$VERBOSE=true");
+        
         File inputFile = classpath.getResource("documentwithinvalidrefs.adoc");
         String renderContent = asciidoctor.renderFile(inputFile,
             options()


### PR DESCRIPTION
…ode from CLI

This PR disables the automatic activation of the verbose mode again and thus disables logging of invalid refs.

The `-v` argument for the CLI additionally enables this again.
Therefore integrators have to run the Ruby script `$VERBOSE=true` themselves before rendering documents.

@mojavelinux Is this what you had in mind?