### PR TITLE
#634: Set line endings for *.asciidoc files to LF to make the content…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.adoc		eol=lf
+*.asciidoc  eol=lf


### PR DESCRIPTION
… comparing tests pass on Windows

This PR reads the update of the .gitattributes file to force unix line endings for the *.asciidoc test files.
This commit got lost while merging 1.6 into master.