### PR TITLE
OSGi snippets update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-discuss: http://discuss.asciidoctor.org
-:artifact-version: 1.5.7
+:artifact-version: 1.5.8.1
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
 :uri-maven-artifact-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}
@@ -1818,25 +1818,20 @@ import org.asciidoctor.Asciidoctor;
 Asciidoctor asciidoctor = create();
 ----
 
-In an OSGi context it will not work because JRuby needs some paths to find the gems (the Asciidoctor ones and the Ruby themselves ones). In order to make it work, you will need two more classes (RubyInstanceConfig and JavaEmbedUtils) and a small modification of the previous snippet of code. The modifications take care of the class loaders because in OSGi, which are a key point in OSGi:
+In an OSGi context it will not work because JRuby needs some paths to find the Asciidoctor gems. In order to make it work, you will need to specify the Asiciidoctor gems path using the JavaEmbedUtils class. We will update the previous snippet of code to specify this path:
 
 [source,java]
 ----
 import static org.asciidoctor.Asciidoctor.Factory.create;
 import org.asciidoctor.Asciidoctor;
 
-RubyInstanceConfig config = new RubyInstanceConfig();
-config.setLoader(this.getClass().getClassLoader()); <1>
+JavaEmbedUtils.initialize(Arrays.asList("uri:classloader:/gems/asciidoctor-1.5.8/lib")); <1><2>
 
-JavaEmbedUtils.initialize(Arrays.asList("META-INF/jruby.home/lib/ruby/2.0", "gems/asciidoctor-1.5.4/lib"), config); <2><3><4>
-
-Asciidoctor asciidoctor = create(this.getClass().getClassLoader()); <5>
+Asciidoctor asciidoctor = create(this.getClass().getClassLoader()); <3>
 ----
-<1> The RubyInstanceConfig will use the class loader of the OSGi bundle ;
-<2> The JavaEmbedUtils will specify the load paths of the required gems. If they are not specified, you will get JRuby exceptions ;
-<3> `META-INF/jruby.home/lib/ruby/2.0` specifies where the Ruby gems are located. Actually this path is located inside the `jruby-complete-<version>.jar` file. Without having this path specified you may get an `org.jruby.exceptions.RaiseException: (LoadError) no such file to load -- set` error ;
-<4> `gems/asciidoctor-<version>/lib` specifies where the gems for Asciidoctor are located. Actually this path is located inside the `asciidoctorj-<version>.jar` file ;
-<5> The factory for the Asciidoctor object also specify the class loader to use.
+<1> The JavaEmbedUtils will specify the load paths of the required gems. If they are not specified, you will get JRuby exceptions ;
+<2> `uri:classloader:/gems/asciidoctor-<version>/lib` specifies where the gems for Asciidoctor are located. Actually this path is located inside the `asciidoctorj-<version>.jar` file ;
+<3> The factory for the Asciidoctor object also specify the class loader to use.
 
 [NOTE]
 We consider this code to be placed inside an OSGi bundle
@@ -1846,7 +1841,6 @@ This solution has pros and cons:
 * _Pros:_ you don't need to extract the gems located in the asciidoctorj binary ;
 * _Cons:_
 ** the version of asciidoctor is hard coded ;
-** the version of ruby is hard coded.
 
 == Optimization
 


### PR DESCRIPTION
Since version `1.5.7` of asciidoctorj, the given snippets for using it in an OSGi didn't work anymore as the JRuby dependency has changed to version 9.x. This make the use of the RubyInstanceConfig useless and not working.

Moreover, the load path passed to the `JavaEmbedUtils#initialize` should be prefix with `uri:classloader`. I didn't find another solution for make it work. The solution has been integrated in [SlideshowFX](https://github.com/twasyl/SlideshowFX/blob/dae814bfbc6bccbf09033adc8223d97ab41d18d3/slideshowfx-asciidoctor/src/main/java/com/twasyl/slideshowfx/markup/asciidoctor/AsciidoctorMarkup.java#L28) using asciidoctorj 1.5.8.1.

Also update the artifact version in the documentation.