### PR TITLE
Use diamond, remove unnecessary public keyword on interfaces

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockMacroProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/BlockMacroProcessor.java
@@ -8,11 +8,11 @@ import java.util.Map;
 public abstract class BlockMacroProcessor extends MacroProcessor<StructuralNode> {
 
     public BlockMacroProcessor() {
-        this(null, new HashMap<String, Object>());
+        this(null, new HashMap<>());
     }
 
     public BlockMacroProcessor(String macroName) {
-        this(macroName, new HashMap<String, Object>());
+        this(macroName, new HashMap<>());
     }
     
     public BlockMacroProcessor(String macroName, Map<String, Object> config) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DocinfoProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/DocinfoProcessor.java
@@ -8,7 +8,7 @@ import java.util.Map;
 public abstract class DocinfoProcessor extends Processor {
 
     public DocinfoProcessor() {
-        super(new HashMap<String, Object>());
+        super(new HashMap<>());
     }
 
     public DocinfoProcessor(Map<String, Object> config) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionGroup.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ExtensionGroup.java
@@ -23,64 +23,64 @@ import java.io.InputStream;
  */
 public interface ExtensionGroup {
 
-  public void register();
+  void register();
 
-  public void unregister();
+  void unregister();
 
-  public ExtensionGroup docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor);
-  public ExtensionGroup docinfoProcessor(DocinfoProcessor docInfoProcessor);
-  public ExtensionGroup docinfoProcessor(String docInfoProcessor);
+  ExtensionGroup docinfoProcessor(Class<? extends DocinfoProcessor> docInfoProcessor);
+  ExtensionGroup docinfoProcessor(DocinfoProcessor docInfoProcessor);
+  ExtensionGroup docinfoProcessor(String docInfoProcessor);
 
-  public ExtensionGroup preprocessor(Class<? extends Preprocessor> preprocessor);
-  public ExtensionGroup preprocessor(Preprocessor preprocessor);
-  public ExtensionGroup preprocessor(String preprocessor);
+  ExtensionGroup preprocessor(Class<? extends Preprocessor> preprocessor);
+  ExtensionGroup preprocessor(Preprocessor preprocessor);
+  ExtensionGroup preprocessor(String preprocessor);
 
-  public ExtensionGroup postprocessor(String postprocessor);
-  public ExtensionGroup postprocessor(Class<? extends Postprocessor> postprocessor);
-  public ExtensionGroup postprocessor(Postprocessor postprocesor);
+  ExtensionGroup postprocessor(String postprocessor);
+  ExtensionGroup postprocessor(Class<? extends Postprocessor> postprocessor);
+  ExtensionGroup postprocessor(Postprocessor postprocesor);
 
-  public ExtensionGroup includeProcessor(String includeProcessor);
-  public ExtensionGroup includeProcessor(Class<? extends IncludeProcessor> includeProcessor);
-  public ExtensionGroup includeProcessor(IncludeProcessor includeProcessor);
+  ExtensionGroup includeProcessor(String includeProcessor);
+  ExtensionGroup includeProcessor(Class<? extends IncludeProcessor> includeProcessor);
+  ExtensionGroup includeProcessor(IncludeProcessor includeProcessor);
 
-  public ExtensionGroup treeprocessor(Treeprocessor treeprocessor);
-  public ExtensionGroup treeprocessor(Class<? extends Treeprocessor> treeProcessor);
-  public ExtensionGroup treeprocessor(String treeProcessor);
+  ExtensionGroup treeprocessor(Treeprocessor treeprocessor);
+  ExtensionGroup treeprocessor(Class<? extends Treeprocessor> treeProcessor);
+  ExtensionGroup treeprocessor(String treeProcessor);
 
-  public ExtensionGroup block(String blockName, String blockProcessor);
-  public ExtensionGroup block(String blockProcessor);
-  public ExtensionGroup block(String blockName, Class<? extends BlockProcessor> blockProcessor);
-  public ExtensionGroup block(Class<? extends BlockProcessor> blockProcessor);
-  public ExtensionGroup block(String blockName, BlockProcessor blockProcessor);
-  public ExtensionGroup block(BlockProcessor blockProcessor);
+  ExtensionGroup block(String blockName, String blockProcessor);
+  ExtensionGroup block(String blockProcessor);
+  ExtensionGroup block(String blockName, Class<? extends BlockProcessor> blockProcessor);
+  ExtensionGroup block(Class<? extends BlockProcessor> blockProcessor);
+  ExtensionGroup block(String blockName, BlockProcessor blockProcessor);
+  ExtensionGroup block(BlockProcessor blockProcessor);
 
-  public ExtensionGroup blockMacro(String blockName, Class<? extends BlockMacroProcessor> blockMacroProcessor);
-  public ExtensionGroup blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor);
-  public ExtensionGroup blockMacro(String blockName, String blockMacroProcessor);
-  public ExtensionGroup blockMacro(String blockMacroProcessor);
-  public ExtensionGroup blockMacro(BlockMacroProcessor blockMacroProcessor);
+  ExtensionGroup blockMacro(String blockName, Class<? extends BlockMacroProcessor> blockMacroProcessor);
+  ExtensionGroup blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor);
+  ExtensionGroup blockMacro(String blockName, String blockMacroProcessor);
+  ExtensionGroup blockMacro(String blockMacroProcessor);
+  ExtensionGroup blockMacro(BlockMacroProcessor blockMacroProcessor);
 
