### PR TITLE
Bump JRuby to 9.2.2.0

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   compile("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
     transitive = false
   }
-  compile 'org.jruby:jruby-complete:9.2.2.0'
+  compile 'org.jruby:jruby-complete:9.2.3.0'
 }
 
 jar.enabled = false

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   compile("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
     transitive = false
   }
-  compile 'org.jruby:jruby-complete:9.1.17.0'
+  compile 'org.jruby:jruby-complete:9.2.2.0'
 }
 
 jar.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '9.1.17.0'
+  jrubyVersion = '9.2.2.0'
   jsoupVersion = '1.8.3'
   junitVersion = '4.12'
   saxonVersion = '9.5.1-6'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '9.2.2.0'
+  jrubyVersion = '9.2.3.0'
   jsoupVersion = '1.8.3'
   junitVersion = '4.12'
   saxonVersion = '9.5.1-6'


### PR DESCRIPTION
This PR bumps JRuby to the latest version for the 1.5.x branch.
We might not need it anymore, but if we come into the situation that we do another release we should have the latest version of JRuby.
