### PR TITLE
Move extension annotations and enums to the API module

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Contexts.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Contexts.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation defines what type of blocks a {@link BlockProcessor} processes.
+ * This annotation defines what type of blocks a BlockProcessor processes.
  * Example for a BlockProcessor that transforms all open blocks with the name {@code yell} to upper case:
  * <pre><code>
  * &#64;Name("yell")

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/DefaultAttribute.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/DefaultAttribute.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation allows to define multiple {@link DefaultAttribute} annotations for one type.
+ * Defines default attributes passed to the {@code process()} method of a processor.
  * <p>Applicable for:
  * <table>
  * <tr><td>BlockMacroProcessor</td><td>&#10003;</td></tr>
@@ -24,8 +24,10 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface DefaultAttributes {
+public @interface DefaultAttribute {
 
-    public DefaultAttribute[] value();
+    String key();
+
+    String value();
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/DefaultAttributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/DefaultAttributes.java
@@ -7,16 +7,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Use this annotation to define the block name handled by a {@link BlockProcessor}, or the macro name of a
- * {@link BlockMacroProcessor} or {@link InlineMacroProcessor}.
+ * This annotation allows to define multiple {@link DefaultAttribute} annotations for one type.
  * <p>Applicable for:
  * <table>
  * <tr><td>BlockMacroProcessor</td><td>&#10003;</td></tr>
  * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
  * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
  * <tr><td>DocInfoProcessor</td><td></td></tr>
- * <tr><td>IncludeProcessor</td><td></td></tr>
- * <tr><td>InlineMacroProcessor</td><td></td></tr>
+ * <tr><td>IncludeProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>InlineMacroProcessor</td><td>&#10003;</td></tr>
  * <tr><td>Postprocessor</td><td></td></tr>
  * <tr><td>Preprocessor</td><td></td></tr>
  * <tr><td>Treeprocessor</td><td></td></tr>
@@ -25,8 +24,8 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface Name {
+public @interface DefaultAttributes {
 
-    String value();
+    DefaultAttribute[] value();
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Format.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Format.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation defines how an {@link InlineMacroProcessor} is applied.
+ * This annotation defines how an InlineMacroProcessor is applied.
  * Possible values are:
  * <dl>
  *  <dt>{@link FormatType#LONG}</dt>
@@ -36,8 +36,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface Format {
 
-    public FormatType value() default FormatType.CUSTOM;
+    FormatType value() default FormatType.CUSTOM;
 
-    public String regexp() default "";
+    String regexp() default "";
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/FormatType.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/FormatType.java
@@ -1,16 +1,16 @@
 package org.asciidoctor.extension;
 
 /**
- * Location used by the {@link Location} annotation.
+ * Inline macro format used by the {@link Format} annotation.
  */
-public enum LocationType {
-
-    HEADER(":head"),
-    FOOTER(":footer");
+public enum FormatType {
+    LONG(":long"),
+    SHORT(":short"),
+    CUSTOM(":regexp");
 
     private final String optionValue;
 
-    private LocationType(String optionValue) {
+    FormatType(String optionValue) {
         this.optionValue = optionValue;
     }
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Location.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Location.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation defines the location where the content created by a {@link DocinfoProcessor} will be added.
+ * This annotation defines the location where the content created by a DocinfoProcessor will be added.
  * <p>The following example will add a robots meta tag to the head element of the resulting HTML document:
  * <pre>
  * <ode>
@@ -40,6 +40,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface Location {
 
-    public LocationType value() default LocationType.HEADER;
+    LocationType value() default LocationType.HEADER;
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/LocationType.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/LocationType.java
@@ -1,16 +1,16 @@
 package org.asciidoctor.extension;
 
 /**
- * Inline macro format used by the {@link Format} annotation.
+ * Location used by the {@link Location} annotation.
  */
-public enum FormatType {
-    LONG(":long"),
-    SHORT(":short"),
-    CUSTOM(":regexp");
+public enum LocationType {
+
+    HEADER(":head"),
+    FOOTER(":footer");
 
     private final String optionValue;
 
-    private FormatType(String optionValue) {
+    LocationType(String optionValue) {
         this.optionValue = optionValue;
     }
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Name.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Name.java
@@ -7,15 +7,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines default attributes passed to the {@code process()} method of a processor.
+ * Use this annotation to define the block name handled by a BlockProcessor, or the macro name of a
+ * BlockMacroProcessor or InlineMacroProcessor.
  * <p>Applicable for:
  * <table>
  * <tr><td>BlockMacroProcessor</td><td>&#10003;</td></tr>
  * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
  * <tr><td>BlockProcessor</td><td>&#10003;</td></tr>
  * <tr><td>DocInfoProcessor</td><td></td></tr>
- * <tr><td>IncludeProcessor</td><td>&#10003;</td></tr>
- * <tr><td>InlineMacroProcessor</td><td>&#10003;</td></tr>
+ * <tr><td>IncludeProcessor</td><td></td></tr>
+ * <tr><td>InlineMacroProcessor</td><td></td></tr>
  * <tr><td>Postprocessor</td><td></td></tr>
  * <tr><td>Preprocessor</td><td></td></tr>
  * <tr><td>Treeprocessor</td><td></td></tr>
@@ -24,10 +25,8 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface DefaultAttribute {
+public @interface Name {
 
-    public String key();
-
-    public String value();
+    String value();
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/PositionalAttributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/PositionalAttributes.java
@@ -45,6 +45,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface PositionalAttributes {
 
-    public String[] value();
+    String[] value();
 
 }


### PR DESCRIPTION
I had to remove javadoc `@link` on `*Processor` classes because we cannot move them without decoupling the implementation (see #715).

Apart from that, I think it's safe to merge.