### PR TITLE
Asciidoctor 2.0.0

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/converter/internal/ConverterProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/converter/internal/ConverterProxy.java
@@ -45,6 +45,7 @@ public class ConverterProxy<T> extends RubyObject {
                 rubyRuntime.getObject(),
                 new ConverterProxy.Allocator(converterClass));
         includeModule(clazz, "Asciidoctor", "Converter");
+        includeModule(clazz, "Asciidoctor", "Converter", "BackendTraits");
 
         clazz.defineAnnotatedMethod(ConverterProxy.class, "initialize");
         clazz.defineAnnotatedMethod(ConverterProxy.class, "convert");
@@ -186,7 +187,7 @@ public class ConverterProxy<T> extends RubyObject {
         RubyModule module = clazz.getRuntime().getModule(moduleName);
         if (moduleNames != null && moduleNames.length > 0) {
             for (String submoduleName: moduleNames) {
-                module = module.defineOrGetModuleUnder(submoduleName);
+                module = module.getModule(submoduleName);
             }
         }
         clazz.includeModule(module);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/processorproxies/AbstractProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/processorproxies/AbstractProcessorProxy.java
@@ -217,7 +217,7 @@ public class AbstractProcessorProxy<T extends Processor> extends RubyObject {
                 positionalAttrs.add(positionalAttribute);
             }
             rubyClass.callMethod(rubyRuntime.getCurrentContext(), "option", new IRubyObject[]{
-                    rubyRuntime.newSymbol("pos_attrs"),
+                    rubyRuntime.newSymbol("positional_attrs"),
                     positionalAttrs
             });
         }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
@@ -71,7 +71,7 @@ public class WhenConverterIsRegistered {
         // Register as default converter
         asciidoctor.javaConverterRegistry().register(DummyConverter.class);
 
-        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options());
+        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options().backend("Undefined"));
 
         assertThat(result, is("Dummy"));
     }

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -48,7 +48,7 @@ startScripts {
   unixStartScriptGenerator.template = resources.text.fromFile('src/main/resources/customUnixStartScript.txt')
 
   applicationName = rootProject.name
-  mainClassName = 'org.asciidoctor.cli.AsciidoctorInvoker'
+  mainClassName = 'org.asciidoctor.jruby.cli.AsciidoctorInvoker'
   defaultJvmOpts = [
     '-client', '-Xmn128m', '-Xms256m', '-Xmx256m',
     '-Xverify:none', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC', '-Djruby.compile.mode=OFF'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
   arquillianSpockVersion = '1.0.0.Beta3'
   asciidoctorjPdfVersion = '1.5.0-alpha.16'
   asciidoctorjEpub3Version = '1.5.0-alpha.8.1'
-  asciidoctorjDiagramVersion = '1.5.12'
+  asciidoctorjDiagramVersion = '1.5.16'
   commonsioVersion = '2.4'
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -54,19 +54,19 @@ ext {
   pdfboxVersion = '1.8.10'
 
   // gem versions
-  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '1.5.8'
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.0'
   coderayGemVersion = '1.1.0'
 
   codenarcVersion = '0.24.1'
   groovyVersion = '2.4.13'
   erubisGemVersion = '2.7.0'
-  hamlGemVersion = '4.0.5'
+  hamlGemVersion = '5.0.4'
   openUriCachedGemVersion = '0.0.5'
-  slimGemVersion = '3.0.6'
+  slimGemVersion = '4.0.1'
   concurrentRubyGemVersion = '1.0.5'
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.6'
-  tiltGemVersion = '2.0.8'
+  tiltGemVersion = '2.0.9'
 }
 
 allprojects {


### PR DESCRIPTION
This PR upgrades Asciidoctor core to 2.0.0.
I also upgraded a few of the other gems after looking at the dependencies of Asciidoctor and what are the most current compatible versions.

For a release a new version of asciidoctor-diagram and asciidoctorj-diagram is required.

Once we have that I would like to release an AsciidoctorJ 1.7.0.
(I don't want to release a 2.0.0 yet given that there is still so much disagreement about how the API should look like in the future)