### PR TITLE
Add concurrent-ruby gem to AsciidoctorJ jar

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   gems "rubygems:open-uri-cached:$openUriCachedGemVersion"
   gems "rubygems:slim:$slimGemVersion"
   gems "rubygems:thread_safe:$threadSafeGemVersion"
+  gems "rubygems:concurrent-ruby:$concurrentRubyVersion"
   gems "rubygems:tilt:$tiltGemVersion"
   // TODO could use dependency replacement feature to fix version of Saxon-HE
   testCompile("org.xmlmatchers:xml-matchers:$xmlMatchersVersion") { exclude module: 'Saxon-HE' }

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ ext {
   hamlGemVersion = '4.0.5'
   openUriCachedGemVersion = '0.0.5'
   slimGemVersion = '3.0.6'
+  concurrentRubyVersion = '1.0.5'
   threadSafeGemVersion = '0.3.6'
   tiltGemVersion = '2.0.8'
 }


### PR DESCRIPTION
This PR adds the gem concurrent-ruby to the AsciidoctorJ jar that I missed in the 1.5.8 release.
After merging this I would create a new release 1.5.8.1.