### PR TITLE
Make Asciidoctor expose interfaces exclusively

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -1,13 +1,5 @@
 package org.asciidoctor;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.StructuredDocument;
@@ -17,6 +9,14 @@ import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.internal.JRubyAsciidoctor;
 import org.asciidoctor.log.LogHandler;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/converter/JavaConverterRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/converter/JavaConverterRegistry.java
@@ -1,82 +1,14 @@
 package org.asciidoctor.converter;
 
-import org.jruby.Ruby;
-import org.jruby.RubyArray;
-import org.jruby.RubyClass;
-
-import java.util.HashMap;
 import java.util.Map;
 
-public class JavaConverterRegistry {
+public interface JavaConverterRegistry {
 
-    private Ruby rubyRuntime;
+    <U, T  extends Converter<U> & OutputFormatWriter<U>> void register(Class<T> converterClass, String... backends);
 
-    public JavaConverterRegistry(Ruby rubyRuntime) {
-        this.rubyRuntime = rubyRuntime;
-    }
+    Class<?> resolve(String backend);
 
-    public <U, T  extends Converter<U> & OutputFormatWriter<U>> void register(final Class<T> converterClass, String... backends) {
+    void unregisterAll();
 
-        RubyClass clazz = ConverterProxy.register(rubyRuntime, converterClass);
-
-        ConverterFor converterForAnnotation = converterClass.getAnnotation(ConverterFor.class);
-        if (converterForAnnotation != null) {
-            // Backend annotation present => Register with name given in annotation
-            String backend = !ConverterFor.UNDEFINED.equals(converterForAnnotation.format()) ? converterForAnnotation.format() : converterForAnnotation.value();
-            getConverterFactory()
-                .callMethod("register", clazz, rubyRuntime.newArray(rubyRuntime.newString(backend)));
-
-        } else if (backends.length == 0) {
-            // No backend annotation and no backend defined => register as default backend
-            getConverterFactory()
-                .callMethod("register", clazz);
-        }
-        if (backends.length > 0) {
-            // Always additionally register with names passed to this method
-            final RubyArray rubyBackendNames = new RubyArray(rubyRuntime, backends.length);
-            for (String backend: backends) {
-                rubyBackendNames.add(rubyRuntime.newString(backend));
-            }
-            getConverterFactory()
-                .callMethod("register", clazz, rubyBackendNames);
-        }
-    }
-
-    public Class<?> resolve(String backend) {
-        RubyClass rubyClass = (RubyClass) getConverterFactory()
-            .callMethod("resolve", rubyRuntime.newString(backend));
-
-        Class<?> clazz = rubyClass.getReifiedClass();
-        if (clazz != null) {
-            return clazz;
-        } else if (rubyClass.getAllocator() instanceof ConverterProxy.Allocator) {
-            ConverterProxy.Allocator allocator = (ConverterProxy.Allocator) rubyClass.getAllocator();
-            return allocator.getConverterClass();
-        }
-        return null;
-    }
-
-    public void unregisterAll() {
-        getConverterFactory()
-            .callMethod("unregister_all");
-    }
-
-    private RubyClass getConverterFactory() {
-        return rubyRuntime.getModule("Asciidoctor")
-            .defineOrGetModuleUnder("Converter")
-            .getClass("Factory");
-    }
-
-    public Map<String, Class<?>> converters() {
-        final RubyArray rubyKeys = (RubyArray) getConverterFactory()
-            .callMethod("converters")
-            .callMethod(rubyRuntime.getCurrentContext(), "keys");
-
-        Map<String, Class<?>> converters = new HashMap<String, Class<?>>();
-        for (Object rubyBackend : rubyKeys) {
-            String backend = rubyBackend.toString();
-            converters.put(backend, resolve(backend));
-        }
-        return converters;
-    }
+    Map<String, Class<?>> converters();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
@@ -1,297 +1,73 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.extension.processorproxies.BlockMacroProcessorProxy;
-import org.asciidoctor.extension.processorproxies.BlockProcessorProxy;
-import org.asciidoctor.extension.processorproxies.DocinfoProcessorProxy;
-import org.asciidoctor.extension.processorproxies.IncludeProcessorProxy;
-import org.asciidoctor.extension.processorproxies.InlineMacroProcessorProxy;
-import org.asciidoctor.extension.processorproxies.PostprocessorProxy;
-import org.asciidoctor.extension.processorproxies.PreprocessorProxy;
-import org.asciidoctor.extension.processorproxies.TreeprocessorProxy;
-import org.jruby.Ruby;
-import org.jruby.RubyClass;
-import org.jruby.RubyModule;
-import org.jruby.internal.runtime.methods.DynamicMethod;
+public interface JavaExtensionRegistry {
 
-import java.util.Map;
+    JavaExtensionRegistry docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor);
 
-public class JavaExtensionRegistry {
+    JavaExtensionRegistry docinfoProcessor(DocinfoProcessor docInfoProcessor);
 
-    private Ruby rubyRuntime;
-    
-    public JavaExtensionRegistry(final Ruby rubyRuntime) {
-        this.rubyRuntime = rubyRuntime;
-    }
+    JavaExtensionRegistry docinfoProcessor(String docInfoProcessor);
 
-    public JavaExtensionRegistry docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor) {
+    JavaExtensionRegistry preprocessor(Class<? extends Preprocessor> preprocessor);
 
-        RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
-        getAsciidoctorModule()
-            .callMethod( "docinfo_processor", rubyClass);
-        return this;
-    }
+    JavaExtensionRegistry preprocessor(Preprocessor preprocessor);
 
-    public JavaExtensionRegistry docinfoProcessor(DocinfoProcessor docInfoProcessor) {
-        RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
-        getAsciidoctorModule()
-            .callMethod( "docinfo_processor", rubyClass);
-        return this;
-    }
+    JavaExtensionRegistry preprocessor(String preprocessor);
 
-    public JavaExtensionRegistry docinfoProcessor(String docInfoProcessor) {
-        try {
-            Class<? extends DocinfoProcessor>  docinfoProcessorClass = (Class<? extends DocinfoProcessor>) Class.forName(docInfoProcessor);
-            docinfoProcessor(docinfoProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    JavaExtensionRegistry postprocessor(String postprocessor);
 
-    public JavaExtensionRegistry preprocessor(Class<? extends Preprocessor> preprocessor) {
-        RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
-        getAsciidoctorModule()
-            .callMethod( "preprocessor", rubyClass);
-        return this;
-    }
+    JavaExtensionRegistry postprocessor(Class<? extends Postprocessor> postprocessor);
 
-    public JavaExtensionRegistry preprocessor(Preprocessor preprocessor) {
-        RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
+    JavaExtensionRegistry postprocessor(Postprocessor postprocessor);
 
-        getAsciidoctorModule()
-            .callMethod( "preprocessor", rubyClass);
-        return this;
-    }
-    
-    public JavaExtensionRegistry preprocessor(String preprocessor) {
-        try {
-            Class<? extends Preprocessor>  preprocessorClass = (Class<? extends Preprocessor>) Class.forName(preprocessor);
-            preprocessor(preprocessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-    
-    public JavaExtensionRegistry postprocessor(String postprocessor) {
-        try {
-            Class<? extends Postprocessor>  postprocessorClass = (Class<? extends Postprocessor>) Class.forName(postprocessor);
-            postprocessor(postprocessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-    
-    public JavaExtensionRegistry postprocessor(Class<? extends Postprocessor> postprocessor) {
-        RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
-        getAsciidoctorModule()
-            .callMethod( "postprocessor", rubyClass);
-        return this;
-    }
-    
-    public JavaExtensionRegistry postprocessor(Postprocessor postprocessor) {
-        RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
-        getAsciidoctorModule()
-            .callMethod( "postprocessor", rubyClass);
-        return this;
-    }
+    JavaExtensionRegistry includeProcessor(String includeProcessor);
 
-    public JavaExtensionRegistry includeProcessor(String includeProcessor) {
-        try {
-            Class<? extends IncludeProcessor>  includeProcessorClass = (Class<? extends IncludeProcessor>) Class.forName(includeProcessor);
-            includeProcessor(includeProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-    
-    public JavaExtensionRegistry includeProcessor(
-            Class<? extends IncludeProcessor> includeProcessor) {
-        RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
-        getAsciidoctorModule()
-            .callMethod( "include_processor", rubyClass);
-        return this;
-    }
+    JavaExtensionRegistry includeProcessor(
+        Class<? extends IncludeProcessor> includeProcessor);
 
-    public JavaExtensionRegistry includeProcessor(IncludeProcessor includeProcessor) {
-        RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
-        getAsciidoctorModule()
-            .callMethod( "include_processor", rubyClass);
-        return this;
-    }
-    
-    public JavaExtensionRegistry treeprocessor(Treeprocessor treeprocessor) {
-        RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeprocessor);
-        getAsciidoctorModule()
-            .callMethod( "treeprocessor", rubyClass);
-        return this;
-    }
+    JavaExtensionRegistry includeProcessor(IncludeProcessor includeProcessor);
 
-    public JavaExtensionRegistry treeprocessor(Class<? extends Treeprocessor> abstractTreeProcessor) {
-        RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, abstractTreeProcessor);
-        getAsciidoctorModule()
-            .callMethod( "treeprocessor", rubyClass);
-        return this;
-    }
-    
-    public JavaExtensionRegistry treeprocessor(String treeProcessor) {
-        try {
-            Class<? extends Treeprocessor>  treeProcessorClass = (Class<? extends Treeprocessor>) Class.forName(treeProcessor);
-            treeprocessor(treeProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    JavaExtensionRegistry treeprocessor(Treeprocessor treeprocessor);
 
-    public JavaExtensionRegistry block(String blockName,
-           String blockProcessor) {
-        try {
-            Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
-            block(blockName, blockProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    JavaExtensionRegistry treeprocessor(Class<? extends Treeprocessor> abstractTreeProcessor);
 
-    public JavaExtensionRegistry block(String blockProcessor) {
-        try {
-            Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
-            block(blockProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    JavaExtensionRegistry treeprocessor(String treeProcessor);
 
-    public JavaExtensionRegistry block(String blockName,
-            Class<? extends BlockProcessor> blockProcessor) {
-        RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-        getAsciidoctorModule()
-            .callMethod( "block_processor", rubyClass, rubyRuntime.newString(blockName));
-        return this;
-    }
+    JavaExtensionRegistry block(String blockName,
+                                    String blockProcessor);
 
-    public JavaExtensionRegistry block(Class<? extends BlockProcessor> blockProcessor) {
-        String name = getName(blockProcessor);
-        block(name, blockProcessor);
-        return this;
-    }
+    JavaExtensionRegistry block(String blockProcessor);
 
-    public JavaExtensionRegistry block(BlockProcessor blockProcessor) {
-        RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-        getAsciidoctorModule()
-            .callMethod( "block_processor", rubyClass, rubyRuntime.newString(blockProcessor.getName()));
-        return this;
-    }
+    JavaExtensionRegistry block(String blockName,
+                                    Class<? extends BlockProcessor> blockProcessor);
 
-    public JavaExtensionRegistry block(String blockName,
-            BlockProcessor blockProcessor) {
-        RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-        getAsciidoctorModule()
-            .callMethod( "block_processor", rubyClass, rubyRuntime.newString(blockName));
-        return this;
-    }
+    JavaExtensionRegistry block(Class<? extends BlockProcessor> blockProcessor);
 
-    public JavaExtensionRegistry blockMacro(String blockName,
-            Class<? extends BlockMacroProcessor> blockMacroProcessor) {
-        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-        getAsciidoctorModule()
-            .callMethod( "block_macro", rubyClass, rubyRuntime.newString(blockName));
-        return this;
-    }
+    JavaExtensionRegistry block(BlockProcessor blockProcessor);
 
-    public JavaExtensionRegistry blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor) {
-        String name = getName(blockMacroProcessor);
-        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-        getAsciidoctorModule()
-            .callMethod( "block_macro", rubyClass, rubyRuntime.newString(name));
-        return this;
-    }
+    JavaExtensionRegistry block(String blockName,
+                                    BlockProcessor blockProcessor);
 
-    public JavaExtensionRegistry blockMacro(String blockName,
-            String blockMacroProcessor) {
-        try {
-            Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
-            blockMacro(blockName, blockMacroProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    JavaExtensionRegistry blockMacro(String blockName,
+                                         Class<? extends BlockMacroProcessor> blockMacroProcessor);
 
-    public JavaExtensionRegistry blockMacro(String blockMacroProcessor) {
-        try {
-            Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
-            blockMacro(blockMacroProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    JavaExtensionRegistry blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor);
 
-    public JavaExtensionRegistry blockMacro(BlockMacroProcessor blockMacroProcessor) {
-        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-        getAsciidoctorModule()
-            .callMethod( "block_macro", rubyClass, rubyRuntime.newString(blockMacroProcessor.getName()));
-        return this;
-    }
+    JavaExtensionRegistry blockMacro(String blockName,
+                                         String blockMacroProcessor);
 
-    public JavaExtensionRegistry inlineMacro(InlineMacroProcessor inlineMacroProcessor) {
-        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        getAsciidoctorModule()
-            .callMethod( "inline_macro", rubyClass, rubyRuntime.newString(inlineMacroProcessor.getName()));
-        return this;
-    }
-    
-    public JavaExtensionRegistry inlineMacro(String blockName,
-            Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
-        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        getAsciidoctorModule()
-            .callMethod( "inline_macro", rubyClass, rubyRuntime.newString(blockName));
-        return this;
-    }
+    JavaExtensionRegistry blockMacro(String blockMacroProcessor);
 
-    public JavaExtensionRegistry inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
-        String name = getName(inlineMacroProcessor);
-        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        getAsciidoctorModule()
-            .callMethod( "inline_macro", rubyClass, rubyRuntime.newString(name));
-        return this;
-    }
+    JavaExtensionRegistry blockMacro(BlockMacroProcessor blockMacroProcessor);
 
-    public JavaExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor) {
-        try {
-            Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
-            inlineMacro(blockName, inlineMacroProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    JavaExtensionRegistry inlineMacro(InlineMacroProcessor inlineMacroProcessor);
 
-    public JavaExtensionRegistry inlineMacro(String inlineMacroProcessor) {
-        try {
-            Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
-            inlineMacro(inlineMacroProcessorClass);
-            return this;
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    JavaExtensionRegistry inlineMacro(String blockName,
+                                          Class<? extends InlineMacroProcessor> inlineMacroProcessor);
 
-    private String getName(Class<?> clazz) {
-        Name nameAnnotation = clazz.getAnnotation(Name.class);
-        if (nameAnnotation == null || nameAnnotation.value() == null) {
-            throw new IllegalArgumentException(clazz + " must be registered with a name or it must have a Name annotation!");
-        }
-        return nameAnnotation.value();
-    }
+    JavaExtensionRegistry inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor);
 
-    private RubyModule getAsciidoctorModule() {
-        return rubyRuntime.getModule("AsciidoctorModule");
-    }
+    JavaExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor);
+
+    JavaExtensionRegistry inlineMacro(String inlineMacroProcessor);
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/RubyExtensionRegistry.java
@@ -1,86 +1,33 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.internal.RubyUtils;
-import org.jruby.Ruby;
-import org.jruby.RubyModule;
+import org.asciidoctor.internal.RubyExtensionRegistryImpl;
 
 import java.io.InputStream;
 
-public class RubyExtensionRegistry {
+public interface RubyExtensionRegistry {
+    RubyExtensionRegistryImpl requireLibrary(String requiredLibrary);
 
+    RubyExtensionRegistryImpl loadClass(InputStream rubyClassStream);
 
-    private Ruby rubyRuntime;
+    RubyExtensionRegistryImpl preprocessor(String preprocessor);
 
-    public RubyExtensionRegistry(final Ruby rubyRuntime) {
-        this.rubyRuntime = rubyRuntime;
-    }
+    RubyExtensionRegistryImpl postprocessor(String postprocessor);
 
-    public RubyExtensionRegistry requireLibrary(String requiredLibrary) {
-        RubyUtils.requireLibrary(rubyRuntime, requiredLibrary);
-        return this;
-    }
-    
-    public RubyExtensionRegistry loadClass(InputStream rubyClassStream) {
-        RubyUtils.loadRubyClass(rubyRuntime, rubyClassStream);
-        return this;
-    }
+    RubyExtensionRegistryImpl docinfoProcessor(String docinfoProcessor);
 
-    public RubyExtensionRegistry preprocessor(String preprocessor) {
-        getAsciidoctorModule().callMethod( "preprocessor", rubyRuntime.newString(preprocessor));
-        return this;
-    }
+    RubyExtensionRegistryImpl includeProcessor(String includeProcessor);
 
-    public RubyExtensionRegistry postprocessor(String postprocessor) {
-        getAsciidoctorModule().callMethod( "postprocessor", rubyRuntime.newString(postprocessor));
-        return this;
-    }
+    RubyExtensionRegistryImpl treeprocessor(String treeProcessor);
 
-    public RubyExtensionRegistry docinfoProcessor(String docinfoProcessor) {
-        getAsciidoctorModule().callMethod( "docinfo_processor", rubyRuntime.newString(docinfoProcessor));
-        return this;
-    }
+    RubyExtensionRegistryImpl block(String blockName, String blockProcessor);
 
-    public RubyExtensionRegistry includeProcessor(String includeProcessor) {
-        getAsciidoctorModule().callMethod( "include_processor", rubyRuntime.newString(includeProcessor));
-        return this;
-    }
+    RubyExtensionRegistryImpl block(String blockProcessor);
 
-    public RubyExtensionRegistry treeprocessor(String treeProcessor) {
-        getAsciidoctorModule().callMethod( "treeprocessor", rubyRuntime.newString(treeProcessor));
-        return this;
-    }
+    RubyExtensionRegistryImpl blockMacro(String blockName, String blockMacroProcessor);
 
-    public RubyExtensionRegistry block(String blockName, String blockProcessor) {
-        getAsciidoctorModule().callMethod( "block_processor", rubyRuntime.newString(blockProcessor), RubyUtils.toSymbol(rubyRuntime, blockName));
-        return this;
-    }
+    RubyExtensionRegistryImpl blockMacro(String blockMacroProcessor);
 
-    public RubyExtensionRegistry block(String blockProcessor) {
-        getAsciidoctorModule().callMethod( "block_processor", rubyRuntime.newString(blockProcessor));
-        return this;
-    }
+    RubyExtensionRegistryImpl inlineMacro(String blockName, String inlineMacroProcessor);
 
-    public RubyExtensionRegistry blockMacro(String blockName, String blockMacroProcessor) {
-        getAsciidoctorModule().callMethod( "block_macro", rubyRuntime.newString(blockMacroProcessor), RubyUtils.toSymbol(rubyRuntime, blockName));
-        return this;
-    }
-
-    public RubyExtensionRegistry blockMacro(String blockMacroProcessor) {
-        getAsciidoctorModule().callMethod( "block_macro", rubyRuntime.newString(blockMacroProcessor));
-        return this;
-    }
-
-    public RubyExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor) {
-        getAsciidoctorModule().callMethod( "inline_macro", rubyRuntime.newString(inlineMacroProcessor), RubyUtils.toSymbol(rubyRuntime, blockName));
-        return this;
-    }
-
-    public RubyExtensionRegistry inlineMacro(String inlineMacroProcessor) {
-        getAsciidoctorModule().callMethod( "inline_macro", rubyRuntime.newString(inlineMacroProcessor));
-        return this;
-    }
-
-    private RubyModule getAsciidoctorModule() {
-        return rubyRuntime.getModule("AsciidoctorModule");
-    }
+    RubyExtensionRegistryImpl inlineMacro(String inlineMacroProcessor);
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -428,17 +428,17 @@ public class JRubyAsciidoctor implements Asciidoctor, LogHandler {
 
     @Override
     public JavaExtensionRegistry javaExtensionRegistry() {
-        return new JavaExtensionRegistry(rubyRuntime);
+        return new JavaExtensionRegistryImpl(rubyRuntime);
     }
 
     @Override
     public RubyExtensionRegistry rubyExtensionRegistry() {
-        return new RubyExtensionRegistry(rubyRuntime);
+        return new RubyExtensionRegistryImpl(rubyRuntime);
     }
 
     @Override
     public JavaConverterRegistry javaConverterRegistry() {
-        return new JavaConverterRegistry(rubyRuntime);
+        return new JavaConverterRegistryImpl(rubyRuntime);
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaConverterRegistryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaConverterRegistryImpl.java
@@ -1,0 +1,91 @@
+package org.asciidoctor.internal;
+
+import org.asciidoctor.converter.Converter;
+import org.asciidoctor.converter.ConverterFor;
+import org.asciidoctor.converter.ConverterProxy;
+import org.asciidoctor.converter.JavaConverterRegistry;
+import org.asciidoctor.converter.OutputFormatWriter;
+import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyClass;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JavaConverterRegistryImpl implements JavaConverterRegistry {
+
+    private Ruby rubyRuntime;
+
+    public JavaConverterRegistryImpl(Ruby rubyRuntime) {
+        this.rubyRuntime = rubyRuntime;
+    }
+
+    @Override
+    public <U, T  extends Converter<U> & OutputFormatWriter<U>> void register(final Class<T> converterClass, String... backends) {
+
+        RubyClass clazz = ConverterProxy.register(rubyRuntime, converterClass);
+
+        ConverterFor converterForAnnotation = converterClass.getAnnotation(ConverterFor.class);
+        if (converterForAnnotation != null) {
+            // Backend annotation present => Register with name given in annotation
+            String backend = !ConverterFor.UNDEFINED.equals(converterForAnnotation.format()) ? converterForAnnotation.format() : converterForAnnotation.value();
+            getConverterFactory()
+                .callMethod("register", clazz, rubyRuntime.newArray(rubyRuntime.newString(backend)));
+
+        } else if (backends.length == 0) {
+            // No backend annotation and no backend defined => register as default backend
+            getConverterFactory()
+                .callMethod("register", clazz);
+        }
+        if (backends.length > 0) {
+            // Always additionally register with names passed to this method
+            final RubyArray rubyBackendNames = new RubyArray(rubyRuntime, backends.length);
+            for (String backend: backends) {
+                rubyBackendNames.add(rubyRuntime.newString(backend));
+            }
+            getConverterFactory()
+                .callMethod("register", clazz, rubyBackendNames);
+        }
+    }
+
+    @Override
+    public Class<?> resolve(String backend) {
+        RubyClass rubyClass = (RubyClass) getConverterFactory()
+            .callMethod("resolve", rubyRuntime.newString(backend));
+
+        Class<?> clazz = rubyClass.getReifiedClass();
+        if (clazz != null) {
+            return clazz;
+        } else if (rubyClass.getAllocator() instanceof ConverterProxy.Allocator) {
+            ConverterProxy.Allocator allocator = (ConverterProxy.Allocator) rubyClass.getAllocator();
+            return allocator.getConverterClass();
+        }
+        return null;
+    }
+
+    @Override
+    public void unregisterAll() {
+        getConverterFactory()
+            .callMethod("unregister_all");
+    }
+
+    private RubyClass getConverterFactory() {
+        return rubyRuntime.getModule("Asciidoctor")
+            .defineOrGetModuleUnder("Converter")
+            .getClass("Factory");
+    }
+
+    @Override
+    public Map<String, Class<?>> converters() {
+        final RubyArray rubyKeys = (RubyArray) getConverterFactory()
+            .callMethod("converters")
+            .callMethod(rubyRuntime.getCurrentContext(), "keys");
+
+        Map<String, Class<?>> converters = new HashMap<String, Class<?>>();
+        for (Object rubyBackend : rubyKeys) {
+            String backend = rubyBackend.toString();
+            converters.put(backend, resolve(backend));
+        }
+        return converters;
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaExtensionRegistryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaExtensionRegistryImpl.java
@@ -1,0 +1,335 @@
+package org.asciidoctor.internal;
+
+import org.asciidoctor.extension.BlockMacroProcessor;
+import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.DocinfoProcessor;
+import org.asciidoctor.extension.IncludeProcessor;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.JavaExtensionRegistry;
+import org.asciidoctor.extension.Name;
+import org.asciidoctor.extension.Postprocessor;
+import org.asciidoctor.extension.Preprocessor;
+import org.asciidoctor.extension.Treeprocessor;
+import org.asciidoctor.extension.processorproxies.BlockMacroProcessorProxy;
+import org.asciidoctor.extension.processorproxies.BlockProcessorProxy;
+import org.asciidoctor.extension.processorproxies.DocinfoProcessorProxy;
+import org.asciidoctor.extension.processorproxies.IncludeProcessorProxy;
+import org.asciidoctor.extension.processorproxies.InlineMacroProcessorProxy;
+import org.asciidoctor.extension.processorproxies.PostprocessorProxy;
+import org.asciidoctor.extension.processorproxies.PreprocessorProxy;
+import org.asciidoctor.extension.processorproxies.TreeprocessorProxy;
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyModule;
+
+public class JavaExtensionRegistryImpl implements JavaExtensionRegistry {
+
+    private Ruby rubyRuntime;
+    
+    public JavaExtensionRegistryImpl(final Ruby rubyRuntime) {
+        this.rubyRuntime = rubyRuntime;
+    }
+
+    @Override
+    public JavaExtensionRegistry docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor) {
+
+        RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
+        getAsciidoctorModule()
+            .callMethod( "docinfo_processor", rubyClass);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry docinfoProcessor(DocinfoProcessor docInfoProcessor) {
+        RubyClass rubyClass = DocinfoProcessorProxy.register(rubyRuntime, docInfoProcessor);
+        getAsciidoctorModule()
+            .callMethod( "docinfo_processor", rubyClass);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry docinfoProcessor(String docInfoProcessor) {
+        try {
+            Class<? extends DocinfoProcessor>  docinfoProcessorClass = (Class<? extends DocinfoProcessor>) Class.forName(docInfoProcessor);
+            docinfoProcessor(docinfoProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public JavaExtensionRegistry preprocessor(Class<? extends Preprocessor> preprocessor) {
+        RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
+        getAsciidoctorModule()
+            .callMethod( "preprocessor", rubyClass);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry preprocessor(Preprocessor preprocessor) {
+        RubyClass rubyClass = PreprocessorProxy.register(rubyRuntime, preprocessor);
+
+        getAsciidoctorModule()
+            .callMethod( "preprocessor", rubyClass);
+        return this;
+    }
+    
+    @Override
+    public JavaExtensionRegistry preprocessor(String preprocessor) {
+        try {
+            Class<? extends Preprocessor>  preprocessorClass = (Class<? extends Preprocessor>) Class.forName(preprocessor);
+            preprocessor(preprocessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @Override
+    public JavaExtensionRegistry postprocessor(String postprocessor) {
+        try {
+            Class<? extends Postprocessor>  postprocessorClass = (Class<? extends Postprocessor>) Class.forName(postprocessor);
+            postprocessor(postprocessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @Override
+    public JavaExtensionRegistry postprocessor(Class<? extends Postprocessor> postprocessor) {
+        RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
+        getAsciidoctorModule()
+            .callMethod( "postprocessor", rubyClass);
+        return this;
+    }
+    
+    @Override
+    public JavaExtensionRegistry postprocessor(Postprocessor postprocessor) {
+        RubyClass rubyClass = PostprocessorProxy.register(rubyRuntime, postprocessor);
+        getAsciidoctorModule()
+            .callMethod( "postprocessor", rubyClass);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry includeProcessor(String includeProcessor) {
+        try {
+            Class<? extends IncludeProcessor>  includeProcessorClass = (Class<? extends IncludeProcessor>) Class.forName(includeProcessor);
+            includeProcessor(includeProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @Override
+    public JavaExtensionRegistry includeProcessor(
+        Class<? extends IncludeProcessor> includeProcessor) {
+        RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
+        getAsciidoctorModule()
+            .callMethod( "include_processor", rubyClass);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry includeProcessor(IncludeProcessor includeProcessor) {
+        RubyClass rubyClass = IncludeProcessorProxy.register(rubyRuntime, includeProcessor);
+        getAsciidoctorModule()
+            .callMethod( "include_processor", rubyClass);
+        return this;
+    }
+    
+    @Override
+    public JavaExtensionRegistry treeprocessor(Treeprocessor treeprocessor) {
+        RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, treeprocessor);
+        getAsciidoctorModule()
+            .callMethod( "treeprocessor", rubyClass);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry treeprocessor(Class<? extends Treeprocessor> abstractTreeProcessor) {
+        RubyClass rubyClass = TreeprocessorProxy.register(rubyRuntime, abstractTreeProcessor);
+        getAsciidoctorModule()
+            .callMethod( "treeprocessor", rubyClass);
+        return this;
+    }
+    
+    @Override
+    public JavaExtensionRegistry treeprocessor(String treeProcessor) {
+        try {
+            Class<? extends Treeprocessor>  treeProcessorClass = (Class<? extends Treeprocessor>) Class.forName(treeProcessor);
+            treeprocessor(treeProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public JavaExtensionRegistry block(String blockName,
+                                           String blockProcessor) {
+        try {
+            Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
+            block(blockName, blockProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public JavaExtensionRegistry block(String blockProcessor) {
+        try {
+            Class<? extends BlockProcessor>  blockProcessorClass = (Class<? extends BlockProcessor>) Class.forName(blockProcessor);
+            block(blockProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public JavaExtensionRegistry block(String blockName,
+                                           Class<? extends BlockProcessor> blockProcessor) {
+        RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+        getAsciidoctorModule()
+            .callMethod( "block_processor", rubyClass, rubyRuntime.newString(blockName));
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry block(Class<? extends BlockProcessor> blockProcessor) {
+        String name = getName(blockProcessor);
+        block(name, blockProcessor);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry block(BlockProcessor blockProcessor) {
+        RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+        getAsciidoctorModule()
+            .callMethod( "block_processor", rubyClass, rubyRuntime.newString(blockProcessor.getName()));
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry block(String blockName,
+                                           BlockProcessor blockProcessor) {
+        RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
+        getAsciidoctorModule()
+            .callMethod( "block_processor", rubyClass, rubyRuntime.newString(blockName));
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry blockMacro(String blockName,
+                                                Class<? extends BlockMacroProcessor> blockMacroProcessor) {
+        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+        getAsciidoctorModule()
+            .callMethod( "block_macro", rubyClass, rubyRuntime.newString(blockName));
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor) {
+        String name = getName(blockMacroProcessor);
+        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+        getAsciidoctorModule()
+            .callMethod( "block_macro", rubyClass, rubyRuntime.newString(name));
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry blockMacro(String blockName,
+                                                String blockMacroProcessor) {
+        try {
+            Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
+            blockMacro(blockName, blockMacroProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public JavaExtensionRegistry blockMacro(String blockMacroProcessor) {
+        try {
+            Class<? extends BlockMacroProcessor>  blockMacroProcessorClass = (Class<? extends BlockMacroProcessor>) Class.forName(blockMacroProcessor);
+            blockMacro(blockMacroProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public JavaExtensionRegistry blockMacro(BlockMacroProcessor blockMacroProcessor) {
+        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+        getAsciidoctorModule()
+            .callMethod( "block_macro", rubyClass, rubyRuntime.newString(blockMacroProcessor.getName()));
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry inlineMacro(InlineMacroProcessor inlineMacroProcessor) {
+        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+        getAsciidoctorModule()
+            .callMethod( "inline_macro", rubyClass, rubyRuntime.newString(inlineMacroProcessor.getName()));
+        return this;
+    }
+    
+    @Override
+    public JavaExtensionRegistry inlineMacro(String blockName,
+                                                 Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
+        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+        getAsciidoctorModule()
+            .callMethod( "inline_macro", rubyClass, rubyRuntime.newString(blockName));
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
+        String name = getName(inlineMacroProcessor);
+        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+        getAsciidoctorModule()
+            .callMethod( "inline_macro", rubyClass, rubyRuntime.newString(name));
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor) {
+        try {
+            Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
+            inlineMacro(blockName, inlineMacroProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public JavaExtensionRegistry inlineMacro(String inlineMacroProcessor) {
+        try {
+            Class<? extends InlineMacroProcessor>  inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
+            inlineMacro(inlineMacroProcessorClass);
+            return this;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getName(Class<?> clazz) {
+        Name nameAnnotation = clazz.getAnnotation(Name.class);
+        if (nameAnnotation == null || nameAnnotation.value() == null) {
+            throw new IllegalArgumentException(clazz + " must be registered with a name or it must have a Name annotation!");
+        }
+        return nameAnnotation.value();
+    }
+
+    private RubyModule getAsciidoctorModule() {
+        return rubyRuntime.getModule("AsciidoctorModule");
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyExtensionRegistryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyExtensionRegistryImpl.java
@@ -1,0 +1,99 @@
+package org.asciidoctor.internal;
+
+import org.asciidoctor.extension.RubyExtensionRegistry;
+import org.jruby.Ruby;
+import org.jruby.RubyModule;
+
+import java.io.InputStream;
+
+public class RubyExtensionRegistryImpl implements RubyExtensionRegistry {
+
+
+    private Ruby rubyRuntime;
+
+    public RubyExtensionRegistryImpl(final Ruby rubyRuntime) {
+        this.rubyRuntime = rubyRuntime;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl requireLibrary(String requiredLibrary) {
+        RubyUtils.requireLibrary(rubyRuntime, requiredLibrary);
+        return this;
+    }
+    
+    @Override
+    public RubyExtensionRegistryImpl loadClass(InputStream rubyClassStream) {
+        RubyUtils.loadRubyClass(rubyRuntime, rubyClassStream);
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl preprocessor(String preprocessor) {
+        getAsciidoctorModule().callMethod( "preprocessor", rubyRuntime.newString(preprocessor));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl postprocessor(String postprocessor) {
+        getAsciidoctorModule().callMethod( "postprocessor", rubyRuntime.newString(postprocessor));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl docinfoProcessor(String docinfoProcessor) {
+        getAsciidoctorModule().callMethod( "docinfo_processor", rubyRuntime.newString(docinfoProcessor));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl includeProcessor(String includeProcessor) {
+        getAsciidoctorModule().callMethod( "include_processor", rubyRuntime.newString(includeProcessor));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl treeprocessor(String treeProcessor) {
+        getAsciidoctorModule().callMethod( "treeprocessor", rubyRuntime.newString(treeProcessor));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl block(String blockName, String blockProcessor) {
+        getAsciidoctorModule().callMethod( "block_processor", rubyRuntime.newString(blockProcessor), RubyUtils.toSymbol(rubyRuntime, blockName));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl block(String blockProcessor) {
+        getAsciidoctorModule().callMethod( "block_processor", rubyRuntime.newString(blockProcessor));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl blockMacro(String blockName, String blockMacroProcessor) {
+        getAsciidoctorModule().callMethod( "block_macro", rubyRuntime.newString(blockMacroProcessor), RubyUtils.toSymbol(rubyRuntime, blockName));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl blockMacro(String blockMacroProcessor) {
+        getAsciidoctorModule().callMethod( "block_macro", rubyRuntime.newString(blockMacroProcessor));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl inlineMacro(String blockName, String inlineMacroProcessor) {
+        getAsciidoctorModule().callMethod( "inline_macro", rubyRuntime.newString(inlineMacroProcessor), RubyUtils.toSymbol(rubyRuntime, blockName));
+        return this;
+    }
+
+    @Override
+    public RubyExtensionRegistryImpl inlineMacro(String inlineMacroProcessor) {
+        getAsciidoctorModule().callMethod( "inline_macro", rubyRuntime.newString(inlineMacroProcessor));
+        return this;
+    }
+
+    private RubyModule getAsciidoctorModule() {
+        return rubyRuntime.getModule("AsciidoctorModule");
+    }
+}


### PR DESCRIPTION
Currently the return types of some methods of the Asciidoctor interface are classes that are tied to the JRuby implementation.
This PR refactors the code by extracting interfaces for JavaExtensionRegistry, RubyExtensionRegistry and JavaConverterRegistry.
As we are already binary incompatible with 1.5 we should use that as a chance to allow further changes in the future. (For example plumbing the Asciidoctor.js implementation behind the Asciidoctor interface)