### PR TITLE
Replace deprecated constants and methods in the extension package

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockProcessor.java
@@ -22,7 +22,9 @@ public abstract class BlockProcessor extends Processor {
      * </verbatim>
      * </pre>
      * </p>
+     * @deprecated Please use {@link Contexts#KEY}
      */
+    @Deprecated
     public static final String CONTEXTS = "contexts";
 
     /**
@@ -35,7 +37,9 @@ public abstract class BlockProcessor extends Processor {
      * or it can masquerade as any other block.
      * --
      * </pre>
+     * @deprecated Please use {@link Contexts#OPEN}
      */
+    @Deprecated
     public static final String CONTEXT_OPEN = ":open";
 
     /**
@@ -47,7 +51,9 @@ public abstract class BlockProcessor extends Processor {
      * This is just a neat example.
      * ====
      * </pre>
+     * @deprecated Please use {@link Contexts#EXAMPLE}
      */
+    @Deprecated
     public static final String CONTEXT_EXAMPLE = ":example";
 
     /**
@@ -59,7 +65,9 @@ public abstract class BlockProcessor extends Processor {
      * This is just a sidebar.
      * ****
      * </pre>
+     * @deprecated Please use {@link Contexts#SIDEBAR}
      */
+    @Deprecated
     public static final String CONTEXT_SIDEBAR = ":sidebar";
 
     /**
@@ -71,7 +79,9 @@ public abstract class BlockProcessor extends Processor {
      * This is just a literal block.
      * ....
      * </pre>
+     * @deprecated Please use {@link Contexts#LITERAL}
      */
+    @Deprecated
     public static final String CONTEXT_LITERAL = ":literal";
 
     /**
@@ -83,7 +93,9 @@ public abstract class BlockProcessor extends Processor {
      * This is just a literal block.
      * ....
      * </pre>
+     * @deprecated Please use {@link Contexts#LISTING}
      */
+    @Deprecated
     public static final String CONTEXT_LISTING = ":listing";
 
     /**
@@ -95,7 +107,9 @@ public abstract class BlockProcessor extends Processor {
      * To be or not to be...
      * ____
      * </pre>
+     * @deprecated Please use {@link Contexts#QUOTE}
      */
+    @Deprecated
     public static final String CONTEXT_QUOTE = ":quote";
 
     /**
@@ -108,7 +122,9 @@ public abstract class BlockProcessor extends Processor {
      * &lt;h1&gt;Big text&lt;/h1&gt;
      * ++++
      * </pre>
+     * @deprecated Please use {@link Contexts#PASS}
      */
+    @Deprecated
     public static final String CONTEXT_PASS = ":pass";
 
     /**
@@ -122,7 +138,9 @@ public abstract class BlockProcessor extends Processor {
      *
      * And don't process this.
      * </pre>
+     * @deprecated Please use {@link Contexts#PARAGRAPH}
      */
+    @Deprecated
     public static final String CONTEXT_PARAGRAPH = ":paragraph";
 
     protected String name;
@@ -132,7 +150,7 @@ public abstract class BlockProcessor extends Processor {
     }
 
     public BlockProcessor(String name) {
-        this(name, new HashMap<String, Object>());
+        this(name, new HashMap<>());
     }
     
     public BlockProcessor(String name, Map<String, Object> config) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Contexts.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Contexts.java
@@ -49,6 +49,23 @@ import java.lang.annotation.Target;
 public @interface Contexts {
 
     /**
+     * This value is used as the config option key when defining the block type
+     * a Processor should process.
+     * Its value must be a list of String constants:
+     *
+     * <p>Example to make a BlockProcessor work on listings and examples named foo:
+     * <pre>
+     * <verbatim>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put(Contexts.KEY, Arrays.asList(Contexts.EXAMPLE, Contexts.LISTING));
+     * BlockProcessor blockProcessor = new BlockProcessor("foo", config);
+     * asciidoctor.javaExtensionRegistry().block(blockProcessor);
+     * </verbatim>
+     * </pre>
+     * </p>
+     */
+    String KEY = "contexts";
+    /**
      * Predefined constant for making a Processor work on open blocks.
      * <pre>
      * [foo]
@@ -58,7 +75,7 @@ public @interface Contexts {
      * --
      * </pre>
      */
-    public static final String OPEN = ":open";
+    String OPEN = ":open";
 
     /**
      * Predefined constant for making a Processor work on example blocks.
@@ -69,7 +86,7 @@ public @interface Contexts {
      * ====
      * </pre>
      */
-    public static final String EXAMPLE = ":example";
+    String EXAMPLE = ":example";
 
     /**
      * Predefined constant for making a Processor work on sidebar blocks.
@@ -80,7 +97,7 @@ public @interface Contexts {
      * ****
      * </pre>
      */
-    public static final String SIDEBAR = ":sidebar";
+    String SIDEBAR = ":sidebar";
 
     /**
      * Predefined constant for making a Processor work on literal blocks.
@@ -91,7 +108,7 @@ public @interface Contexts {
      * ....
      * </pre>
      */
-    public static final String LITERAL = ":literal";
+    String LITERAL = ":literal";
 
     /**
      * Predefined constant for making a Processor work on source blocks.
@@ -102,7 +119,7 @@ public @interface Contexts {
      * ....
      * </pre>
      */
-    public static final String LISTING = ":listing";
+    String LISTING = ":listing";
 
     /**
      * Predefined constant for making a Processor work on quote blocks.
@@ -113,7 +130,7 @@ public @interface Contexts {
      * ____
      * </pre>
      */
-    public static final String QUOTE = ":quote";
+    String QUOTE = ":quote";
 
     /**
      * Predefined constant for making a Processor work on passthrough blocks.
@@ -125,7 +142,7 @@ public @interface Contexts {
      * ++++
      * </pre>
      */
-    public static final String PASS = ":pass";
+    String PASS = ":pass";
 
     /**
      * Predefined constant for making a Processor work on paragraph blocks.
@@ -137,7 +154,7 @@ public @interface Contexts {
      * And don't process this.
      * </pre>
      */
-    public static final String PARAGRAPH = ":paragraph";
+    String PARAGRAPH = ":paragraph";
 
 
     String[] value();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Processor.java
@@ -129,11 +129,11 @@ public class Processor {
     private boolean configFinalized = false;
 
     public Processor() {
-        this(new HashMap<String, Object>());
+        this(new HashMap<>());
     }
 
     public Processor(Map<String, Object> config) {
-        this.config = new HashMap<String, Object>(config);
+        this.config = new HashMap<>(config);
     }
 
     public Map<String, Object> getConfig() {
@@ -160,7 +160,7 @@ public class Processor {
 
 
     public Table createTable(StructuralNode parent) {
-        return createTable(parent, new HashMap<String, Object>());
+        return createTable(parent, new HashMap<>());
     }
 
     public Table createTable(StructuralNode parent, Map<String, Object> attributes) {
@@ -173,7 +173,7 @@ public class Processor {
                 ((StructuralNodeImpl) parent).getRubyObject(),
                 rubyAttributes};
         Table ret = (Table) NodeConverter.createASTNode(rubyRuntime, TABLE_CLASS, parameters);
-        ret.setAttr("rowcount", 0, false);
+        ret.setAttribute("rowcount", 0, false);
         return ret;
     }
 
@@ -185,7 +185,7 @@ public class Processor {
     }
 
     public Column createTableColumn(Table parent, int index) {
-        return createTableColumn(parent, index, new HashMap<String, Object>());
+        return createTableColumn(parent, index, new HashMap<>());
     }
 
     public Column createTableColumn(Table parent, int index, Map<String, Object> attributes) {
@@ -203,11 +203,11 @@ public class Processor {
     }
 
     public Cell createTableCell(Column column, String text) {
-        return createTableCell(column, text, new HashMap<String, Object>());
+        return createTableCell(column, text, new HashMap<>());
     }
 
     public Cell createTableCell(Column column, Document innerDocument) {
-        return createTableCell(column, innerDocument, new HashMap<String, Object>());
+        return createTableCell(column, innerDocument, new HashMap<>());
     }
 
     public Cell createTableCell(Column column, Document innerDocument, Map<String, Object> attributes) {
@@ -232,11 +232,11 @@ public class Processor {
     }
 
     public Block createBlock(StructuralNode parent, String context, String content) {
-        return createBlock(parent, context, content, new HashMap<String, Object>(), new HashMap<Object, Object>());
+        return createBlock(parent, context, content, new HashMap<>(), new HashMap<>());
     }
 
     public Block createBlock(StructuralNode parent, String context, String content, Map<String, Object> attributes) {
-        return createBlock(parent, context, content, attributes, new HashMap<Object, Object>());
+        return createBlock(parent, context, content, attributes, new HashMap<>());
     }
 
     public Block createBlock(StructuralNode parent, String context, String content, Map<String, Object> attributes,
@@ -249,24 +249,24 @@ public class Processor {
     }
 
     public Block createBlock(StructuralNode parent, String context, List<String> content) {
-        return createBlock(parent, context, content, new HashMap<String, Object>(), new HashMap<Object, Object>());
+        return createBlock(parent, context, content, new HashMap<>(), new HashMap<>());
     }
 
     public Block createBlock(StructuralNode parent, String context, List<String> content, Map<String, Object> attributes) {
-        return createBlock(parent, context, content, attributes, new HashMap<Object, Object>());
+        return createBlock(parent, context, content, attributes, new HashMap<>());
     }
 
     public Block createBlock(StructuralNode parent, String context, List<String> content, Map<String, Object> attributes,
             Map<Object, Object> options) {
 
         options.put(Options.SOURCE, content);
-        options.put(Options.ATTRIBUTES, new HashMap<String, Object>(attributes));
+        options.put(Options.ATTRIBUTES, new HashMap<>(attributes));
         
         return createBlock(parent, context, options);
     }
 
     public Section createSection(StructuralNode parent) {
-        return createSection(parent, null, true, new HashMap<Object, Object>());
+        return createSection(parent, null, true, new HashMap<>());
     }
 
     public Section createSection(StructuralNode parent, Map<Object, Object> options) {
@@ -282,11 +282,11 @@ public class Processor {
     }
 
     public PhraseNode createPhraseNode(ContentNode parent, String context, List<String> text) {
-        return createPhraseNode(parent, context, text, new HashMap<String, Object>());
+        return createPhraseNode(parent, context, text, new HashMap<>());
     }
 
     public PhraseNode createPhraseNode(ContentNode parent, String context, List<String> text, Map<String, Object> attributes) {
-        return createPhraseNode(parent, context, text, attributes, new HashMap<Object, Object>());
+        return createPhraseNode(parent, context, text, attributes, new HashMap<>());
     }
 
     public PhraseNode createPhraseNode(ContentNode parent, String context, List<String> text, Map<String, Object> attributes, Map<Object, Object> options) {
@@ -310,11 +310,11 @@ public class Processor {
     }
 
     public PhraseNode createPhraseNode(ContentNode parent, String context, String text) {
-        return createPhraseNode(parent, context, text, new HashMap<String, Object>());
+        return createPhraseNode(parent, context, text, new HashMap<>());
     }
 
     public PhraseNode createPhraseNode(ContentNode parent, String context, String text, Map<String, Object> attributes) {
-        return createPhraseNode(parent, context, text, attributes, new HashMap<String, Object>());
+        return createPhraseNode(parent, context, text, attributes, new HashMap<>());
     }
 
     public PhraseNode createPhraseNode(ContentNode parent, String context, String text, Map<String, Object> attributes, Map<String, Object> options) {

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/ConfigModifyingBlockProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/ConfigModifyingBlockProcessor.groovy
@@ -1,5 +1,6 @@
 package org.asciidoctor.extension
 
+import org.asciidoctor.ast.ContentModel
 import org.asciidoctor.ast.StructuralNode
 
 class ConfigModifyingBlockProcessor extends BlockProcessor {
@@ -12,8 +13,8 @@ class ConfigModifyingBlockProcessor extends BlockProcessor {
         super(name)
 
         Map<String, Object> config = [:]
-        config[BlockProcessor.CONTEXTS] = [BlockProcessor.CONTEXT_PARAGRAPH]
-        config[Processor.CONTENT_MODEL] = Processor.CONTENT_MODEL_SIMPLE
+        config[Contexts.KEY] = [Contexts.PARAGRAPH]
+        config[ContentModel.KEY] = ContentModel.SIMPLE
         this.config = config
     }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenTheConfigIsSetOfAJavaExtension.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenTheConfigIsSetOfAJavaExtension.groovy
@@ -2,6 +2,7 @@ package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
 import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.ast.ContentModel
 import org.asciidoctor.internal.AsciidoctorCoreException
 import spock.lang.Specification
 
@@ -16,12 +17,12 @@ Parsing will crash when processing this block
         given:
         BlockProcessor blockProcessor = new ConfigModifyingBlockProcessor()
         Map<String, Object> config = [:]
-        config[BlockProcessor.CONTEXTS] = [BlockProcessor.CONTEXT_PARAGRAPH]
-        config[Processor.CONTENT_MODEL] = Processor.CONTENT_MODEL_SIMPLE
+        config[Contexts.KEY] = [Contexts.PARAGRAPH]
+        config[ContentModel.KEY] = ContentModel.SIMPLE
         blockProcessor.config = config
 
         expect:
-        blockProcessor.config[Processor.CONTENT_MODEL] == Processor.CONTENT_MODEL_SIMPLE
+        blockProcessor.config[ContentModel.KEY] == ContentModel.SIMPLE
     }
 
     def 'setConfig should throw an IllegalStateException in Processor_process when a processor instance is registered'() {
@@ -31,8 +32,8 @@ Parsing will crash when processing this block
 
         BlockProcessor blockProcessor = new ConfigModifyingBlockProcessor()
         Map<String, Object> config = [:]
-        config[BlockProcessor.CONTEXTS] = [BlockProcessor.CONTEXT_PARAGRAPH]
-        config[Processor.CONTENT_MODEL] = Processor.CONTENT_MODEL_SIMPLE
+        config[Contexts.KEY] = [Contexts.PARAGRAPH]
+        config[ContentModel.KEY] = ContentModel.SIMPLE
         blockProcessor.config = config
 
         asciidoctor.javaExtensionRegistry().block(blockProcessor)

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
@@ -4,6 +4,7 @@ import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.ast.ContentModel;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Section;
 import org.asciidoctor.ast.StructuralNode;
@@ -620,7 +621,7 @@ public class WhenJavaExtensionGroupIsRegistered {
     public void a_block_macro_as_instance_extension_should_be_executed_when_macro_is_detected() {
 
         Map<String, Object> options = new HashMap<String, Object>();
-        options.put(BlockMacroProcessor.CONTENT_MODEL, BlockMacroProcessor.CONTENT_MODEL_RAW);
+        options.put(ContentModel.KEY, ContentModel.RAW);
 
         this.asciidoctor.createGroup()
             .blockMacro(new GistMacro("gist", options))
@@ -792,8 +793,8 @@ public class WhenJavaExtensionGroupIsRegistered {
             throws IOException {
 
         Map<String, Object> config = new HashMap<String, Object>();
-        config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_PARAGRAPH));
-        config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
+        config.put(Contexts.KEY, Arrays.asList(Contexts.PARAGRAPH));
+        config.put(ContentModel.KEY, ContentModel.SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
         this.asciidoctor.createGroup()
             .block(yellBlock)
@@ -830,8 +831,8 @@ public class WhenJavaExtensionGroupIsRegistered {
             throws IOException {
 
         Map<String, Object> config = new HashMap<String, Object>();
-        config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_LISTING));
-        config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
+        config.put(Contexts.KEY, Arrays.asList(Contexts.LISTING));
+        config.put(ContentModel.KEY, ContentModel.SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
         this.asciidoctor.createGroup()
             .block(yellBlock)

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -4,6 +4,7 @@ import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.ast.ContentModel;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Section;
 import org.asciidoctor.ast.StructuralNode;
@@ -613,7 +614,7 @@ public class WhenJavaExtensionIsRegistered {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> options = new HashMap<String, Object>();
-        options.put(BlockMacroProcessor.CONTENT_MODEL, BlockMacroProcessor.CONTENT_MODEL_RAW);
+        options.put(ContentModel.KEY, ContentModel.RAW);
 
         javaExtensionRegistry.blockMacro(new GistMacro("gist", options));
 
@@ -803,8 +804,8 @@ public class WhenJavaExtensionIsRegistered {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> config = new HashMap<String, Object>();
-        config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_PARAGRAPH));
-        config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
+        config.put(BlockProcessor.CONTEXTS, Arrays.asList(Contexts.PARAGRAPH));
+        config.put(ContentModel.KEY, ContentModel.SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
         javaExtensionRegistry.block(yellBlock);
         String content = asciidoctor.renderFile(
@@ -824,8 +825,8 @@ public class WhenJavaExtensionIsRegistered {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> config = new HashMap<String, Object>();
-        config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_PARAGRAPH));
-        config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
+        config.put(Contexts.KEY, Arrays.asList(Contexts.PARAGRAPH));
+        config.put(ContentModel.KEY, ContentModel.SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
         javaExtensionRegistry.block(yellBlock);
 
@@ -910,8 +911,8 @@ public class WhenJavaExtensionIsRegistered {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         Map<String, Object> config = new HashMap<String, Object>();
-        config.put(BlockProcessor.CONTEXTS, Arrays.asList(BlockProcessor.CONTEXT_LISTING));
-        config.put(Processor.CONTENT_MODEL, Processor.CONTENT_MODEL_SIMPLE);
+        config.put(Contexts.KEY, Arrays.asList(Contexts.LISTING));
+        config.put(ContentModel.KEY, ContentModel.SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
         javaExtensionRegistry.block(yellBlock);
         String content = asciidoctor.renderFile(

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticListingBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticListingBlock.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.extension;
 
+import org.asciidoctor.ast.ContentModel;
 import org.asciidoctor.ast.StructuralNode;
 
 import java.util.Arrays;
@@ -9,10 +10,10 @@ import java.util.Map;
 
 public class YellStaticListingBlock extends BlockProcessor {
 
-	private static Map<String, Object> configs = new HashMap<String, Object>() {{
-        put(CONTEXTS, Arrays.asList(CONTEXT_LISTING));
-        put(CONTENT_MODEL, CONTENT_MODEL_SIMPLE);
-	}};
+    private static Map<String, Object> configs = new HashMap<String, Object>() {{
+        put(Contexts.KEY, Arrays.asList(Contexts.LISTING));
+        put(ContentModel.KEY, ContentModel.SIMPLE);
+    }};
 
     public YellStaticListingBlock(String name) {
         super(name, configs);
@@ -29,13 +30,12 @@ public class YellStaticListingBlock extends BlockProcessor {
         for (String line : lines) {
             if (upperLines == null) {
                 upperLines = line.toUpperCase();
-            }
-            else {
+            } else {
                 upperLines = upperLines + "\n" + line.toUpperCase();
             }
         }
 
-		return createBlock(parent, "paragraph", Arrays.asList(upperLines), attributes, new HashMap<Object, Object>());
+        return createBlock(parent, "paragraph", Arrays.asList(upperLines), attributes, new HashMap<>());
     }
 
 }


### PR DESCRIPTION
- @deprecated BlockProcessor context constants (replaced by Contexts)
- should we remove Processor constants ?
- Use diamond where possible `Map<String, String> config = new HashMap<>()`
- Reformat code (tabs -> spaces)