### PR TITLE
Upgrade JRuby to 9.2.6.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,8 @@ Enhancements::
 
 Improvements::
 
+  * Upgrade to JRuby 9.2.6.0. This version of AsciidoctorJ is incompatible with any version of JRuby <= 9.2.5.0
+
 Bug Fixes::
 
   * Fix extension initialization in OSGi environments(#754)
@@ -24,7 +26,7 @@ Bug Fixes::
 Build / Infrastructure::
 
 
-== 1.6.1 (2018-10-28) - @mojavelinux
+== 1.6.1 (2018-10-28)
 
 Enhancements::
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/log/internal/JavaLogger.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/log/internal/JavaLogger.java
@@ -19,6 +19,7 @@ import org.jruby.runtime.backtrace.BacktraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public class JavaLogger extends RubyObject {
 
@@ -94,9 +95,12 @@ public class JavaLogger extends RubyObject {
                                     final Severity severity,
                                     final Cursor cursor,
                                     final String message) {
-    BacktraceElement[] backtrace = threadContext.getBacktrace();
-    final String sourceFileName = backtrace[2].getFilename();
-    final String sourceMethodName = backtrace[2].getMethod();
+    final Optional<BacktraceElement> elem = threadContext.getBacktrace(0)
+        .skip(1)
+        .findFirst();
+
+    final String sourceFileName = elem.map(BacktraceElement::getFilename).orElse(null);
+    final String sourceMethodName = elem.map(BacktraceElement::getMethod).orElse(null);
     final LogRecord record = new LogRecord(severity, cursor, message, sourceFileName, sourceMethodName);
     return record;
   }

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.35'
-  jrubyVersion = '9.2.5.0'
+  jrubyVersion = '9.2.6.0'
   jsoupVersion = '1.10.2'
   junitVersion = '4.12'
   nettyVersion = '4.0.33.Final'


### PR DESCRIPTION
In addition to only bumping the version of JRuby there is also a change of an internal API for the backtrace elements.
The PR aligns to this so that AsciidoctorJ 1.6.2 will be incompatible with JRuby <= 9.2.5.0.