### PR TITLE
Bump JRuby to 9.2.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '9.2.3.0'
+  jrubyVersion = '9.2.4.0'
   jsoupVersion = '1.10.2'
   junitVersion = '4.12'
   nettyVersion = '4.0.33.Final'


### PR DESCRIPTION
Looks like the JRuby release train is rolling fast atm.
So here is the next bump.