### PR TITLE
Run ci build with Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 language: java
 matrix:
   include:
-    - jdk: oraclejdk9
-      dist: trusty
+    - jdk: openjdk11
+      dist: xenial
     - jdk: oraclejdk8
     - os: osx
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ clone_depth: 10
 environment:
   TERM: dumb
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    - JAVA_HOME: C:\Program Files\Java\jdk11
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%
   # remove Ruby entry (C:\Ruby193\bin;) from PATH


### PR DESCRIPTION
I successfully built AsciidoctorJ locally with OpenJDK 11.
Let's cross fingers that it works on the ci systems as well.
There's probably not much value anymore running tests with Java9 which is already eol. 