-  public ExtensionGroup inlineMacro(InlineMacroProcessor inlineMacroProcessor);
-  public ExtensionGroup inlineMacro(String name, Class<? extends InlineMacroProcessor> inlineMacroProcessor);
-  public ExtensionGroup inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor);
-  public ExtensionGroup inlineMacro(String name, String inlineMacroProcessor);
-  public ExtensionGroup inlineMacro(String inlineMacroProcessor);
+  ExtensionGroup inlineMacro(InlineMacroProcessor inlineMacroProcessor);
+  ExtensionGroup inlineMacro(String name, Class<? extends InlineMacroProcessor> inlineMacroProcessor);
+  ExtensionGroup inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor);
+  ExtensionGroup inlineMacro(String name, String inlineMacroProcessor);
+  ExtensionGroup inlineMacro(String inlineMacroProcessor);
 
-  public ExtensionGroup requireRubyLibrary(String requiredLibrary);
-  public ExtensionGroup loadRubyClass(InputStream rubyClassStream);
+  ExtensionGroup requireRubyLibrary(String requiredLibrary);
+  ExtensionGroup loadRubyClass(InputStream rubyClassStream);
 
-  public ExtensionGroup rubyPreprocessor(String preprocessor);
-  public ExtensionGroup rubyPostprocessor(String postprocessor);
-  public ExtensionGroup rubyDocinfoProcessor(String docinfoProcessor);
-  public ExtensionGroup rubyIncludeProcessor(String includeProcessor);
-  public ExtensionGroup rubyTreeprocessor(String treeProcessor);
+  ExtensionGroup rubyPreprocessor(String preprocessor);
+  ExtensionGroup rubyPostprocessor(String postprocessor);
+  ExtensionGroup rubyDocinfoProcessor(String docinfoProcessor);
+  ExtensionGroup rubyIncludeProcessor(String includeProcessor);
+  ExtensionGroup rubyTreeprocessor(String treeProcessor);
 
-  public ExtensionGroup rubyBlock(String blockName, String blockProcessor);
-  public ExtensionGroup rubyBlock(String blockProcessor);
+  ExtensionGroup rubyBlock(String blockName, String blockProcessor);
+  ExtensionGroup rubyBlock(String blockProcessor);
 
-  public ExtensionGroup rubyBlockMacro(String blockName, String blockMacroProcessor);
-  public ExtensionGroup rubyBlockMacro(String blockMacroProcessor);
+  ExtensionGroup rubyBlockMacro(String blockName, String blockMacroProcessor);
+  ExtensionGroup rubyBlockMacro(String blockMacroProcessor);
 
-  public ExtensionGroup rubyInlineMacro(String macroName, String inlineMacroProcessor);
-  public ExtensionGroup rubyInlineMacro(String inlineMacroProcessor);
+  ExtensionGroup rubyInlineMacro(String macroName, String inlineMacroProcessor);
+  ExtensionGroup rubyInlineMacro(String inlineMacroProcessor);
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/IncludeProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/IncludeProcessor.java
@@ -8,7 +8,7 @@ import org.asciidoctor.ast.Document;
 public abstract class IncludeProcessor extends Processor {
 
     public IncludeProcessor() {
-        this(new HashMap<String, Object>());
+        this(new HashMap<>());
     }
     
     public IncludeProcessor(Map<String, Object> config) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
@@ -32,7 +32,7 @@ public abstract class InlineMacroProcessor extends MacroProcessor<ContentNode> {
     }
 
     public InlineMacroProcessor(String macroName) {
-        this(macroName, new HashMap<String, Object>());
+        this(macroName, new HashMap<>());
     }
     
     public InlineMacroProcessor(String macroName, Map<String, Object> config) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/MacroProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/MacroProcessor.java
@@ -10,7 +10,7 @@ public abstract class MacroProcessor<T extends ContentNode> extends Processor {
     protected String name;
     
     public MacroProcessor(String name) {
-        this(name, new HashMap<String, Object>());
+        this(name, new HashMap<>());
     }
     
     public MacroProcessor(String name, Map<String, Object> config) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Postprocessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Postprocessor.java
@@ -8,7 +8,7 @@ import org.asciidoctor.ast.Document;
 public abstract class Postprocessor extends Processor {
 
     public Postprocessor() {
-        this(new HashMap<String, Object>());
+        this(new HashMap<>());
     }
     
     public Postprocessor(Map<String, Object> config) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Preprocessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Preprocessor.java
@@ -8,7 +8,7 @@ import org.asciidoctor.ast.Document;
 public abstract class Preprocessor extends Processor {
 
     public Preprocessor() {
-        this(new HashMap<String, Object>());
+        this(new HashMap<>());
     }
     
     public Preprocessor(Map<String, Object> config) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Treeprocessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/Treeprocessor.java
@@ -8,7 +8,7 @@ import org.asciidoctor.ast.Document;
 public abstract class Treeprocessor extends Processor {
 
     public Treeprocessor() {
-        this(new HashMap<String, Object>());
+        this(new HashMap<>());
     }
     
     public Treeprocessor(Map<String, Object> config) {


### PR DESCRIPTION
A little code cleanup in the extension package (to reduce the code changes in #715).

If you want to do a single commit to use diamond operator everywhere I can do it. I can also remove the unnecessary `public` keyword from interfaces at once ?