### PR TITLE
Fix initialization of extension in OSGi environments

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,40 @@
+= Asciidoctor Changelog
+:uri-asciidoctor: http://asciidoctor.org
+:uri-asciidoc: {uri-asciidoctor}/docs/what-is-asciidoc
+:uri-repo: https://github.com/asciidoctor/asciidoctorj
+:icons: font
+:star: icon:star[role=red]
+ifndef::icons[]
+:star: &#9733;
+endif::[]
+
+This document provides a high-level view of the changes introduced in AsciidoctorJ by release.
+For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
+
+== Unreleased
+
+Enhancements::
+
+Improvements::
+
+Bug Fixes::
+
+  * Fix extension initialization in OSGi environments(#754)
+
+Build / Infrastructure::
+
+
+== 1.6.1 (2018-10-28) - @mojavelinux
+
+Enhancements::
+
+  * Upgrade asciidoctorj-diagram to 1.5.12
+
+Bug Fixes::
+
+  * Fix registration of extension as instances (#754)
+
+
+Documentation::
+
+  * Add extension migration guide

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/BaseProcessor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/BaseProcessor.java
@@ -14,10 +14,7 @@ import org.asciidoctor.ast.Section;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.Table;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
+import java.util.*;
 
 public class BaseProcessor implements Processor {
 
@@ -32,13 +29,20 @@ public class BaseProcessor implements Processor {
     }
 
     public BaseProcessor(Map<String, Object> config) {
-        // FIXME: Use a strategy to resolve the processor
-        this(ServiceLoader.load(Processor.class).iterator().next(), config);
+        this(resolveProcessor(), config);
     }
 
     public BaseProcessor(Processor delegate, Map<String, Object> config) {
         this.delegate = delegate;
         this.delegate.setConfig(config);
+    }
+
+    private static Processor resolveProcessor() {
+        Iterator<Processor> iterator = ServiceLoader.load(Processor.class).iterator();
+        if (!iterator.hasNext()) {
+            iterator = ServiceLoader.load(Processor.class, BaseProcessor.class.getClassLoader()).iterator();
+        }
+        return iterator.next();
     }
 
     @Override


### PR DESCRIPTION
This PR fixes #754.
In OSGi environments the TCCL seems to be set in a way so that the Processor service class cannot be found by java.util.ServiceLoader.
Added a fallback to also use the class loader of the local class.