### PR TITLE
Fixes #754. Initialize BlockProcessor.name correctly

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
@@ -34,36 +34,39 @@ public interface JavaExtensionRegistry {
     JavaExtensionRegistry treeprocessor(String treeProcessor);
 
     JavaExtensionRegistry block(String blockName,
-                                    String blockProcessor);
+                                String blockProcessor);
 
     JavaExtensionRegistry block(String blockProcessor);
 
     JavaExtensionRegistry block(String blockName,
-                                    Class<? extends BlockProcessor> blockProcessor);
+                                Class<? extends BlockProcessor> blockProcessor);
 
     JavaExtensionRegistry block(Class<? extends BlockProcessor> blockProcessor);
 
     JavaExtensionRegistry block(BlockProcessor blockProcessor);
 
     JavaExtensionRegistry block(String blockName,
-                                    BlockProcessor blockProcessor);
+                                BlockProcessor blockProcessor);
 
     JavaExtensionRegistry blockMacro(String blockName,
-                                         Class<? extends BlockMacroProcessor> blockMacroProcessor);
+                                     Class<? extends BlockMacroProcessor> blockMacroProcessor);
 
     JavaExtensionRegistry blockMacro(Class<? extends BlockMacroProcessor> blockMacroProcessor);
 
     JavaExtensionRegistry blockMacro(String blockName,
-                                         String blockMacroProcessor);
+                                     String blockMacroProcessor);
 
     JavaExtensionRegistry blockMacro(String blockMacroProcessor);
 
     JavaExtensionRegistry blockMacro(BlockMacroProcessor blockMacroProcessor);
 
