### PR TITLE
Fix build of integrator guide on Windows

### DIFF
--- a/asciidoctorj-documentation/build.gradle
+++ b/asciidoctorj-documentation/build.gradle
@@ -5,7 +5,9 @@ dependencies {
     testCompile project(path: ':asciidoctorj-arquillian-extension')
     testCompile "commons-io:commons-io:$commonsioVersion"
     testCompile "org.jsoup:jsoup:$jsoupVersion"
-    testCompile "org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion"
+    testCompile("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
+        transitive = false
+    }
 }
 
 task processAsciidocFiles(type: Copy) {


### PR DESCRIPTION
Because asciidoctorj-pdf depends on jruby-complete.jar and asciidoctorj now depends on jruby.jar, both jars appeared in the dependencies, and to make it even worse with 2 different versions.
That cause the build error of asciidoctorj-documentation on Appveyor.