### PR TITLE
Fix upstream

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/converter/internal/ConverterProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/converter/internal/ConverterProxy.java
@@ -45,6 +45,7 @@ public class ConverterProxy<T> extends RubyObject {
                 rubyRuntime.getObject(),
                 new ConverterProxy.Allocator(converterClass));
         includeModule(clazz, "Asciidoctor", "Converter");
+        includeModule(clazz, "Asciidoctor", "Converter", "BackendTraits");
 
         clazz.defineAnnotatedMethod(ConverterProxy.class, "initialize");
         clazz.defineAnnotatedMethod(ConverterProxy.class, "convert");
@@ -186,7 +187,7 @@ public class ConverterProxy<T> extends RubyObject {
         RubyModule module = clazz.getRuntime().getModule(moduleName);
         if (moduleNames != null && moduleNames.length > 0) {
             for (String submoduleName: moduleNames) {
-                module = module.defineOrGetModuleUnder(submoduleName);
+                module = module.getModule(submoduleName);
             }
         }
         clazz.includeModule(module);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
@@ -71,7 +71,7 @@ public class WhenConverterIsRegistered {
         // Register as default converter
         asciidoctor.javaConverterRegistry().register(DummyConverter.class);
 
-        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options());
+        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options().backend("Undefined"));
 
         assertThat(result, is("Dummy"));
     }


### PR DESCRIPTION
This PR adapts AsciidoctorJ to the latest changes in Asciidoctor upstream.
Besides changes to the converter registration, also the structure of DefinitionLists in the AST has changed.

This PR must not be merged prior to Asciidoctor 2.0.0 as the changes are incompatible with the current version of Asciidoctor, 1.5.8.