+    JavaExtensionRegistry blockMacro(String blockName,
+                                     BlockMacroProcessor blockMacroProcessor);
+
     JavaExtensionRegistry inlineMacro(InlineMacroProcessor inlineMacroProcessor);
 
     JavaExtensionRegistry inlineMacro(String blockName,
-                                          Class<? extends InlineMacroProcessor> inlineMacroProcessor);
+                                      Class<? extends InlineMacroProcessor> inlineMacroProcessor);
 
     JavaExtensionRegistry inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor);
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/JavaExtensionRegistry.java
@@ -65,7 +65,10 @@ public interface JavaExtensionRegistry {
 
     JavaExtensionRegistry inlineMacro(InlineMacroProcessor inlineMacroProcessor);
 
-    JavaExtensionRegistry inlineMacro(String blockName,
+    JavaExtensionRegistry inlineMacro(String macroName,
+                                      InlineMacroProcessor inlineMacroProcessor);
+
+    JavaExtensionRegistry inlineMacro(String macroName,
                                       Class<? extends InlineMacroProcessor> inlineMacroProcessor);
 
     JavaExtensionRegistry inlineMacro(Class<? extends InlineMacroProcessor> inlineMacroProcessor);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockMacroProcessorProxy.java
@@ -61,6 +61,8 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
 
     @JRubyMethod(name = "initialize", required = 1, optional = 1)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
+
         if (getProcessor() != null) {
             // Instance was created in Java and has options set, so we pass these
             // instead of those passed by asciidoctor
@@ -73,16 +75,24 @@ public class BlockMacroProcessorProxy extends AbstractMacroProcessorProxy<BlockM
                             JavaEmbedUtils.javaToRuby(getRuntime(), getProcessor().getName()),
                             RubyHashUtil.convertMapToRubyHashWithSymbols(getRuntime(), getProcessor().getConfig())},
                     Block.NULL_BLOCK);
+
+            if (macroName != null) {
+                getProcessor().setName(macroName);
+            } else if (getProcessor().getName() == null) {
+                RubyHash config = (RubyHash) this.callMethod(context, "config");
+                Object rubyName = config.get(context.getRuntime().newSymbol("name"));
+                if (rubyName != null) {
+                    getProcessor().setName(rubyName.toString());
+                }
+            }
+
             // The extension config in the Java extension is just a view on the @config member of the Ruby part
             getProcessor().updateConfig(new RubyHashMapDecorator((RubyHash)getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the name
-            String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
             setProcessor(instantiateProcessor(macroName, new HashMap<String, Object>()));
 
-            if (getProcessor().getName() == null) {
-                getProcessor().setName(macroName);
-            }
+            getProcessor().setName(macroName);
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/extension/processorproxies/BlockProcessorProxy.java
@@ -62,9 +62,12 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
 
     @JRubyMethod(name = "initialize", required = 1, optional = 1)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) throws IllegalAccessException, InvocationTargetException, InstantiationException {
-        String macroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
+        String explicitMacroName = RubyUtils.rubyToJava(getRuntime(), args[0], String.class);
 
         if (getProcessor() != null) {
+
+            String macroName = explicitMacroName != null ? explicitMacroName : getProcessor().getName();
+
             // Instance was created in Java and has options set, so we pass these
             // instead of those passed by asciidoctor
             Helpers.invokeSuper(
@@ -73,12 +76,12 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
                     getMetaClass(),
                     METHOD_NAME_INITIALIZE,
                     new IRubyObject[]{
-                            JavaEmbedUtils.javaToRuby(getRuntime(), getProcessor().getName()),
+                            JavaEmbedUtils.javaToRuby(getRuntime(), macroName),
                             RubyHashUtil.convertMapToRubyHashWithSymbols(getRuntime(), getProcessor().getConfig())},
                     Block.NULL_BLOCK);
 
-            if (macroName != null) {
-                getProcessor().setName(macroName);
+            if (explicitMacroName != null) {
+                getProcessor().setName(explicitMacroName);
             } else if (getProcessor().getName() == null) {
                 RubyHash config = (RubyHash) this.callMethod(context, "config");
                 Object rubyName = config.get(context.getRuntime().newSymbol("name"));
@@ -91,9 +94,9 @@ public class BlockProcessorProxy extends AbstractProcessorProxy<BlockProcessor> 
             getProcessor().updateConfig(new RubyHashMapDecorator((RubyHash) getInstanceVariable(MEMBER_NAME_CONFIG)));
         } else {
             // First create only the instance passing in the block name
-            setProcessor(instantiateProcessor(macroName, new HashMap<String, Object>()));
+            setProcessor(instantiateProcessor(explicitMacroName, new HashMap<String, Object>()));
 
-            getProcessor().setName(macroName);
+            getProcessor().setName(explicitMacroName);
 
             // Then create the config hash that may contain config options defined in the Java constructor
             RubyHash config = RubyHashUtil.convertMapToRubyHashWithSymbols(context.getRuntime(), getProcessor().getConfig());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaExtensionRegistryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaExtensionRegistryImpl.java
@@ -181,7 +181,7 @@ public class JavaExtensionRegistryImpl implements JavaExtensionRegistry {
     @Override
     public JavaExtensionRegistry block(BlockProcessor blockProcessor) {
         RubyClass rubyClass = BlockProcessorProxy.register(rubyRuntime, blockProcessor);
-        getAsciidoctorModule().callMethod("block_processor", rubyClass, rubyRuntime.newString(blockProcessor.getName()));
+        getAsciidoctorModule().callMethod("block_processor", rubyClass);
         return this;
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaExtensionRegistryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaExtensionRegistryImpl.java
@@ -247,17 +247,25 @@ public class JavaExtensionRegistryImpl implements JavaExtensionRegistry {
     }
 
     @Override
-    public JavaExtensionRegistry inlineMacro(InlineMacroProcessor inlineMacroProcessor) {
+    public JavaExtensionRegistry inlineMacro(String macroName,
+                                             InlineMacroProcessor inlineMacroProcessor) {
         RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        getAsciidoctorModule().callMethod("inline_macro", rubyClass, rubyRuntime.newString(inlineMacroProcessor.getName()));
+        getAsciidoctorModule().callMethod("inline_macro", rubyClass, rubyRuntime.newString(macroName));
         return this;
     }
 
     @Override
-    public JavaExtensionRegistry inlineMacro(String blockName,
+    public JavaExtensionRegistry inlineMacro(InlineMacroProcessor inlineMacroProcessor) {
+        RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
+        getAsciidoctorModule().callMethod("inline_macro", rubyClass);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry inlineMacro(String macroName,
                                              Class<? extends InlineMacroProcessor> inlineMacroProcessor) {
         RubyClass rubyClass = InlineMacroProcessorProxy.register(rubyRuntime, inlineMacroProcessor);
-        getAsciidoctorModule().callMethod("inline_macro", rubyClass, rubyRuntime.newString(blockName));
+        getAsciidoctorModule().callMethod("inline_macro", rubyClass, rubyRuntime.newString(macroName));
         return this;
     }
 
@@ -270,10 +278,10 @@ public class JavaExtensionRegistryImpl implements JavaExtensionRegistry {
     }
 
     @Override
-    public JavaExtensionRegistry inlineMacro(String blockName, String inlineMacroProcessor) {
+    public JavaExtensionRegistry inlineMacro(String macroName, String inlineMacroProcessor) {
         try {
             Class<? extends InlineMacroProcessor> inlineMacroProcessorClass = (Class<? extends InlineMacroProcessor>) Class.forName(inlineMacroProcessor);
-            inlineMacro(blockName, inlineMacroProcessorClass);
+            inlineMacro(macroName, inlineMacroProcessorClass);
             return this;
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaExtensionRegistryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/internal/JavaExtensionRegistryImpl.java
@@ -235,7 +235,14 @@ public class JavaExtensionRegistryImpl implements JavaExtensionRegistry {
     @Override
     public JavaExtensionRegistry blockMacro(BlockMacroProcessor blockMacroProcessor) {
         RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
-        getAsciidoctorModule().callMethod("block_macro", rubyClass, rubyRuntime.newString(blockMacroProcessor.getName()));
+        getAsciidoctorModule().callMethod("block_macro", rubyClass);
+        return this;
+    }
+
+    @Override
+    public JavaExtensionRegistry blockMacro(String macroName, BlockMacroProcessor blockMacroProcessor) {
+        RubyClass rubyClass = BlockMacroProcessorProxy.register(rubyRuntime, blockMacroProcessor);
+        getAsciidoctorModule().callMethod("block_macro", rubyClass, rubyRuntime.newString(macroName));
         return this;
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockMacroRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockMacroRegistrationTest.java
@@ -1,0 +1,150 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.internal.AsciidoctorCoreException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jsoup.Jsoup;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+public class BlockMacroRegistrationTest {
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor;
+
+    private String document(String blockName, String text) {
+        return "= Test\n" +
+            "\n" +
+            "== A section\n" +
+            "\n" +
+            blockName + "::" + text + "[]";
+    }
+
+    public static class AbstractTestProcessor extends BlockMacroProcessor {
+        @Override
+        public Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+            return createBlock(parent, "paragraph", target.toUpperCase());
+        }
+    }
+
+    public static class TestProcessorWithName extends BlockMacroProcessor {
+
+        public static final String NAME = "somename";
+
+        public TestProcessorWithName() {
+            super(NAME);
+        }
+
+        @Override
+        public Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+            return createBlock(parent, "paragraph", target.toUpperCase());
+        }
+    }
+
+    @Name(AnnotatedTestProcessor.NAME)
+    public static class AnnotatedTestProcessor extends AbstractTestProcessor {
+        public static final String NAME = "annotated";
+    }
+
+    @Test
+    public void testRegisterNamedClassAsClass() {
+        asciidoctor.javaExtensionRegistry().blockMacro(AnnotatedTestProcessor.class);
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Hello World"), OptionsBuilder.options());
+        check("HELLO WORLD", result);
+    }
+
+    @Test
+    public void testRegisterNamedClassAsClassWithExplicitName() {
+        final String explicitblockname = "explicitblockname";
+        asciidoctor.javaExtensionRegistry().blockMacro(explicitblockname, AnnotatedTestProcessor.class);
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), OptionsBuilder.options());
+        check("HELLO EXPLICIT", result);
+    }
+    @Test
+    public void testRegisterNamedClassAsInstance() {
+        asciidoctor.javaExtensionRegistry().blockMacro(new AnnotatedTestProcessor());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Another Test"), OptionsBuilder.options());
+        check("ANOTHER TEST", result);
+    }
+
+    @Test
+    public void testRegisterNamedClassAsInstanceWithExplicitName() {
+        final String blockName = "somename";
+        asciidoctor.javaExtensionRegistry().blockMacro(blockName, new AnnotatedTestProcessor());
+        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), OptionsBuilder.options());
+        check("YET ANOTHER TEST", result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterClassWithoutExplicitName() {
+        asciidoctor.javaExtensionRegistry().blockMacro(AbstractTestProcessor.class);
+    }
+
+
+    @Test
+    public void testRegisterClassAsClassWithExplicitName() {
+        final String explicitblockname = "anotherexplicitname";
+        asciidoctor.javaExtensionRegistry().blockMacro(explicitblockname, AbstractTestProcessor.class);
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Class"), OptionsBuilder.options());
+        check("HELLO EXPLICIT CLASS", result);
+    }
+
+    @Test(expected = AsciidoctorCoreException.class)
+    public void testRegisterClassAsInstance() {
+        asciidoctor.javaExtensionRegistry().blockMacro(new AbstractTestProcessor());
+        asciidoctor.convert(document("foo", "Hello Explicit Instance"), OptionsBuilder.options());
+    }
+
+    @Test
+    public void testRegisterClassAsInstanceWithExplicitName() {
+        final String explicitblockname = "aname";
+        asciidoctor.javaExtensionRegistry().blockMacro(explicitblockname, new AbstractTestProcessor());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Instance"), OptionsBuilder.options());
+        check("HELLO EXPLICIT INSTANCE", result);
+    }
+
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterClassWithNameAsClass() {
+        asciidoctor.javaExtensionRegistry().blockMacro(TestProcessorWithName.class);
+    }
+
+    @Test
+    public void testRegisterClassWithNameAsClassWithExplicitName() {
+        final String explicitblockname = "explicitblockname";
+        asciidoctor.javaExtensionRegistry().blockMacro(explicitblockname, TestProcessorWithName.class);
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), OptionsBuilder.options());
+        check("HELLO EXPLICIT", result);
+    }
+
+    @Test
+    public void testRegisterClassWithNameAsInstance() {
+        asciidoctor.javaExtensionRegistry().blockMacro(new TestProcessorWithName());
+        final String result = asciidoctor.convert(document(TestProcessorWithName.NAME, "Another Test"), OptionsBuilder.options());
+        check("ANOTHER TEST", result);
+    }
+
+    @Test
+    public void testRegisterClassWithNameAsInstanceWithExplicitName() {
+        final String blockName = "somename";
+        asciidoctor.javaExtensionRegistry().blockMacro(blockName, new TestProcessorWithName());
+        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), OptionsBuilder.options());
+        check("YET ANOTHER TEST", result);
+    }
+
+    private void check(String expected, String html) {
+        assertEquals(expected, Jsoup.parse(html).select("div.paragraph > p").first().text());
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockProcessorRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockProcessorRegistrationTest.java
@@ -1,0 +1,123 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.internal.AsciidoctorCoreException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jsoup.Jsoup;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+public class BlockProcessorRegistrationTest {
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor;
+
+    private String document(String blockName, String text) {
+        return "= Test\n" +
+            "\n" +
+            "== A section\n" +
+            "\n" +
+            "[" + blockName + "]\n" +
+            text + "\n";
+    }
+
+    public static class AbstractTestProcessor extends BlockProcessor {
+        @Override
+        public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
+            List<String> s = reader.readLines().stream()
+                .map(line -> 
+                    line.chars()
+                        .mapToObj(c -> Character.toString((char) c))
+                        .collect(joining(" ")))
+                .collect(toList());
+            return createBlock(parent, "paragraph", s);
+        }
+    }
+
+    @Name(AnnotatedTestProcessor.NAME)
+    public static class AnnotatedTestProcessor extends AbstractTestProcessor {
+        public static final String NAME = "annotated";
+    }
+
+    @Test
+    public void testRegisterNamedClassAsClass() {
+        asciidoctor.javaExtensionRegistry().block(AnnotatedTestProcessor.class);
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Hello World"), OptionsBuilder.options());
+        check("H e l l o W o r l d", result);
+    }
+
+    @Test
+    public void testRegisterNamedClassAsClassWithExplicitName() {
+        final String explicitblockname = "explicitblockname";
+        asciidoctor.javaExtensionRegistry().block(explicitblockname, AnnotatedTestProcessor.class);
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), OptionsBuilder.options());
+        check("H e l l o E x p l i c i t", result);
+    }
+
+    @Test
+    public void testRegisterNamedClassAsInstance() {
+        asciidoctor.javaExtensionRegistry().block(new AnnotatedTestProcessor());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Another Test"), OptionsBuilder.options());
+        check("A n o t h e r T e s t", result);
+    }
+
+    @Test
+    public void testRegisterNamedClassAsInstanceWithExplicitName() {
+        final String blockName = "somename";
+        asciidoctor.javaExtensionRegistry().block(blockName, new AnnotatedTestProcessor());
+        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), OptionsBuilder.options());
+        check("Y e t A n o t h e r T e s t", result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterClassWithoutExplicitName() {
+        asciidoctor.javaExtensionRegistry().block(AbstractTestProcessor.class);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterClassAsClass() {
+        asciidoctor.javaExtensionRegistry().block(AbstractTestProcessor.class);
+    }
+
+    @Test
+    public void testRegisterClassAsClassWithExplicitName() {
+        final String explicitblockname = "anotherexplicitname";
+        asciidoctor.javaExtensionRegistry().block(explicitblockname, AbstractTestProcessor.class);
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Class"), OptionsBuilder.options());
+        check("H e l l o E x p l i c i t C l a s s", result);
+    }
+
+    @Test(expected = AsciidoctorCoreException.class)
+    public void testRegisterClassAsInstance() {
+        asciidoctor.javaExtensionRegistry().block(new AbstractTestProcessor());
+        asciidoctor.convert(document("foo", "Hello Explicit Instance"), OptionsBuilder.options());
+    }
+
+    @Test
+    public void testRegisterClassAsInstanceWithExplicitName() {
+        final String explicitblockname = "aname";
+        asciidoctor.javaExtensionRegistry().block(explicitblockname, new AbstractTestProcessor());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Instance"), OptionsBuilder.options());
+        check("H e l l o E x p l i c i t I n s t a n c e", result);
+    }
+
+
+    private void check(String expected, String html) {
+        assertEquals(expected, Jsoup.parse(html).select("div.paragraph > p").first().text());
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/InlineMacroRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/InlineMacroRegistrationTest.java
@@ -1,0 +1,156 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.internal.AsciidoctorCoreException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jsoup.Jsoup;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static java.util.stream.Collectors.joining;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+public class InlineMacroRegistrationTest {
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor;
+
+    private String document(String blockName, String text) {
+        return "= Test\n" +
+            "\n" +
+            "== A section\n" +
+            "\n" +
+            "\nHello " + blockName + ":" + text + "[]";
+    }
+
+    public static class AbstractTestProcessor extends InlineMacroProcessor {
+        @Override
+        public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+            String transformed = target.chars()
+                .mapToObj(c -> Character.isUpperCase(c) ? " " + (char) c : Character.toString((char) c))
+                .collect(joining())
+                .toUpperCase().trim();
+            return createPhraseNode(parent, "quoted", transformed);
+        }
+    }
+
+    public static class TestProcessorWithName extends InlineMacroProcessor {
+
+        public static final String NAME = "somename";
+
+        public TestProcessorWithName() {
+            super(NAME);
+        }
+
+        @Override
+        public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+            String transformed = target.chars()
+                .mapToObj(c -> Character.isUpperCase(c) ? " " + (char) c : Character.toString((char) c))
+                .collect(joining())
+                .toUpperCase().trim();
+            return createPhraseNode(parent, "quoted", transformed);
+        }
+    }
+
+    @Name(AnnotatedTestProcessor.NAME)
+    public static class AnnotatedTestProcessor extends AbstractTestProcessor {
+        public static final String NAME = "annotated";
+    }
+
+    @Test
+    public void testRegisterNamedClassAsClass() {
+        asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedTestProcessor.class);
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "World"), OptionsBuilder.options());
+        check("Hello WORLD", result);
+    }
+
+    @Test
+    public void testRegisterNamedClassAsClassWithExplicitName() {
+        final String explicitblockname = "explicitblockname";
+        asciidoctor.javaExtensionRegistry().inlineMacro(explicitblockname, AnnotatedTestProcessor.class);
+        final String result = asciidoctor.convert(document(explicitblockname, "Explicit"), OptionsBuilder.options());
+        check("Hello EXPLICIT", result);
+    }
+
+    @Test
+    public void testRegisterNamedClassAsInstance() {
+        asciidoctor.javaExtensionRegistry().inlineMacro(new AnnotatedTestProcessor());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "AnotherTest"), OptionsBuilder.options());
+        check("Hello ANOTHER TEST", result);
+    }
+
+    @Test
+    public void testRegisterNamedClassAsInstanceWithExplicitName() {
+        final String blockName = "somename";
+        asciidoctor.javaExtensionRegistry().inlineMacro(blockName, new AnnotatedTestProcessor());
+        final String result = asciidoctor.convert(document(blockName, "YetAnotherTest"), OptionsBuilder.options());
+        check("Hello YET ANOTHER TEST", result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterClassWithoutExplicitName() {
+        asciidoctor.javaExtensionRegistry().inlineMacro(AbstractTestProcessor.class);
+    }
+
+
+    @Test
+    public void testRegisterClassAsClassWithExplicitName() {
+        final String explicitblockname = "anotherexplicitname";
+        asciidoctor.javaExtensionRegistry().inlineMacro(explicitblockname, AbstractTestProcessor.class);
+        final String result = asciidoctor.convert(document(explicitblockname, "ExplicitClass"), OptionsBuilder.options());
+        check("Hello EXPLICIT CLASS", result);
+    }
+
+    @Test(expected = AsciidoctorCoreException.class)
+    public void testRegisterClassAsInstance() {
+        asciidoctor.javaExtensionRegistry().inlineMacro(new AbstractTestProcessor());
+        asciidoctor.convert(document("foo", "HelloExplicitInstance"), OptionsBuilder.options());
+    }
+
+    @Test
+    public void testRegisterClassAsInstanceWithExplicitName() {
+        final String explicitblockname = "someexplicitname";
+        asciidoctor.javaExtensionRegistry().inlineMacro(explicitblockname, new AbstractTestProcessor());
+        final String result = asciidoctor.convert(document(explicitblockname, "ExplicitInstance"), OptionsBuilder.options());
+        check("Hello EXPLICIT INSTANCE", result);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterClassWithNameAsClass() {
+        asciidoctor.javaExtensionRegistry().inlineMacro(TestProcessorWithName.class);
+    }
+
+    @Test
+    public void testRegisterClassWithNameAsClassWithExplicitName() {
+        final String explicitblockname = "explicitblockname";
+        asciidoctor.javaExtensionRegistry().inlineMacro(explicitblockname, TestProcessorWithName.class);
+        final String result = asciidoctor.convert(document(explicitblockname, "Explicit"), OptionsBuilder.options());
+        check("Hello EXPLICIT", result);
+    }
+
+    @Test
+    public void testRegisterClassWithNameAsInstance() {
+        asciidoctor.javaExtensionRegistry().inlineMacro(new TestProcessorWithName());
+        final String result = asciidoctor.convert(document(TestProcessorWithName.NAME, "AnotherTest"), OptionsBuilder.options());
+        check("Hello ANOTHER TEST", result);
+    }
+
+    @Test
+    public void testRegisterClassWithNameAsInstanceWithExplicitName() {
+        final String blockName = "somename";
+        asciidoctor.javaExtensionRegistry().inlineMacro(blockName, new TestProcessorWithName());
+        final String result = asciidoctor.convert(document(blockName, "YetAnotherTest"), OptionsBuilder.options());
+        check("Hello YET ANOTHER TEST", result);
+    }
+
+    private void check(String expected, String html) {
+        assertEquals(expected, Jsoup.parse(html).select("div.paragraph > p").first().text());
+    }
+}


### PR DESCRIPTION
This PR fixes #754.

Before merging this I will also have to fix the same problem for macros, as they like have it as well.
