### PR TITLE
Add timings command option and fix timings

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
@@ -34,11 +34,14 @@ public class AsciidoctorCliOptions {
     public static final String BACKEND = "-b";
     public static final String VERSION = "-V";
     public static final String VERBOSE = "-v";
+    public static final String TIMINGS = "-t";
     public static final char ATTRIBUTE_SEPARATOR = '=';
-    public static final String MONITOR_OPTION_NAME = "monitor";
 
     @Parameter(names = { VERBOSE, "--verbose" }, description = "enable verbose mode (default: false)")
     private boolean verbose = false;
+
+    @Parameter(names = { TIMINGS, "--timings" }, description = "enable timings mode (default: false)")
+    private boolean timings = false;
 
     @Parameter(names = { VERSION, "--version" }, description = "display the version and runtime environment")
     private boolean version = false;
@@ -129,6 +132,10 @@ public class AsciidoctorCliOptions {
 
     public boolean isVerbose() {
         return this.verbose;
+    }
+
+    public boolean isTimings() {
+        return this.timings;
     }
 
     public String getBackend() {
@@ -277,10 +284,6 @@ public class AsciidoctorCliOptions {
 
         if (isInPlaceRequired()) {
             optionsBuilder.inPlace(true);
-        }
-
-        if (this.verbose) {
-            optionsBuilder.option(MONITOR_OPTION_NAME, new HashMap<Object, Object>());
         }
 
         attributesBuilder.attributes(getAttributes());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
@@ -79,8 +79,10 @@ public class AsciidoctorInvoker {
     }
 
     private void setTimingsMode(AsciidoctorCliOptions asciidoctorCliOptions, Options options) {
-        options.setOption("timings",
-            JRubyRuntimeContext.get().evalScriptlet("Asciidoctor::Timings.new"));
+        if (asciidoctorCliOptions.isTimings()) {
+            options.setOption("timings",
+                JRubyRuntimeContext.get().evalScriptlet("Asciidoctor::Timings.new"));
+        }
     }
 
     private void setVerboseLevel(AsciidoctorCliOptions asciidoctorCliOptions) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorInvoker.java
@@ -17,6 +17,7 @@ import org.asciidoctor.internal.RubyUtils;
 import org.jruby.RubySymbol;
 
 import com.beust.jcommander.JCommander;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public class AsciidoctorInvoker {
 
@@ -31,17 +32,11 @@ public class AsciidoctorInvoker {
             jCommander.usage();
         } else {
 
-            Asciidoctor asciidoctor = null;
-            
-            asciidoctor = buildAsciidoctorJInstance(asciidoctorCliOptions);
+            Asciidoctor asciidoctor = buildAsciidoctorJInstance(asciidoctorCliOptions);
             
             if (asciidoctorCliOptions.isVersion()) {
                 System.out.println("Asciidoctor " + asciidoctor.asciidoctorVersion() + " [http://asciidoctor.org]");
                 return;
-            }
-
-            if (asciidoctorCliOptions.isVerbose()) {
-                JRubyRuntimeContext.get().evalScriptlet("$VERBOSE=true");
             }
 
             List<File> inputFiles = getInputFiles(asciidoctorCliOptions);
@@ -63,34 +58,29 @@ public class AsciidoctorInvoker {
                     RubyUtils.requireLibrary(JRubyRuntimeContext.get(), require);
                 }
             }
-            
+
+            setTimingsMode(asciidoctorCliOptions, options);
+
             setVerboseLevel(asciidoctorCliOptions);
             
             String output = renderInput(asciidoctor, options, inputFiles);
 
-            if (asciidoctorCliOptions.isVerbose()) {
+            if (asciidoctorCliOptions.isTimings()) {
 
                 Map<String, Object> optionsMap = options.map();
-                Map<Object, Object> monitor = RubyHashUtil
-                        .convertRubyHashMapToMap((Map<Object, Object>) optionsMap
-                                .get(AsciidoctorCliOptions.MONITOR_OPTION_NAME));
-
-                System.out.println(String.format(
-                        "Time to read and parse source: %05.5f",
-                        monitor.get("parse")));
-                System.out.println(String.format(
-                        "Time to render document: %05.5f",
-                        monitor.get("render")));
-                System.out.println(String.format(
-                        "Total time to read, parse and render: %05.5f",
-                        monitor.get("load_render")));
-
+                IRubyObject timings = (IRubyObject) optionsMap.get("timings");
+                timings.callMethod(JRubyRuntimeContext.get().getCurrentContext(), "print_report");
             }
 
             if (!"".equals(output.trim())) {
                 System.out.println(output);
             }
         }
+    }
+
+    private void setTimingsMode(AsciidoctorCliOptions asciidoctorCliOptions, Options options) {
+        options.setOption("timings",
+            JRubyRuntimeContext.get().evalScriptlet("Asciidoctor::Timings.new"));
     }
 
     private void setVerboseLevel(AsciidoctorCliOptions asciidoctorCliOptions) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.cli;
 
-import static org.hamcrest.core.StringStartsWith.startsWith; 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
@@ -109,11 +110,11 @@ public class WhenAsciidoctorIsCalledUsingCli {
 	public void destination_dir_should_render_files_to_ouput_directory() {
 		File outputDirectory = temporaryFolder.getRoot();
 		
-        File inputFile = classpath.getResource("rendersample.asciidoc");
-        String inputPath = inputFile.getPath().substring(pwd.length() + 1);
+		File inputFile = classpath.getResource("rendersample.asciidoc");
+		String inputPath = inputFile.getPath().substring(pwd.length() + 1);
 		new AsciidoctorInvoker().invoke("-D", outputDirectory.getAbsolutePath(), inputPath);
 
-		File expectedFile = new File(inputPath.replaceFirst("\\.asciidoc$", ".html"));
+		File expectedFile = new File(outputDirectory, inputFile.getName().replaceFirst("\\.asciidoc$", ".html"));
 		assertThat(expectedFile.exists(), is(true));
 		
 	}
@@ -221,17 +222,18 @@ public class WhenAsciidoctorIsCalledUsingCli {
 	}
 	
 	@Test
-	public void verbose_option_should_fill_monitor_map() {
+	public void timings_option_should_fill_monitor_map() {
 		
 		ByteArrayOutputStream output = redirectStdout();
 		
-        File inputFile = classpath.getResource("rendersample.asciidoc");
-        String inputPath = inputFile.getPath().substring(pwd.length() + 1);
-		new AsciidoctorInvoker().invoke("--verbose", inputPath);
+		File inputFile = classpath.getResource("rendersample.asciidoc");
+		String inputPath = inputFile.getPath().substring(pwd.length() + 1);
+		new AsciidoctorInvoker().invoke("--timings", inputPath);
 		
 		String outputConsole = output.toString();
-		assertThat(outputConsole, startsWith("Time to read and parse source"));
-		
+		assertThat(outputConsole, startsWith("  Time to read and parse source:"));
+		assertThat(outputConsole, not(containsString("null")));
+
 	}
 	
 	@Test


### PR DESCRIPTION
This PR adds a `-t` command line option to align with the original `asciidoctor` command.
Previously the timings should've been printed when starting with `-v` (verbose mode).

But it looks like this didn't even work, as the timings are now managed by the `Asciidoctor::Timings` class which has to be present in the options.
I fixed this by explicitly creating such an instance, and then after the rendering calling this to print its report, so that the report should also look identically to what asciidoctor produces.

Along the way I also found an error in the tests regarding the destination dir option `-D`.
The test `destination_dir_should_render_files_to_ouput_directory()` also fails on the current master when running in isolation.
It only succeeded because the test `verbose_option_should_fill_monitor_map()` was executed before.