### PR TITLE
Remove deprecation

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Block.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Block.java
@@ -7,6 +7,7 @@ public interface Block extends StructuralNode {
      * @deprecated Please use {@link #getLines}
      * @return The original content of this block
      */
+    @Deprecated
     List<String> lines();
 
     /**
@@ -24,6 +25,7 @@ public interface Block extends StructuralNode {
      * @deprecated Please use {@link #getSource}
      * @return the String containing the lines joined together or null if there are no lines
      */
+    @Deprecated
     String source();
 
     /**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Cell.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Cell.java
@@ -83,7 +83,7 @@ public interface Cell extends ContentNode {
     Document getInnerDocument();
 
     /**
-     * @see {@link #getInnerDocument()}
+     * @see #getInnerDocument()
      */
     void setInnerDocument(Document document);
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentModel.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentModel.java
@@ -43,42 +43,42 @@ public @interface ContentModel {
      * </pre>
      * </p>
      */
-    public static final String KEY = "content_model";
+    String KEY = "content_model";
 
     /**
      * Predefined constant to let Asciidoctor know that this BlockProcessor creates zero or more child blocks.
      */
-    public static final String COMPOUND = ":compound";
+    String COMPOUND = ":compound";
 
     /**
      * Predefined constant to let Asciidoctor know that this BlockProcessor creates simple paragraph content.
      */
-    public static final String SIMPLE = ":simple";
+    String SIMPLE = ":simple";
 
     /**
      * Predefined constant to let Asciidoctor know that this BlockProcessor creates literal content.
      */
-    public static final String VERBATIM = ":verbatim";
+    String VERBATIM = ":verbatim";
 
     /**
      * Predefined constant to make Asciidoctor pass through the content unprocessed.
      */
-    public static final String RAW = ":raw";
+    String RAW = ":raw";
 
     /**
      * Predefined constant to make Asciidoctor drop the content.
      */
-    public static final String SKIP = ":skip";
+    String SKIP = ":skip";
 
     /**
      * Predefined constant to make Asciidoctor not expect any content.
      */
-    public static final String EMPTY = ":empty";
+    String EMPTY = ":empty";
 
     /**
      * Predefined constant to make Asciidoctor parse content as attributes.
      */
-    public static final String ATTRIBUTES = ":attributes";
+    String ATTRIBUTES = ":attributes";
 
     /**
      * See the constants defined in this enumeration for possible values.

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentNode.java
@@ -9,6 +9,7 @@ public interface ContentNode {
      * @deprecated Please use {@link #getId()}
      * @return A unique ID for this node
      */
+    @Deprecated
     String id();
 
     /**
@@ -22,16 +23,19 @@ public interface ContentNode {
     /**
      * @deprecated Use {@linkplain #getParent()}  instead.
      */
+    @Deprecated
     ContentNode parent();
     ContentNode getParent();
     /**
      * @deprecated Use {@linkplain #getContext()}  instead.
      */
+    @Deprecated
     String context();
     String getContext();
     /**
      * @deprecated Use {@linkplain #getDocument()}  instead.
      */
+    @Deprecated
     Document document();
     Document getDocument();
     boolean isInline();
@@ -46,6 +50,7 @@ public interface ContentNode {
      * @return
      * @deprecated Use {@link #getAttribute(Object, Object, boolean)} instead
      */
+    @Deprecated
     Object getAttr(Object name, Object defaultValue, boolean inherit);
 
     /**
@@ -55,6 +60,7 @@ public interface ContentNode {
      * @return
      * @deprecated Use {@link #getAttribute(Object, Object)} instead
      */
+    @Deprecated
     Object getAttr(Object name, Object defaultValue);
 
     /**
@@ -62,6 +68,7 @@ public interface ContentNode {
      * @return
      * @deprecated Use {@link #getAttribute(Object)} instead
      */
+    @Deprecated
     Object getAttr(Object name);
 
     Object getAttribute(Object name, Object defaultValue, boolean inherit);
@@ -75,6 +82,7 @@ public interface ContentNode {
      * @return {@code true} if this node or the document has an attribute with the given name
      * @deprecated Use {@link #hasAttribute(Object)} instead
      */
+    @Deprecated
     boolean hasAttr(Object name);
 
     /**
@@ -84,6 +92,7 @@ public interface ContentNode {
      * @return {@code true} if the current node or depending on the inherited parameter the document has an attribute with the given name.
      * @deprecated Use {@link #hasAttribute(Object, boolean)} instead
      */
+    @Deprecated
     boolean hasAttr(Object name, boolean inherited);
 
     /**
@@ -107,6 +116,7 @@ public interface ContentNode {
      * @return
      * @deprecated Use {@link #isAttribute(Object, Object)} instead.
      */
+    @Deprecated
     boolean isAttr(Object name, Object expected);
 
     /**
@@ -117,6 +127,7 @@ public interface ContentNode {
      * @return
      * @deprecated Use {@link #isAttribute(Object, Object, boolean)} instead.
      */
+    @Deprecated
     boolean isAttr(Object name, Object expected, boolean inherit);
 
     /**
@@ -144,6 +155,7 @@ public interface ContentNode {
      * @return
      * @deprecated Use {@link #setAttribute(Object, Object, boolean)} instead.
      */
+    @Deprecated
     boolean setAttr(Object name, Object value, boolean overwrite);
 
     boolean setAttribute(Object name, Object value, boolean overwrite);
@@ -158,6 +170,7 @@ public interface ContentNode {
     /**
      * @deprecated Use {@linkplain #getRole()}  instead.
      */
+    @Deprecated
     String role();
     List<String> getRoles();
 
@@ -173,6 +186,5 @@ public interface ContentNode {
     String imageUri(String targetImage, String assetDirKey);
     String readAsset(String path, Map<Object, Object> opts);
     String normalizeWebPath(String path, String start, boolean preserveUriTarget);
-
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/DescriptionList.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/DescriptionList.java
@@ -6,6 +6,10 @@ public interface DescriptionList extends StructuralNode {
 
     boolean hasItems();
 
+    /**
+     * @deprecated Please use {@link #convert()}
+     * @return
+     */
     @Deprecated
     String render();
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
@@ -21,6 +21,7 @@ public interface Document extends StructuralNode {
      * @return The title as a String.
      * @see Title
      */
+    @Deprecated
     String doctitle();
 
     /**
@@ -32,6 +33,7 @@ public interface Document extends StructuralNode {
      * @deprecated Please use {@link #isBasebackend(String)}
      * @return basebackend attribute value
      */
+    @Deprecated
     boolean basebackend(String backend);
 
     /**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/List.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/List.java
@@ -6,6 +6,10 @@ public interface List extends StructuralNode {
 
     boolean hasItems();
 
+    /**
+     * @deprecated Please use {@link #convert()}
+     * @return
+     */
     @Deprecated
     String render();
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ListItem.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ListItem.java
@@ -6,7 +6,7 @@ public interface ListItem extends StructuralNode {
 
     /**
      * @return The text of the cell including substitutions being applied.
-     * @throws Exception when no text is set. Consider calling {@link #hasText()} before calling this method.
+     * @throws RuntimeException when no text is set. Consider calling {@link #hasText()} before calling this method.
      */
     String getText();
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/PhraseNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/PhraseNode.java
@@ -2,6 +2,9 @@ package org.asciidoctor.ast;
 
 public interface PhraseNode extends ContentNode {
 
+    /**
+     * @deprecated Please use {@link #convert()}
+     */
     @Deprecated
     String render();
     

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Section.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Section.java
@@ -6,6 +6,7 @@ public interface Section extends StructuralNode {
      * @deprecated Please use {@link #getIndex()}
      * @return the 0-based index order of this section within the parent block
      */
+    @Deprecated
     int index();
 
     /**
@@ -17,6 +18,7 @@ public interface Section extends StructuralNode {
      * @deprecated Please use {@link #getNumber()}
      * @return the number of this section within the parent block
      */
+    @Deprecated
     int number();
 
     /**
@@ -28,6 +30,7 @@ public interface Section extends StructuralNode {
      * @deprecated Please use {@link #getSectionName()}
      * @return the section name of this section
      */
+    @Deprecated
     String sectname();
 
     /**
@@ -39,6 +42,7 @@ public interface Section extends StructuralNode {
      * @deprecated Please use {@link #isSpecial()}
      * @return Get the flag to indicate whether this is a special section or a child of one
      */
+    @Deprecated
     boolean special();
 
     /**
@@ -50,6 +54,7 @@ public interface Section extends StructuralNode {
      * @deprecated Please use {@link #isNumbered()}
      * @return the state of the numbered attribute at this section (need to preserve for creating TOC)
      */
+    @Deprecated
     boolean numbered();
 
     /**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
@@ -9,41 +9,42 @@ public interface StructuralNode extends ContentNode {
      * Constant for special character replacement substitution like {@code <} to {@code &amp;lt;}.
      * @see <a href="http://asciidoctor.org/docs/user-manual/#special-characters">Asciidoctor User Manual</a>
      */
-    public static final String SUBSTITUTION_SPECIAL_CHARACTERS = "specialcharacters";
+    String SUBSTITUTION_SPECIAL_CHARACTERS = "specialcharacters";
 
     /**
      * Constant for quote replacements like {@code *bold*} to <b>{@code bold}</b>.
      * @see <a href="http://asciidoctor.org/docs/user-manual/#quotes">Asciidoctor User Manual</a>
      */
-    public static final String SUBSTITUTION_QUOTES             = "quotes";
+    String SUBSTITUTION_QUOTES             = "quotes";
 
     /**
      * Constant for attribute replacements like {@code {foo}}.
      * @see <a href="http://asciidoctor.org/docs/user-manual/#attributes-2">Asciidoctor User Manual</a>
      */
-    public static final String SUBSTITUTION_ATTRIBUTES         = "attributes";
+    String SUBSTITUTION_ATTRIBUTES         = "attributes";
 
     /**
      * Constant for replacements like {@code (C)} to {@code &#169;}.
      * @see <a href="http://asciidoctor.org/docs/user-manual/#replacements">Asciidoctor User Manual</a>
      */
-    public static final String SUBSTITUTION_REPLACEMENTS       = "replacements";
+    String SUBSTITUTION_REPLACEMENTS       = "replacements";
 
     /**
      * Constant for macro replacements like {@code mymacro:target[]}.
      * @see <a href="http://asciidoctor.org/docs/user-manual/#subs-mac">Asciidoctor User Manual</a>
      */
-    public static final String SUBSTITUTION_MACROS             = "macros";
+    String SUBSTITUTION_MACROS             = "macros";
 
     /**
      * Constant for post replacements like creating line breaks from a trailing {@code +} in a line.
      * @see <a href="http://asciidoctor.org/docs/user-manual/#post-replacements">Asciidoctor User Manual</a>
      */
-    public static final String SUBSTITUTION_POST_REPLACEMENTS  = "post_replacements";
+    String SUBSTITUTION_POST_REPLACEMENTS  = "post_replacements";
 
     /**
      * @deprecated Please use {@linkplain #getTitle()} instead
      */
+    @Deprecated
     String title();
     String getTitle();
     void setTitle(String title);
@@ -54,6 +55,7 @@ public interface StructuralNode extends ContentNode {
     /**
      * @deprecated Please use {@linkplain #getStyle()} instead
      */
+    @Deprecated
     String style();
     String getStyle();
 
@@ -63,6 +65,7 @@ public interface StructuralNode extends ContentNode {
      * @return The list of child blocks of this block
      * @deprecated Please use {@linkplain #getBlocks()} instead
      */
+    @Deprecated
     List<StructuralNode> blocks();
 
     /**
@@ -79,6 +82,7 @@ public interface StructuralNode extends ContentNode {
     /**
      * @deprecated Please use {@linkplain #getContent()} instead
      */
+    @Deprecated
     Object content();
     Object getContent();
     String convert();

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Table.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Table.java
@@ -4,11 +4,11 @@ import java.util.List;
 
 public interface Table extends StructuralNode {
 
-    public static enum HorizontalAlignment {
+    enum HorizontalAlignment {
         LEFT, CENTER, RIGHT
     }
 
-    public static enum VerticalAlignment {
+    enum VerticalAlignment {
         TOP, BOTTOM, MIDDLE
     }
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/PreprocessorReader.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/PreprocessorReader.java
@@ -9,12 +9,11 @@ public interface PreprocessorReader extends Reader {
     void push_include(String data, String file, String path, int lineNumber, Map<String, Object> attributes);
 
     /**
-     *
      * @return
      * @deprecated Please use {@link #getDocument()}
      */
+    @Deprecated
     Document document();
 
     Document getDocument();
-
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Reader.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Reader.java
@@ -10,6 +10,7 @@ public interface Reader {
      * @return 1-based offset.
      * @deprecated Please use {@link #getLineNumber()}
      */
+    @Deprecated
     int getLineno();
 
     /**

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/BlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/BlockImpl.java
@@ -15,6 +15,7 @@ public class BlockImpl extends StructuralNodeImpl implements Block {
     }
 
     @Override
+    @Deprecated
     public List<String> lines() {
         return getLines();
     }
@@ -34,6 +35,7 @@ public class BlockImpl extends StructuralNodeImpl implements Block {
     }
 
     @Override
+    @Deprecated
     public String source() {
         return getSource();
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/CellImpl.java
@@ -60,31 +60,31 @@ public class CellImpl extends ContentNodeImpl implements Cell {
 
     @Override
     public Table.HorizontalAlignment getHorizontalAlignment() {
-        return Table.HorizontalAlignment.valueOf(((String) getAttr("halign", "left")).toUpperCase());
+        return Table.HorizontalAlignment.valueOf(((String) getAttribute("halign", "left")).toUpperCase());
     }
 
     @Override
     public void setHorizontalAlignment(Table.HorizontalAlignment halign) {
-        setAttr("halign", halign.name().toLowerCase(), true);
+        setAttribute("halign", halign.name().toLowerCase(), true);
     }
 
     @Override
     public Table.VerticalAlignment getVerticalAlignment() {
-        return Table.VerticalAlignment.valueOf(((String) getAttr("valign", "top")).toUpperCase());
+        return Table.VerticalAlignment.valueOf(((String) getAttribute("valign", "top")).toUpperCase());
     }
 
     @Override
     public void setVerticalAlignment(Table.VerticalAlignment valign) {
-        setAttr("valign", valign.name().toLowerCase(), true);
+        setAttribute("valign", valign.name().toLowerCase(), true);
     }
 
     @Override
     public Document getInnerDocument() {
         IRubyObject innerDocument = getRubyProperty("inner_document");
         if (innerDocument.isNil()) {
-        	return null;
+            return null;
         }
-		return (Document) NodeConverter.createASTNode(innerDocument);
+        return (Document) NodeConverter.createASTNode(innerDocument);
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ColumnImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ColumnImpl.java
@@ -27,39 +27,39 @@ public class ColumnImpl extends ContentNodeImpl implements Column {
 
     @Override
     public int getColumnNumber() {
-        Number columnNumber = (Number) getAttr("colnumber");
+        Number columnNumber = (Number) getAttribute("colnumber");
         return columnNumber == null ? -1 : columnNumber.intValue();
     }
 
     @Override
     public int getWidth() {
-        Number width =  (Number) getAttr("width");
+        Number width = (Number) getAttribute("width");
         return width == null ? 0 : width.intValue();
     }
 
     @Override
     public void setWidth(int width) {
-        setAttr("width", width, true);
+        setAttribute("width", width, true);
     }
 
     @Override
     public Table.HorizontalAlignment getHorizontalAlignment() {
-        return Table.HorizontalAlignment.valueOf(((String) getAttr("halign", "left")).toUpperCase());
+        return Table.HorizontalAlignment.valueOf(((String) getAttribute("halign", "left")).toUpperCase());
     }
 
     @Override
     public void setHorizontalAlignment(Table.HorizontalAlignment halign) {
-        setAttr("halign", halign.name().toLowerCase(), true);
+        setAttribute("halign", halign.name().toLowerCase(), true);
     }
 
     @Override
     public Table.VerticalAlignment getVerticalAlignment() {
-        return Table.VerticalAlignment.valueOf(((String) getAttr("valign", "top")).toUpperCase());
+        return Table.VerticalAlignment.valueOf(((String) getAttribute("valign", "top")).toUpperCase());
     }
 
     @Override
     public void setVerticalAlignment(Table.VerticalAlignment valign) {
-        setAttr("valign", valign.name().toLowerCase(), true);
+        setAttribute("valign", valign.name().toLowerCase(), true);
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ContentNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ContentNodeImpl.java
@@ -21,6 +21,7 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public String id() {
         return getId();
     }
@@ -36,6 +37,7 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public String context() {
         return getContext();
     }
@@ -46,6 +48,7 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public ContentNode parent() {
         return getParent();
     }
@@ -56,6 +59,7 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public Document document() {
         return getDocument();
     }
@@ -86,16 +90,19 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public Object getAttr(Object name, Object defaultValue, boolean inherit) {
         return getAttribute(name, defaultValue, inherit);
     }
 
     @Override
+    @Deprecated
     public Object getAttr(Object name, Object defaultValue) {
         return getAttribute(name, defaultValue);
     }
 
     @Override
+    @Deprecated
     public Object getAttr(Object name) {
         return getAttribute(name);
     }
@@ -116,11 +123,13 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public boolean isAttr(Object name, Object expected, boolean inherit) {
         return isAttribute(name, expected, inherit);
     }
 
     @Override
+    @Deprecated
     public boolean isAttr(Object name, Object expected) {
         return isAttribute(name, expected);
     }
@@ -136,11 +145,13 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public boolean hasAttr(Object name) {
         return hasAttribute(name);
     }
 
     @Override
+    @Deprecated
     public boolean hasAttr(Object name, boolean inherited) {
         return hasAttribute(name, inherited);
     }
@@ -156,6 +167,7 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public boolean setAttr(Object name, Object value, boolean overwrite) {
         return setAttribute(name, value, overwrite);
     }
@@ -181,6 +193,7 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    @Deprecated
     public String role() {
         return getRole();
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DescriptionListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DescriptionListImpl.java
@@ -18,7 +18,7 @@ public class DescriptionListImpl extends StructuralNodeImpl implements Descripti
     @Override
     public java.util.List<DescriptionListEntry> getItems() {
         RubyArray rubyBlocks = (RubyArray) getRubyProperty("items");
-        return new RubyBlockListDecorator<DescriptionListEntry>(rubyBlocks);
+        return new RubyBlockListDecorator<>(rubyBlocks);
     }
 
     @Override
@@ -27,6 +27,7 @@ public class DescriptionListImpl extends StructuralNodeImpl implements Descripti
     }
 
     @Override
+    @Deprecated
     public String render() {
         return getString("render");
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DocumentImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/DocumentImpl.java
@@ -24,6 +24,7 @@ public class DocumentImpl extends StructuralNodeImpl implements Document {
     }
 
     @Override
+    @Deprecated
     public boolean basebackend(String backend) {
         return isBasebackend(backend);
     }
@@ -46,10 +47,13 @@ public class DocumentImpl extends StructuralNodeImpl implements Document {
 
     }
 
+    @Override
     public String getDoctitle() {
         return getString("doctitle");
     }
 
+    @Override
+    @Deprecated
     public String doctitle() {
         return getDoctitle();
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/ListImpl.java
@@ -2,7 +2,6 @@ package org.asciidoctor.ast.impl;
 
 import org.asciidoctor.ast.List;
 import org.asciidoctor.ast.StructuralNode;
-import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.asciidoctor.internal.RubyBlockListDecorator;
 import org.jruby.RubyArray;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -14,9 +13,9 @@ public class ListImpl extends StructuralNodeImpl implements List {
     }
 
     @Override
-    public java.util.List getItems() {
+    public java.util.List<StructuralNode> getItems() {
         RubyArray rubyBlocks = (RubyArray) getRubyProperty("items");
-        return new RubyBlockListDecorator<StructuralNode>(rubyBlocks);
+        return new RubyBlockListDecorator<>(rubyBlocks);
     }
 
     @Override
@@ -25,6 +24,7 @@ public class ListImpl extends StructuralNodeImpl implements List {
     }
 
     @Override
+    @Deprecated
     public String render() {
         return getString("render");
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/PhraseNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/PhraseNodeImpl.java
@@ -10,6 +10,7 @@ public class PhraseNodeImpl extends ContentNodeImpl implements PhraseNode {
     }
 
     @Override
+    @Deprecated
     public String render() {
         return getString("render");
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/SectionImpl.java
@@ -1,7 +1,6 @@
 package org.asciidoctor.ast.impl;
 
 import org.asciidoctor.ast.Section;
-import org.asciidoctor.ast.impl.StructuralNodeImpl;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class SectionImpl extends StructuralNodeImpl implements Section {
@@ -11,6 +10,7 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
     }
 
     @Override
+    @Deprecated
     public int index() {
         return getIndex();
     }
@@ -21,6 +21,7 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
     }
 
     @Override
+    @Deprecated
     public int number() {
         return getNumber();
     }
@@ -31,6 +32,7 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
     }
 
     @Override
+    @Deprecated
     public String sectname() {
         return getSectionName();
     }
@@ -41,6 +43,7 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
     }
 
     @Override
+    @Deprecated
     public boolean special() {
         return isSpecial();
     }
@@ -51,6 +54,7 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
     }
 
     @Override
+    @Deprecated
     public boolean numbered() {
         return isNumbered();
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/StructuralNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/StructuralNodeImpl.java
@@ -13,14 +13,12 @@ import java.util.Map;
 
 public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNode {
 
-    private static final String BLOCK_CLASS = "Block";
-    private static final String SECTION_CLASS = "Section";
-
     public StructuralNodeImpl(IRubyObject blockDelegate) {
         super(blockDelegate);
     }
 
     @Override
+    @Deprecated
     public String title() {
         return getTitle();
     }
@@ -46,6 +44,7 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     }
 
     @Override
+    @Deprecated
     public String style() {
         return getStyle();
     }
@@ -61,6 +60,7 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     }
 
     @Override
+    @Deprecated
     public List<StructuralNode> blocks() {
         return getBlocks();
     }
@@ -68,16 +68,16 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     @Override
     public List<StructuralNode> getBlocks() {
         RubyArray rubyBlocks = (RubyArray) getRubyProperty("blocks");
-        return new RubyBlockListDecorator<StructuralNode>(rubyBlocks);
+        return new RubyBlockListDecorator<>(rubyBlocks);
     }
 
     @Override
     public void append(StructuralNode block) {
-
         getRubyObject().callMethod(runtime.getCurrentContext(), "<<", ((StructuralNodeImpl) block).getRubyObject());
     }
 
     @Override
+    @Deprecated
     public Object content() {
         return getContent();
     }
@@ -151,10 +151,8 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
 
     @Override
     public List<StructuralNode> findBy(Map<Object, Object> selector) {
-
-        RubyArray rubyBlocks = (RubyArray) getRubyProperty("find_by", RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime,
-                selector));
-        return new RubyBlockListDecorator(rubyBlocks);
+        RubyArray rubyBlocks = (RubyArray) getRubyProperty("find_by", RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(runtime, selector));
+        return new RubyBlockListDecorator<>(rubyBlocks);
     }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/TableImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/impl/TableImpl.java
@@ -17,7 +17,7 @@ public class TableImpl extends StructuralNodeImpl implements Table {
 
     private static final String FRAME_ATTR = "frame";
 
-    private static final String GRID_ATTR  = "grid";
+    private static final String GRID_ATTR = "grid";
 
     private Rows rows;
 
@@ -33,28 +33,28 @@ public class TableImpl extends StructuralNodeImpl implements Table {
 
     @Override
     public String getFrame() {
-        return (String)getAttr(FRAME_ATTR, "all");
+        return (String) getAttribute(FRAME_ATTR, "all");
     }
 
     @Override
     public void setFrame(String frame) {
-        setAttr(FRAME_ATTR, frame, true);
+        setAttribute(FRAME_ATTR, frame, true);
     }
 
     @Override
     public String getGrid() {
-        return (String)getAttr(GRID_ATTR, "all");
+        return (String) getAttribute(GRID_ATTR, "all");
     }
 
     @Override
     public void setGrid(String grid) {
-        setAttr(GRID_ATTR, grid, true);
+        setAttribute(GRID_ATTR, grid, true);
     }
 
     @Override
     public List<Column> getColumns() {
         RubyArray rubyBlocks = (RubyArray) getRubyProperty("columns");
-        return new RubyBlockListDecorator<Column>(rubyBlocks);
+        return new RubyBlockListDecorator<>(rubyBlocks);
     }
 
     @Override
@@ -130,7 +130,7 @@ public class TableImpl extends StructuralNodeImpl implements Table {
         @Override
         public boolean add(Row row) {
             boolean changed = rubyArray.add(((RowImpl) row).getRubyObject());
-            TableImpl.this.setAttr("rowcount", size(), true);
+            TableImpl.this.setAttribute("rowcount", size(), true);
             return changed;
         }
 
@@ -140,7 +140,7 @@ public class TableImpl extends StructuralNodeImpl implements Table {
                 return false;
             }
             boolean changed = rubyArray.remove(((RowImpl) o).getRubyObject());
-            TableImpl.this.setAttr("rowcount", size(), true);
+            TableImpl.this.setAttribute("rowcount", size(), true);
             return changed;
         }
 
@@ -152,7 +152,7 @@ public class TableImpl extends StructuralNodeImpl implements Table {
         @Override
         public void clear() {
             rubyArray.clear();
-            TableImpl.this.setAttr("rowcount", size(), true);
+            TableImpl.this.setAttribute("rowcount", size(), true);
         }
 
         @Override
@@ -174,13 +174,13 @@ public class TableImpl extends StructuralNodeImpl implements Table {
         @Override
         public void add(int index, Row element) {
             rubyArray.add(index, ((RowImpl) element).getRubyObject());
-            TableImpl.this.setAttr("rowcount", size(), true);
+            TableImpl.this.setAttribute("rowcount", size(), true);
         }
 
         @Override
         public Row remove(int index) {
             IRubyObject rubyObject = (IRubyObject) rubyArray.remove(index);
-            TableImpl.this.setAttr("rowcount", size(), true);
+            TableImpl.this.setAttribute("rowcount", size(), true);
             return new RowImpl(rubyObject);
         }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PreprocessorReaderImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/PreprocessorReaderImpl.java
@@ -23,6 +23,7 @@ public class PreprocessorReaderImpl extends ReaderImpl implements PreprocessorRe
     }
 
     @Override
+    @Deprecated
     public Document document() {
         return getDocument();
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ReaderImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/ReaderImpl.java
@@ -25,6 +25,7 @@ public class ReaderImpl extends RubyObjectWrapper implements Reader {
     }
 
     @Override
+    @Deprecated
     public int getLineno() {
         return getLineNumber();
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyObjectWrapper.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/RubyObjectWrapper.java
@@ -2,11 +2,9 @@ package org.asciidoctor.internal;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
-import org.jruby.RubyBoolean;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyNil;
 import org.jruby.RubyNumeric;
-import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.ThreadContext;
@@ -39,9 +37,9 @@ public class RubyObjectWrapper {
         if (result instanceof RubyNil) {
             return null;
         } else if (result instanceof RubySymbol) {
-            return ((RubySymbol) result).asJavaString();
+            return result.asJavaString();
         } else {
-            return ((RubyString) result).asJavaString();
+            return result.asJavaString();
         }
     }
 
@@ -59,7 +57,7 @@ public class RubyObjectWrapper {
         if (result instanceof RubyNil) {
             return null;
         }
-        return ((RubySymbol) result).asJavaString();
+        return result.asJavaString();
     }
 
     public void setSymbol(String propertyName, String value) {
@@ -75,7 +73,7 @@ public class RubyObjectWrapper {
         if (result instanceof RubyNil) {
             return false;
         } else {
-            return ((RubyBoolean) result).isTrue();
+            return result.isTrue();
         }
     }
 
@@ -110,7 +108,7 @@ public class RubyObjectWrapper {
     public IRubyObject getRubyProperty(String propertyName, Object... args) {
         ThreadContext threadContext = runtime.getThreadService().getCurrentContext();
 
-        IRubyObject result = null;
+        IRubyObject result;
         if (propertyName.startsWith("@")) {
             if (args != null && args.length > 0) {
                 throw new IllegalArgumentException("No args allowed for direct field access");
@@ -123,7 +121,7 @@ public class RubyObjectWrapper {
                 IRubyObject[] rubyArgs = new IRubyObject[args.length];
                 for (int i = 0; i < args.length; i++) {
                     if (args[i] instanceof RubyObjectWrapper) {
-                        rubyArgs[i] = ((RubyObjectWrapper)args[i]).getRubyObject();
+                        rubyArgs[i] = ((RubyObjectWrapper) args[i]).getRubyObject();
                     } else {
                         rubyArgs[i] = JavaEmbedUtils.javaToRuby(runtime, args[i]);
                     }
@@ -137,7 +135,6 @@ public class RubyObjectWrapper {
     public void setRubyProperty(String propertyName, IRubyObject arg) {
         ThreadContext threadContext = runtime.getThreadService().getCurrentContext();
 
-        IRubyObject result = null;
         if (propertyName.startsWith("@")) {
             rubyNode.getInstanceVariables().setInstanceVariable(propertyName, arg);
         } else {
@@ -160,6 +157,5 @@ public class RubyObjectWrapper {
     public <T> T toJava(IRubyObject rubyObject, Class<T> targetClass) {
         return (T) JavaEmbedUtils.rubyToJava(runtime, rubyObject, targetClass);
     }
-
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NumberLinesPreprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/NumberLinesPreprocessor.java
@@ -2,21 +2,16 @@ package org.asciidoctor.extension;
 
 import org.asciidoctor.ast.Document;
 
-import java.util.Map;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class NumberLinesPreprocessor extends Preprocessor {
 
-	public NumberLinesPreprocessor() {}
+    public NumberLinesPreprocessor() {
+    }
 
-	@Override
-	public void process(Document document,
-			PreprocessorReader reader) {
-
-		assertThat(reader.getLineno(), is(1));
-
-	}
-
+    @Override
+    public void process(Document document, PreprocessorReader reader) {
+        assertThat(reader.getLineNumber(), is(1));
+    }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
@@ -94,15 +93,13 @@ public class WhenJavaExtensionIsRegistered {
 
                 BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(openStream));
 
-                String line = null;
+                String line;
                 while ((line = bufferedReader.readLine()) != null) {
                     content.append(line);
                 }
 
                 bufferedReader.close();
 
-            } catch (MalformedURLException e) {
-                throw new IllegalArgumentException(e);
             } catch (IOException e) {
                 throw new IllegalArgumentException(e);
             }
@@ -123,7 +120,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.includeProcessor(new RubyIncludeSource(new HashMap<String, Object>()));
+        javaExtensionRegistry.includeProcessor(new RubyIncludeSource(new HashMap<>()));
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("sample-with-uri-include.ad"),
@@ -144,7 +141,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.includeProcessor(new IncludeProcessor(new HashMap<String, Object>()) {
+        javaExtensionRegistry.includeProcessor(new IncludeProcessor(new HashMap<>()) {
 
             @Override
             public void process(Document document, PreprocessorReader reader, String target,
@@ -164,15 +161,13 @@ public class WhenJavaExtensionIsRegistered {
 
                     BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(openStream));
 
-                    String line = null;
+                    String line;
                     while ((line = bufferedReader.readLine()) != null) {
                         content.append(line);
                     }
 
                     bufferedReader.close();
 
-                } catch (MalformedURLException e) {
-                    throw new IllegalArgumentException(e);
                 } catch (IOException e) {
                     throw new IllegalArgumentException(e);
                 }
@@ -217,7 +212,7 @@ public class WhenJavaExtensionIsRegistered {
     public void a_docinfoprocessor_should_be_executed_and_add_meta_in_footer() {
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new HashMap<>();
         options.put("location", ":footer");
         MetaRobotsDocinfoProcessor metaRobotsDocinfoProcessor = new MetaRobotsDocinfoProcessor(options);
 
@@ -273,7 +268,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.preprocessor(new ChangeAttributeValuePreprocessor(new HashMap<String, Object>()));
+        javaExtensionRegistry.preprocessor(new ChangeAttributeValuePreprocessor(new HashMap<>()));
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("changeattribute.adoc"),
@@ -328,7 +323,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.postprocessor(new CustomFooterPostProcessor(new HashMap<String, Object>()));
+        javaExtensionRegistry.postprocessor(new CustomFooterPostProcessor(new HashMap<>()));
 
         Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
                 .safe(SafeMode.UNSAFE).get();
@@ -391,7 +386,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.includeProcessor(new UriIncludeProcessor(new HashMap<String, Object>()));
+        javaExtensionRegistry.includeProcessor(new UriIncludeProcessor(new HashMap<>()));
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("sample-with-uri-include.ad"),
@@ -441,7 +436,7 @@ public class WhenJavaExtensionIsRegistered {
 
     }
 
-	@Test
+    @Test
     public void a_treeprocessor_should_be_executed_in_document() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
@@ -483,9 +478,7 @@ public class WhenJavaExtensionIsRegistered {
         assertThat(contentElement.text(), is("gem install asciidoctor"));
 
         Element script = doc.getElementsByTag("script").first();
-
         assertThat(script.attr("src"), is("https://gist.github.com/42.js"));
-
     }
 
     @Test
@@ -514,7 +507,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.treeprocessor(new TerminalCommandTreeprocessor(new HashMap<String, Object>()));
+        javaExtensionRegistry.treeprocessor(new TerminalCommandTreeprocessor(new HashMap<>()));
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("sample-with-terminal-command.ad"),
@@ -579,7 +572,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.blockMacro(new GistMacro("gist", new HashMap<String, Object>()));
+        javaExtensionRegistry.blockMacro(new GistMacro("gist", new HashMap<>()));
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("sample-with-gist-macro.ad"),
@@ -613,7 +606,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new HashMap<>();
         options.put(ContentModel.KEY, ContentModel.RAW);
 
         javaExtensionRegistry.blockMacro(new GistMacro("gist", options));
@@ -666,7 +659,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new HashMap<>();
         options.put(InlineMacroProcessor.REGEXP, "man(?:page)?:(\\S+?)\\[(.*?)\\]");
 
         ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
@@ -688,7 +681,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new HashMap<>();
         options.put(InlineMacroProcessor.REGEXP, "man(?:page)?:(ThisDoesNotMatch)\\[(.*?)\\]");
 
         ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
@@ -708,7 +701,7 @@ public class WhenJavaExtensionIsRegistered {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new HashMap<>();
 
         ManpageMacro inlineMacroProcessor = new ManpageMacro("man", options);
         javaExtensionRegistry.inlineMacro(inlineMacroProcessor);
@@ -745,8 +738,7 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_block_processor_as_string_should_be_executed_when_registered_block_is_found_in_document()
-            throws IOException {
+    public void a_block_processor_as_string_should_be_executed_when_registered_block_is_found_in_document() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
@@ -763,7 +755,7 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_block_processor_should_be_executed_when_registered_block_is_found_in_document() throws IOException {
+    public void a_block_processor_should_be_executed_when_registered_block_is_found_in_document() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
@@ -780,15 +772,15 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_block_processor_class_should_be_executed_twice() throws IOException {
+    public void a_block_processor_class_should_be_executed_twice() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
         javaExtensionRegistry.block("yell", YellStaticBlock.class);
         for (int i = 0; i < 2; i++) {
             String content = asciidoctor.convertFile(
-                classpath.getResource("sample-with-yell-block.ad"),
-                options().toFile(false).get());
+                    classpath.getResource("sample-with-yell-block.ad"),
+                    options().toFile(false).get());
 
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
             Elements elements = doc.getElementsByClass("paragraph");
@@ -798,13 +790,12 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_block_processor_instance_should_be_executed_when_registered_block_is_found_in_document()
-            throws IOException {
+    public void a_block_processor_instance_should_be_executed_when_registered_block_is_found_in_document() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        Map<String, Object> config = new HashMap<String, Object>();
-        config.put(BlockProcessor.CONTEXTS, Arrays.asList(Contexts.PARAGRAPH));
+        Map<String, Object> config = new HashMap<>();
+        config.put(Contexts.KEY, Arrays.asList(Contexts.PARAGRAPH));
         config.put(ContentModel.KEY, ContentModel.SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
         javaExtensionRegistry.block(yellBlock);
@@ -819,21 +810,20 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_block_processor_instance_should_be_executed_twice()
-            throws IOException {
+    public void a_block_processor_instance_should_be_executed_twice() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        Map<String, Object> config = new HashMap<String, Object>();
+        Map<String, Object> config = new HashMap<>();
         config.put(Contexts.KEY, Arrays.asList(Contexts.PARAGRAPH));
         config.put(ContentModel.KEY, ContentModel.SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
         javaExtensionRegistry.block(yellBlock);
 
-        for (int i = 0; i < 2; i++){
+        for (int i = 0; i < 2; i++) {
             String content = asciidoctor.convertFile(
-                classpath.getResource("sample-with-yell-block.ad"),
-                options().toFile(false).get());
+                    classpath.getResource("sample-with-yell-block.ad"),
+                    options().toFile(false).get());
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
             Elements elements = doc.getElementsByClass("paragraph");
             assertThat(elements.size(), is(1));
@@ -842,8 +832,7 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_include_processor_class_should_be_executed_twice()
-            throws IOException {
+    public void a_include_processor_class_should_be_executed_twice() {
 
         TestHttpServer.start(Collections.singletonMap("http://example.com/asciidoctorclass.rb", classpath.getResource("org/asciidoctor/internal/asciidoctorclass.rb")));
 
@@ -851,10 +840,10 @@ public class WhenJavaExtensionIsRegistered {
 
         javaExtensionRegistry.includeProcessor(UriIncludeProcessor.class);
 
-        for (int i = 0; i < 2; i++){
+        for (int i = 0; i < 2; i++) {
             String content = asciidoctor.convertFile(
-                classpath.getResource("sample-with-uri-include.ad"),
-                options().toFile(false).get());
+                    classpath.getResource("sample-with-uri-include.ad"),
+                    options().toFile(false).get());
 
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -865,19 +854,18 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_include_processor_instance_should_be_executed_twice()
-            throws IOException {
+    public void a_include_processor_instance_should_be_executed_twice() {
 
         TestHttpServer.start(Collections.singletonMap("http://example.com/asciidoctorclass.rb", classpath.getResource("org/asciidoctor/internal/asciidoctorclass.rb")));
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        javaExtensionRegistry.includeProcessor(new UriIncludeProcessor(new HashMap<String, Object>()));
+        javaExtensionRegistry.includeProcessor(new UriIncludeProcessor(new HashMap<>()));
 
-        for (int i = 0; i < 2; i++){
+        for (int i = 0; i < 2; i++) {
             String content = asciidoctor.convertFile(
-                classpath.getResource("sample-with-uri-include.ad"),
-                options().toFile(false).get());
+                    classpath.getResource("sample-with-uri-include.ad"),
+                    options().toFile(false).get());
 
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -888,7 +876,7 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_block_processor_should_be_executed_when_registered_listing_block_is_found_in_document() throws IOException {
+    public void a_block_processor_should_be_executed_when_registered_listing_block_is_found_in_document() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
@@ -905,12 +893,11 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void a_block_processor_instance_should_be_executed_when_registered_listing_block_is_found_in_document()
-            throws IOException {
+    public void a_block_processor_instance_should_be_executed_when_registered_listing_block_is_found_in_document() {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
 
-        Map<String, Object> config = new HashMap<String, Object>();
+        Map<String, Object> config = new HashMap<>();
         config.put(Contexts.KEY, Arrays.asList(Contexts.LISTING));
         config.put(ContentModel.KEY, ContentModel.SIMPLE);
         YellBlock yellBlock = new YellBlock("yell", config);
@@ -926,14 +913,14 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void should_create_toc_with_treeprocessor() throws Exception {
+    public void should_create_toc_with_treeprocessor() {
         asciidoctor.javaExtensionRegistry().treeprocessor(new Treeprocessor() {
             @Override
             public org.asciidoctor.ast.Document process(org.asciidoctor.ast.Document document) {
-                List<StructuralNode> blocks=document.getBlocks();
+                List<StructuralNode> blocks = document.getBlocks();
                 for (StructuralNode block : blocks) {
                     for (StructuralNode block2 : block.getBlocks()) {
-                        if(block2 instanceof Section)
+                        if (block2 instanceof Section)
                             System.out.println(((Section) block2).getId());
                     }
                 }
@@ -952,16 +939,16 @@ public class WhenJavaExtensionIsRegistered {
         assertThat(elements.size(), is(1));
     }
 
-     public void should_unregister_postprocessor() throws IOException {
+    public void should_unregister_postprocessor() throws IOException {
 
         // Given: A registered Postprocessor
         ExtensionGroup extensionGroup = asciidoctor.createGroup(UUID.randomUUID().toString())
-            .postprocessor(CustomFooterPostProcessor.class);
+                .postprocessor(CustomFooterPostProcessor.class);
 
         // When: I render a document without registering the ExtensionGroup
         {
             Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
-                .safe(SafeMode.UNSAFE).get();
+                    .safe(SafeMode.UNSAFE).get();
 
             asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options);
 
@@ -976,7 +963,7 @@ public class WhenJavaExtensionIsRegistered {
         {
             extensionGroup.register();
             Options options = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample.html"))
-                .safe(SafeMode.UNSAFE).get();
+                    .safe(SafeMode.UNSAFE).get();
 
             asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options);
 
@@ -988,10 +975,11 @@ public class WhenJavaExtensionIsRegistered {
         }
         // When: I unregister the Postprocessor and render again with the same Asciidoctor instance
         {
-            extensionGroup.unregister();;
+            extensionGroup.unregister();
+            ;
 
             Options options2 = options().inPlace(false).toFile(new File(testFolder.getRoot(), "rendersample2.html"))
-                .safe(SafeMode.UNSAFE).get();
+                    .safe(SafeMode.UNSAFE).get();
             asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options2);
             File renderedFile2 = new File(testFolder.getRoot(), "rendersample2.html");
             org.jsoup.nodes.Document doc2 = Jsoup.parse(renderedFile2, "UTF-8");
@@ -1002,10 +990,9 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
-    public void should_unregister_block_processor()
-        throws IOException {
+    public void should_unregister_block_processor() {
 
-        Map<String, Object> config = new HashMap<String, Object>();
+        Map<String, Object> config = new HashMap<>();
         config.put("contexts", Arrays.asList(":paragraph"));
         config.put("content_model", ":simple");
         YellBlock yellBlock = new YellBlock("yell", config);
@@ -1014,8 +1001,8 @@ public class WhenJavaExtensionIsRegistered {
 
         {
             String contentWithoutBlock = asciidoctor.convertFile(
-                classpath.getResource("sample-with-yell-block.ad"),
-                options().toFile(false).get());
+                    classpath.getResource("sample-with-yell-block.ad"),
+                    options().toFile(false).get());
             org.jsoup.nodes.Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
             Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
             assertThat(elementsWithoutBlock.size(), is(1));
@@ -1025,8 +1012,8 @@ public class WhenJavaExtensionIsRegistered {
         {
             extensionGroup.register();
             String content = asciidoctor.convertFile(
-                classpath.getResource("sample-with-yell-block.ad"),
-                options().toFile(false).get());
+                    classpath.getResource("sample-with-yell-block.ad"),
+                    options().toFile(false).get());
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
             Elements elements = doc.getElementsByClass("paragraph");
             assertThat(elements.size(), is(1));
@@ -1035,8 +1022,8 @@ public class WhenJavaExtensionIsRegistered {
         {
             extensionGroup.unregister();
             String contentWithoutBlock = asciidoctor.convertFile(
-                classpath.getResource("sample-with-yell-block.ad"),
-                options().toFile(false).get());
+                    classpath.getResource("sample-with-yell-block.ad"),
+                    options().toFile(false).get());
             org.jsoup.nodes.Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
             Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
             assertThat(elementsWithoutBlock.size(), is(1));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellBlock.java
@@ -1,11 +1,11 @@
 package org.asciidoctor.extension;
 
+import org.asciidoctor.ast.StructuralNode;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.asciidoctor.ast.StructuralNode;
 
 public class YellBlock extends BlockProcessor {
 
@@ -20,13 +20,12 @@ public class YellBlock extends BlockProcessor {
         for (String line : lines) {
             if (upperLines == null) {
                 upperLines = line.toUpperCase();
-            }
-            else {
+            } else {
                 upperLines = upperLines + "\n" + line.toUpperCase();
             }
         }
 
-		return createBlock(parent, "paragraph", Arrays.asList(upperLines), attributes, new HashMap<Object, Object>());
+        return createBlock(parent, "paragraph", Arrays.asList(upperLines), attributes, new HashMap<>());
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticBlock.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/YellStaticBlock.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class YellStaticBlock extends BlockProcessor {
 
     private static Map<String, Object> configs = new HashMap<String, Object>() {{
-        put(CONTEXTS, Arrays.asList(CONTEXT_PARAGRAPH));
+        put(Contexts.KEY, Arrays.asList(Contexts.PARAGRAPH));
         put(ContentModel.KEY, ContentModel.SIMPLE);
     }};
 

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroProcessor.java
@@ -20,11 +20,12 @@ public class IssueInlineMacroProcessor extends InlineMacroProcessor {    // <2>
                 new StringBuilder()
                     .append("https://github.com/")
                     .append(attributes.containsKey("repo") ?
-                            attributes.get("repo") : parent.getDocument().getAttr("repo"))
+                            attributes.get("repo") :
+                            parent.getDocument().getAttribute("repo"))
                     .append("/issues/")
                     .append(target).toString();
 
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new HashMap<>();
         options.put("type", ":link");
         options.put("target", href);
         return createPhraseNode(parent, "anchor", target, attributes, options) // <4>

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,12 @@ subprojects {
     project.tasks.withType(JavaCompile) { task ->
       task.sourceCompatibility = project.sourceCompatibility
       task.targetCompatibility = project.targetCompatibility
+      if (project.hasProperty("showDeprecation")) {
+        options.compilerArgs << "-Xlint:deprecation"
+      }
+      if (project.hasProperty("showUnchecked")) {
+        options.compilerArgs << "-Xlint:unchecked"
+      }
     }
     project.tasks.withType(GroovyCompile) { task ->
       task.sourceCompatibility = project.sourceCompatibility


### PR DESCRIPTION
- Mark both interface and implementation as deprecated with @Deprecated
- Remove deprecated usage
- Code cleanup (diamond operator, remove unnecessary/redundant code)
- Add two Gradle options to show deprecations and unchecked