### PR TITLE
Add wildfly integration test

### DIFF
--- a/asciidoctorj-wildfly-integration-test/build.gradle
+++ b/asciidoctorj-wildfly-integration-test/build.gradle
@@ -54,37 +54,43 @@ test {
 
 }
 
-if (project.hasProperty('jboss.home')) {
 
-    task integrationTest(type: Test) {
-        useJUnit {
-            includeCategories 'org.asciidoctor.categories.Wildfly'
+test {
+    useJUnit {
+        if (!project.hasProperty('jboss.home')) {
+            excludeCategories 'org.asciidoctor.categories.Wildfly'
         }
+    }
 
-        testLogging {
-            // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
-            // events 'standard_out', 'standard_error'
-            afterSuite { desc, result ->
-                if (!desc.parent && logger.infoEnabled) {
-                    logger.info "Test results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
-                }
+    testLogging {
+        // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
+        // events 'standard_out', 'standard_error'
+        afterSuite { desc, result ->
+            if (!desc.parent && logger.infoEnabled) {
+                logger.info "Test results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
             }
         }
+    }
 
-        reports {
-            html {
-                destination file("$buildDir/reports/integrationTest")
-            }
-            junitXml {
-                destination file("$buildDir/integrationTest")
-            }
+    reports {
+        html {
+            destination file("$buildDir/reports/integrationTest")
         }
+        junitXml {
+            destination file("$buildDir/integrationTest")
+        }
+    }
 
+    if (project.hasProperty('jboss.home')) {
         systemProperty('jboss.home', project.getProperty("jboss.home"))
         systemProperty('module.path', project.getProperty("jboss.home") + "/modules" + File.pathSeparator + file('build/modules').absolutePath)
     }
 
-    integrationTest.dependsOn createModule
-    integrationTest.dependsOn configurations.jbossmodule
+    dependsOn createModule
+    dependsOn configurations.jbossmodule
+}
 
+
+configurations.all {
+    artifacts.clear()
 }

--- a/asciidoctorj-wildfly-integration-test/build.gradle
+++ b/asciidoctorj-wildfly-integration-test/build.gradle
@@ -1,0 +1,90 @@
+jar.enabled = false
+
+ext {
+    arquillianVersion = '1.1.13.Final'
+    arquillianWildflyVersion = '2.1.1.Final'
+}
+
+configurations {
+    jbossmodule
+}
+
+dependencies {
+
+    jbossmodule(project(':asciidoctorj-api')) {
+        transitive = false
+    }
+    jbossmodule(project(':asciidoctorj')) {
+        transitive = false
+    }
+    jbossmodule "org.jruby:jruby-complete:$jrubyVersion"
+
+    testCompile "javax:javaee-api:7.0"
+    testCompileOnly project(':asciidoctorj')
+    testCompile "junit:junit:$junitVersion"
+    testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
+    testCompile "org.jboss.arquillian.junit:arquillian-junit-container:$arquillianVersion"
+    testCompile "org.jsoup:jsoup:$jsoupVersion"
+
+    testRuntime "org.wildfly.arquillian:wildfly-arquillian-container-managed:$arquillianWildflyVersion"
+}
+
+task createModule << {
+    copy {
+        from "src/test/resources/module.xml"
+        into "build/modules/org/asciidoctor/asciidoctorj/main"
+        filter {
+            it
+                    .replaceAll('@@version@@', project(':asciidoctorj').version)
+                    .replaceAll('@@jrubyVersion@@', jrubyVersion)
+        }
+    }
+
+    copy {
+        from configurations.jbossmodule
+        into "build/modules/org/asciidoctor/asciidoctorj/main"
+    }
+}
+
+
+test {
+    useJUnit {
+        excludeCategories 'org.asciidoctor.categories.Wildfly'
+    }
+
+}
+
+if (project.hasProperty('jboss.home')) {
+
+    task integrationTest(type: Test) {
+        useJUnit {
+            includeCategories 'org.asciidoctor.categories.Wildfly'
+        }
+
+        testLogging {
+            // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
+            // events 'standard_out', 'standard_error'
+            afterSuite { desc, result ->
+                if (!desc.parent && logger.infoEnabled) {
+                    logger.info "Test results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+                }
+            }
+        }
+
+        reports {
+            html {
+                destination file("$buildDir/reports/integrationTest")
+            }
+            junitXml {
+                destination file("$buildDir/integrationTest")
+            }
+        }
+
+        systemProperty('jboss.home', project.getProperty("jboss.home"))
+        systemProperty('module.path', project.getProperty("jboss.home") + "/modules" + File.pathSeparator + file('build/modules').absolutePath)
+    }
+
+    integrationTest.dependsOn createModule
+    integrationTest.dependsOn configurations.jbossmodule
+
+}

--- a/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/AsciidoctorServlet.java
+++ b/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/AsciidoctorServlet.java
@@ -1,0 +1,34 @@
+package org.asciidoctor;
+
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+@WebServlet("/asciidoctor")
+public class AsciidoctorServlet extends HttpServlet {
+
+    private Asciidoctor asciidoctor;
+
+    @Override
+    public void init() throws ServletException {
+        asciidoctor = Asciidoctor.Factory.create();
+
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        resp.setStatus(200);
+        try (InputStreamReader reader = new InputStreamReader(req.getInputStream());
+             OutputStreamWriter writer = new OutputStreamWriter(resp.getOutputStream())) {
+            asciidoctor.convert(reader, writer, OptionsBuilder.options().get());
+        }
+
+    }
+}

--- a/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/WildflyIntegrationTest.java
+++ b/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/WildflyIntegrationTest.java
@@ -1,0 +1,66 @@
+package org.asciidoctor;
+
+import org.asciidoctor.categories.Wildfly;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+@Category(Wildfly.class)
+public class WildflyIntegrationTest {
+
+    @Deployment
+    public static WebArchive deploy() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addClasses(AsciidoctorServlet.class)
+            .setManifest(new File("src/test/resources/MANIFEST.MF"));
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void test() throws Exception {
+        HttpURLConnection conn = (HttpURLConnection) new URL(url, "asciidoctor").openConnection();
+        conn.setDoOutput(true);
+        conn.setRequestMethod("POST");
+        conn.getOutputStream().write("Hello World".getBytes());
+
+        byte[] buf = new byte[65535];
+        try (InputStream in = conn.getInputStream()) {
+
+            final Document doc = Jsoup.parse(readFull(in));
+            final Element first = doc.body().children().first();
+            assertEquals("div", first.tagName());
+            assertEquals("paragraph", first.className());
+            final Element paragraph = first.children().first();
+            assertEquals("p", paragraph.tagName());
+            assertEquals("Hello World", paragraph.ownText());
+
+
+        }
+    }
+
+    public static String readFull(InputStream inputStream) {
+        return new Scanner(inputStream).useDelimiter("\\A").next();
+    }
+
+}

--- a/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/categories/Wildfly.java
+++ b/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/categories/Wildfly.java
@@ -1,0 +1,4 @@
+package org.asciidoctor.categories;
+
+public class Wildfly {
+}

--- a/asciidoctorj-wildfly-integration-test/src/test/resources/MANIFEST.MF
+++ b/asciidoctorj-wildfly-integration-test/src/test/resources/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Dependencies: org.asciidoctor.asciidoctorj

--- a/asciidoctorj-wildfly-integration-test/src/test/resources/arquillian.xml
+++ b/asciidoctorj-wildfly-integration-test/src/test/resources/arquillian.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <!--<defaultProtocol type="jmx-as7"/>-->
+
+  <engine>
+    <property name="deploymentExportPath">build/</property>
+  </engine>
+
+  <container default="true" qualifier="default">
+    <configuration>
+      <property name="jbossHome">${jboss.home}</property>
+      <!--<property name="javaVmArguments">-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005</property>-->
+      <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+      <property name="jbossArguments">${jboss.args:}</property>
+    </configuration>
+  </container>
+</arquillian>

--- a/asciidoctorj-wildfly-integration-test/src/test/resources/module.xml
+++ b/asciidoctorj-wildfly-integration-test/src/test/resources/module.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="org.asciidoctor.asciidoctorj">
+  <resources>
+    <resource-root path="asciidoctorj-api-@@version@@.jar"/>
+    <resource-root path="asciidoctorj-@@version@@.jar"/>
+    <!--resource-root path="asciidoctorj-pdf-1.5.0-alpha.6.jar"/-->
+    <resource-root path="jruby-complete-@@jrubyVersion@@.jar"/>
+
+    <!-- EPUB3 doesn't work with this configuration for now -->
+    <!--resource-root path="asciidoctorj-epub3-1.5.0-alpha.4.jar"/-->
+  </resources>
+
+  <dependencies>
+    <module name="sun.jdk" export="true" >
+      <imports>
+        <include path="sun/misc/Unsafe" />
+      </imports>
+    </module>
+    <module name="org.slf4j"/>
+  </dependencies>
+</module>

--- a/build.gradle
+++ b/build.gradle
@@ -122,23 +122,27 @@ subprojects {
     configFile = rootProject.file('config/codenarc/codenarc.groovy')
   }
 
-  dependencies {
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
-    testCompile("org.spockframework:spock-core:$spockVersion") {
-      exclude group: 'org.hamcrest', module: 'hamcrest-core'
-    }
-    testCompile "org.codehaus.groovy:groovy-all:$groovyVersion"
-    testCompile "org.jboss.arquillian.junit:arquillian-junit-container:$arquillianVersion"
-    testCompile "org.jboss.arquillian.spock:arquillian-spock-container:$arquillianSpockVersion"
+  if (it.name != 'asciidoctorj-wildfly-integration-test') {
 
-    codenarc "org.codehaus.groovy:groovy:$groovyVersion"
-    codenarc "org.codehaus.groovy:groovy-xml:$groovyVersion"
-    codenarc "org.codehaus.groovy:groovy-ant:$groovyVersion"
-    codenarc("org.codenarc:CodeNarc:$codenarcVersion") {
-      exclude group: 'org.codehaus.groovy'
+    dependencies {
+      testCompile "junit:junit:$junitVersion"
+      testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
+      testCompile("org.spockframework:spock-core:$spockVersion") {
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+      }
+      testCompile "org.codehaus.groovy:groovy-all:$groovyVersion"
+      testCompile "org.jboss.arquillian.junit:arquillian-junit-container:$arquillianVersion"
+      testCompile "org.jboss.arquillian.spock:arquillian-spock-container:$arquillianSpockVersion"
+
+      codenarc "org.codehaus.groovy:groovy:$groovyVersion"
+      codenarc "org.codehaus.groovy:groovy-xml:$groovyVersion"
+      codenarc "org.codehaus.groovy:groovy-ant:$groovyVersion"
+      codenarc("org.codenarc:CodeNarc:$codenarcVersion") {
+        exclude group: 'org.codehaus.groovy'
+      }
     }
   }
+
 
   test {
     forkEvery = 10
@@ -163,7 +167,7 @@ subprojects {
 
 }
 
-configure(subprojects.findAll { !it.isDistribution() && it.name != 'asciidoctorj-api' && it.name != 'asciidoctorj-documentation' && it.name != 'asciidoctorj-test-support' && it.name != 'asciidoctorj-arquillian-extension' }) {
+configure(subprojects.findAll { !it.isDistribution() && it.name != 'asciidoctorj-api' && it.name != 'asciidoctorj-documentation' && it.name != 'asciidoctorj-test-support' && it.name != 'asciidoctorj-arquillian-extension' && it.name != 'asciidoctorj-wildfly-integration-test' }) {
   apply from: rootProject.file('gradle/versioncheck.gradle')
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include \
   'asciidoctorj-epub3',
   'asciidoctorj-distribution',
   'asciidoctorj-documentation',
+  'asciidoctorj-wildfly-integration-test',
   'asciidoctorj-test-support'
 
 project(':asciidoctorj').projectDir = file('asciidoctorj-core')


### PR DESCRIPTION
This PR adds an integration test for Wildfly, which is special for AsciidoctorJ due to the jboss modules class loading.
As the Arquillian Wildfly seems to require an external installation this test currently can only be executed locally after installing Wildfly.
I was not aware that a Wildfly distribution can be downloaded from Maven central.

To run the test execute:
```
./gradlew clean integrationTest -Pjboss.home=<path to wildfly>
```

Thanks to @mgreau for providing the blueprint for this in the docker-asciidoctorj repo!