### PR TITLE
Add flag for timings mode and fix it

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
@@ -36,11 +36,15 @@ public class AsciidoctorCliOptions {
     public static final String BACKEND = "-b";
     public static final String VERSION = "-V";
     public static final String VERBOSE = "-v";
+    public static final String TIMINGS = "-t";
     public static final char ATTRIBUTE_SEPARATOR = '=';
-    public static final String MONITOR_OPTION_NAME = "monitor";
+    public static final String TIMINGS_OPTION_NAME = "timings";
 
     @Parameter(names = { VERBOSE, "--verbose" }, description = "enable verbose mode (default: false)")
     private boolean verbose = false;
+
+    @Parameter(names = { TIMINGS, "--timings" }, description = "enable timings mode (default: false)")
+    private boolean timings = false;
 
     @Parameter(names = { VERSION, "--version" }, description = "display the version and runtime environment")
     private boolean version = false;
@@ -142,6 +146,10 @@ public class AsciidoctorCliOptions {
 
     public boolean isVerbose() {
         return this.verbose;
+    }
+
+    public boolean isTimings() {
+        return this.timings;
     }
 
     public String getBackend() {
@@ -290,10 +298,6 @@ public class AsciidoctorCliOptions {
 
         if (isInPlaceRequired()) {
             optionsBuilder.inPlace(true);
-        }
-
-        if (this.verbose) {
-            optionsBuilder.option(MONITOR_OPTION_NAME, new HashMap<Object, Object>());
         }
 
         attributesBuilder.attributes(getAttributes());

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.cli;
 
-import static org.hamcrest.core.StringStartsWith.startsWith; 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
@@ -113,11 +114,11 @@ public class WhenAsciidoctorIsCalledUsingCli {
 	public void destination_dir_should_render_files_to_ouput_directory() {
 		File outputDirectory = temporaryFolder.getRoot();
 		
-        File inputFile = classpath.getResource("rendersample.asciidoc");
-        String inputPath = inputFile.getPath().substring(pwd.length() + 1);
+		File inputFile = classpath.getResource("rendersample.asciidoc");
+		String inputPath = inputFile.getPath().substring(pwd.length() + 1);
 		new AsciidoctorInvoker().invoke("-D", outputDirectory.getAbsolutePath(), inputPath);
 
-		File expectedFile = new File(inputPath.replaceFirst("\\.asciidoc$", ".html"));
+		File expectedFile = new File(outputDirectory, inputFile.getName().replaceFirst("\\.asciidoc$", ".html"));
 		assertThat(expectedFile.exists(), is(true));
 		
 	}
@@ -231,11 +232,11 @@ public class WhenAsciidoctorIsCalledUsingCli {
 		
         File inputFile = classpath.getResource("rendersample.asciidoc");
         String inputPath = inputFile.getPath().substring(pwd.length() + 1);
-		new AsciidoctorInvoker().invoke("--verbose", inputPath);
+		new AsciidoctorInvoker().invoke("--timings", inputPath);
 		
 		String outputConsole = output.toString();
-		assertThat(outputConsole, startsWith("Time to read and parse source"));
-		
+		assertThat(outputConsole, startsWith("  Time to read and parse source:"));
+		assertThat(outputConsole, not(containsString("null")));
 	}
 	
 	@Test


### PR DESCRIPTION
This PR adds the `-t / --timings` option to the 1.6.0 branch. #695 is the corresponding PR for 1.5.x.
It also fixes collecting the timings which was previously tied to the `--verbose` option.