### PR TITLE
Revert #712

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -811,26 +811,36 @@ public interface Asciidoctor {
         }
 
         /**
-         * Creates a new instance of Asciidoctor and sets a specific classloader for the  JRuby runtime to use. This method is mostly
-         * used in environments where different threads may have different classloaders, like build tools sbt or ANT.
+         * Creates a new instance of Asciidoctor and sets a specific classloader for the  JRuby runtime to use.
+         * This method is for use in environments like OSGi.
+         * To initialize Asciidoctor in OSGi create the Asciidoctor instance like this:
+         *
+         * <pre>
+         * org.jruby.javasupport.JavaEmbedUtils.initialize(Arrays.asList("uri:classloader:/gems/asciidoctor-1.5.8/lib"));
+         * Asciidoctor asciidoctor = Asciidoctor.Factory.create(this.getClass().getClassLoader()); <3>
+         * </pre>
          *
          * @param classloader
          * @return Asciidoctor instance which uses JRuby to wraps Asciidoctor
          *         Ruby calls.
-         * @deprecated Please use {@link #create()} and set the TCCL before or {@link #create(List)} passing the paths
-         * that you would have used to create the ClassLoader.
          */
         public static Asciidoctor create(ClassLoader classloader) {
             return JRubyAsciidoctor.create(classloader);
         }
 
         /**
-         * Cerates a new instance of Asciidoctor and sets a specific classloader and gempath for the JRuby runtime to use.
+         * Creates a new instance of Asciidoctor and sets a specific classloader and gempath for the JRuby runtime to use.
+         * This method is for use in environments like OSGi.
+         * To initialize Asciidoctor in OSGi create the Asciidoctor instance like this:
+         *
+         * <pre>
+         * org.jruby.javasupport.JavaEmbedUtils.initialize(Arrays.asList("uri:classloader:/gems/asciidoctor-1.5.8/lib"));
+         * Asciidoctor asciidoctor = Asciidoctor.Factory.create(this.getClass().getClassLoader()); <3>
+         * </pre>
+         * 
          * @param classloader
          * @param gemPath
          * @return Asciidoctor instance which uses JRuby to wraps Asciidoctor
-         * @deprecated Please use {@link #create(String)} and set the TCCL before or {@link #create(List, String)}
-         * passing the paths that you would have used to create the ClassLoader.
          */
         public static Asciidoctor create(ClassLoader classloader, String gemPath) {
             return JRubyAsciidoctor.create(classloader, gemPath);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -811,6 +811,32 @@ public interface Asciidoctor {
         }
 
         /**
+         * Creates a new instance of Asciidoctor and sets a specific classloader for the  JRuby runtime to use. This method is mostly
+         * used in environments where different threads may have different classloaders, like build tools sbt or ANT.
+         *
+         * @param classloader
+         * @return Asciidoctor instance which uses JRuby to wraps Asciidoctor
+         *         Ruby calls.
+         * @deprecated Please use {@link #create()} and set the TCCL before or {@link #create(List)} passing the paths
+         * that you would have used to create the ClassLoader.
+         */
+        public static Asciidoctor create(ClassLoader classloader) {
+            return JRubyAsciidoctor.create(classloader);
+        }
+
+        /**
+         * Cerates a new instance of Asciidoctor and sets a specific classloader and gempath for the JRuby runtime to use.
+         * @param classloader
+         * @param gemPath
+         * @return Asciidoctor instance which uses JRuby to wraps Asciidoctor
+         * @deprecated Please use {@link #create(String)} and set the TCCL before or {@link #create(List, String)}
+         * passing the paths that you would have used to create the ClassLoader.
+         */
+        public static Asciidoctor create(ClassLoader classloader, String gemPath) {
+            return JRubyAsciidoctor.create(classloader, gemPath);
+        }
+
+        /**
          * Creates a new instance of Asciidoctor and sets loadPath to provided paths.
          * The gem path of the Ruby instance is set to the gemPath parameter.
          *

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JRubyAsciidoctor.java
@@ -79,15 +79,23 @@ public class JRubyAsciidoctor implements Asciidoctor, LogHandler {
     }
 
     public static JRubyAsciidoctor create(String gemPath) {
-        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), new ArrayList<>()));
+        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), new ArrayList<String>(), null));
     }
 
     public static JRubyAsciidoctor create(List<String> loadPaths) {
-        return processRegistrations(createJRubyAsciidoctorInstance(null, loadPaths));
+        return processRegistrations(createJRubyAsciidoctorInstance(null, loadPaths, null));
+    }
+
+    public static JRubyAsciidoctor create(ClassLoader classloader) {
+        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<String>(), classloader));
+    }
+
+    public static JRubyAsciidoctor create(ClassLoader classloader, String gemPath) {
+        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), new ArrayList<String>(), classloader));
     }
 
     public static JRubyAsciidoctor create(List<String> loadPaths, String gemPath) {
-        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), loadPaths));
+        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), loadPaths, null));
     }
 
     private static JRubyAsciidoctor processRegistrations(JRubyAsciidoctor asciidoctor) {
@@ -109,11 +117,15 @@ public class JRubyAsciidoctor implements Asciidoctor, LogHandler {
         new LogHandlerRegistryExecutor(asciidoctor).registerAllLogHandlers();
     }
 
-    private static JRubyAsciidoctor createJRubyAsciidoctorInstance(Map<String, String> environmentVars, List<String> loadPaths) {
+    private static JRubyAsciidoctor createJRubyAsciidoctorInstance(Map<String, String> environmentVars, List<String> loadPaths, ClassLoader classloader) {
 
-        Map<String, String> env = environmentVars != null ? new HashMap<>(environmentVars) : new HashMap<>();
+        Map<String, String> env = environmentVars != null ?
+                new HashMap<String, String>(environmentVars) : new HashMap<String, String>();
 
         RubyInstanceConfig config = createOptimizedConfiguration();
+        if (classloader != null) {
+            config.setLoader(classloader);
+        }
         injectEnvironmentVariables(config, env);
 
         Ruby rubyRuntime = JavaEmbedUtils.initialize(loadPaths, config);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenClassloaderIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/internal/WhenClassloaderIsRequired.java
@@ -1,34 +1,32 @@
 package org.asciidoctor.internal;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import org.asciidoctor.Asciidoctor;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-class AsciiDoctorJClassloaderTestRunnable implements Runnable {
+ class AsciiDoctorJClassloaderTestRunnable implements Runnable {
     private boolean loadingsucceeded = false;
     private ClassLoader classloader = null;
 
-    public boolean getLoadingsucceeded() {
+    public boolean getLoadingsucceeded(){
         return loadingsucceeded;
     }
 
-    public void setClassloader(ClassLoader newclassloader) {
-        classloader = newclassloader;
-    }
+     public void setClassloader(ClassLoader newclassloader){
+         classloader = newclassloader;
+     }
 
     public void run() {
-        try {
-            if (classloader == null) {
+        try{
+            if(classloader == null) {
                 Asciidoctor.Factory.create();
             } else {
-                Thread.currentThread().setContextClassLoader(classloader);
-                Asciidoctor.Factory.create();
+                Asciidoctor.Factory.create(classloader);
             }
             loadingsucceeded = true;
-        } catch (org.jruby.exceptions.RaiseException exp) {
+        } catch(org.jruby.exceptions.RaiseException exp) {
             loadingsucceeded = false;
         }
     }
@@ -45,11 +43,11 @@ public class WhenClassloaderIsRequired {
      */
     @Test
     @Ignore("Behavior changed in JRuby 9000. It no longer only uses the TCCL by default")
-    public void contentsOfJRubyCompleteShouldFailToLoadWithoutPassingClassloader() throws Exception {
-        ClassLoader currentclassloader = this.getClass().getClassLoader();
-        ClassLoader rootclassloader = currentclassloader.getParent();
+    public void contentsOfJRubyCompleteShouldFailToLoadWithoutPassingClassloader() throws Exception{
+        ClassLoader currentclassloader =  this.getClass().getClassLoader();
+        ClassLoader rootclassloader =  currentclassloader.getParent();
         AsciiDoctorJClassloaderTestRunnable runnable = new AsciiDoctorJClassloaderTestRunnable();
-        final Thread thread = new Thread(runnable);
+        final Thread thread = new Thread( runnable );
         // make the thread use  classloader context  without JRuby and all
         thread.setContextClassLoader(rootclassloader);
         thread.start();
@@ -58,12 +56,12 @@ public class WhenClassloaderIsRequired {
     }
 
     @Test
-    public void contentsOfJRubyCompleteShouldSucceedWhenPassingTheCorrectClassloader() throws Exception {
-        ClassLoader currentclassloader = this.getClass().getClassLoader();
-        ClassLoader rootclassloader = currentclassloader.getParent();
+    public void contentsOfJRubyCompleteShouldSucceedWhenPassingTheCorrectClassloader() throws Exception{
+        ClassLoader currentclassloader =  this.getClass().getClassLoader();
+        ClassLoader rootclassloader =  currentclassloader.getParent();
         AsciiDoctorJClassloaderTestRunnable runnable = new AsciiDoctorJClassloaderTestRunnable();
         runnable.setClassloader(currentclassloader);
-        final Thread thread = new Thread(runnable);
+        final Thread thread = new Thread( runnable );
         // make the thread use  classloader context  without JRuby and all
         thread.setContextClassLoader(rootclassloader);
         thread.start();


### PR DESCRIPTION
This PR reverts #712 again.
Apparently (see #721) the create methods that take a Classloader are required to use AsciidoctorJ in OSGi environments.
Until we can offer alternatives we should therefore keep these methods.