### PR TITLE
Fix logger and upgrade to Asciidoctor 2.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install: ./gradlew -S -Pskip.signing assemble
 before_script: unset GEM_PATH GEM_HOME JRUBY_OPTS
 
 script: ./gradlew -S -Pskip.signing check && bash test-asciidoctor-upstream.sh
-after_success: if [ "${TRAVIS_BRANCH}" = "asciidoctorj-1.6.0" -a "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_JDK_VERSION}" = "oraclejdk8" ]; then ./gradlew clean build artifactoryPublish -x test ; fi
+after_success: if [ "${TRAVIS_BRANCH}" = "master" -a "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_JDK_VERSION}" = "oraclejdk8" ]; then ./gradlew clean build artifactoryPublish -x test ; fi
 notifications:
   email: false
   irc:

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/JavaLogger.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/JavaLogger.java
@@ -93,8 +93,7 @@ public class JavaLogger extends RubyObject {
 
   @JRubyMethod(name = "fatal", required = 1, optional = 1)
   public IRubyObject fatal(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
-    final Severity severity = Severity.FATAL;
-    return log(threadContext, args, block, severity);
+    return log(threadContext, args, block, Severity.FATAL);
   }
 
   @JRubyMethod(name = "fatal?")
@@ -104,8 +103,7 @@ public class JavaLogger extends RubyObject {
 
   @JRubyMethod(name = "error", required = 1, optional = 1)
   public IRubyObject error(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
-    final Severity severity = Severity.ERROR;
-    return log(threadContext, args, block, severity);
+    return log(threadContext, args, block, Severity.ERROR);
   }
 
   @JRubyMethod(name = "error?")
@@ -115,8 +113,7 @@ public class JavaLogger extends RubyObject {
 
   @JRubyMethod(name = "warn", required = 1, optional = 1)
   public IRubyObject warn(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
-    final Severity severity = Severity.WARN;
-    return log(threadContext, args, block, severity);
+    return log(threadContext, args, block, Severity.WARN);
   }
 
   @JRubyMethod(name = "warn?")
@@ -126,8 +123,7 @@ public class JavaLogger extends RubyObject {
 
   @JRubyMethod(name = "info", required = 1, optional = 1)
   public IRubyObject info(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
-    final Severity severity = Severity.INFO;
-    return log(threadContext, args, block, severity);
+    return log(threadContext, args, block, Severity.INFO);
   }
 
   @JRubyMethod(name = "info?")
@@ -137,8 +133,7 @@ public class JavaLogger extends RubyObject {
 
   @JRubyMethod(name = "debug", required = 1, optional = 1)
   public IRubyObject debug(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
-    final Severity severity = Severity.DEBUG;
-    return log(threadContext, args, block, severity);
+    return log(threadContext, args, block, Severity.DEBUG);
   }
 
   @JRubyMethod(name = "debug?")

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/JavaLogger.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/JavaLogger.java
@@ -91,6 +91,79 @@ public class JavaLogger extends RubyObject {
     return getRuntime().getNil();
   }
 
+  @JRubyMethod(name = "fatal", required = 1, optional = 1)
+  public IRubyObject fatal(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
+    final Severity severity = Severity.FATAL;
+    return log(threadContext, args, block, severity);
+  }
+
+  @JRubyMethod(name = "fatal?")
+  public IRubyObject fatal(final ThreadContext threadContext) {
+    return getRuntime().getTrue();
+  }
+
+  @JRubyMethod(name = "error", required = 1, optional = 1)
+  public IRubyObject error(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
+    final Severity severity = Severity.ERROR;
+    return log(threadContext, args, block, severity);
+  }
+
+  @JRubyMethod(name = "error?")
+  public IRubyObject error(final ThreadContext threadContext) {
+    return getRuntime().getTrue();
+  }
+
+  @JRubyMethod(name = "warn", required = 1, optional = 1)
+  public IRubyObject warn(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
+    final Severity severity = Severity.WARN;
+    return log(threadContext, args, block, severity);
+  }
+
+  @JRubyMethod(name = "warn?")
+  public IRubyObject warn(final ThreadContext threadContext) {
+    return getRuntime().getTrue();
+  }
+
+  @JRubyMethod(name = "info", required = 1, optional = 1)
+  public IRubyObject info(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
+    final Severity severity = Severity.INFO;
+    return log(threadContext, args, block, severity);
+  }
+
+  @JRubyMethod(name = "info?")
+  public IRubyObject info(final ThreadContext threadContext) {
+    return getRuntime().getTrue();
+  }
+
+  @JRubyMethod(name = "debug", required = 1, optional = 1)
+  public IRubyObject debug(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
+    final Severity severity = Severity.DEBUG;
+    return log(threadContext, args, block, severity);
+  }
+
+  @JRubyMethod(name = "debug?")
+  public IRubyObject debug(final ThreadContext threadContext) {
+    return getRuntime().getTrue();
+  }
+
+
+  private IRubyObject log(ThreadContext threadContext, IRubyObject[] args, Block block, Severity severity) {
+    final IRubyObject rubyMessage;
+    if (block.isGiven()) {
+      rubyMessage = block.yield(threadContext, getRuntime().getNil());
+    } else {
+      rubyMessage = args[0];
+    }
+    final Cursor cursor = getSourceLocation(rubyMessage);
+    final String message = formatMessage(rubyMessage);
+
+    final LogRecord record = createLogRecord(threadContext, severity, cursor, message);
+
+    rootLogHandler.log(record);
+    return getRuntime().getNil();
+  }
+
+
   private LogRecord createLogRecord(final ThreadContext threadContext,
                                     final Severity severity,
                                     final Cursor cursor,
@@ -100,7 +173,8 @@ public class JavaLogger extends RubyObject {
             .findFirst();
 
     final String sourceFileName = elem.map(BacktraceElement::getFilename).orElse(null);
-    final String sourceMethodName = elem.map(BacktraceElement::getMethod).orElse(null);    final LogRecord record = new LogRecord(severity, cursor, message, sourceFileName, sourceMethodName);
+    final String sourceMethodName = elem.map(BacktraceElement::getMethod).orElse(null);
+    final LogRecord record = new LogRecord(severity, cursor, message, sourceFileName, sourceMethodName);
     return record;
   }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -17,7 +17,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -99,13 +98,7 @@ public class WhenAsciidoctorLogsToConsole {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 
-        final LogHandler logHandler = new LogHandler() {
-            @Override
-            public void log(LogRecord logRecord) {
-                logRecords.add(logRecord);
-            }
-        };
-        asciidoctor.registerLogHandler(logHandler);
+        asciidoctor.registerLogHandler(logRecords::add);
 
         File inputFile = classpath.getResource("documentwithnotexistingfile.adoc");
         String renderContent = asciidoctor.convertFile(inputFile,
@@ -135,18 +128,11 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    @Ignore("Until logging of invalid refs is enabled by default")
     public void shouldLogInvalidRefs() throws Exception {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 
-        final LogHandler logHandler = new LogHandler() {
-            @Override
-            public void log(LogRecord logRecord) {
-                logRecords.add(logRecord);
-            }
-        };
-        asciidoctor.registerLogHandler(logHandler);
+        asciidoctor.registerLogHandler(logRecords::add);
 
         File inputFile = classpath.getResource("documentwithinvalidrefs.adoc");
         String renderContent = asciidoctor.convertFile(inputFile,
@@ -171,14 +157,7 @@ public class WhenAsciidoctorLogsToConsole {
 
         final Asciidoctor secondInstance = Asciidoctor.Factory.create();
 
-        final LogHandler logHandler = new LogHandler() {
-            @Override
-            public void log(LogRecord logRecord) {
-                logRecords.add(logRecord);
-            }
-        };
-        // Register at first instance!
-        asciidoctor.registerLogHandler(logHandler);
+        asciidoctor.registerLogHandler(logRecords::add);
 
         // Now render via second instance and check that there is no notification
         File inputFile = classpath.getResource("documentwithnotexistingfile.adoc");
@@ -220,12 +199,7 @@ public class WhenAsciidoctorLogsToConsole {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 
-        final LogHandler logHandler = new LogHandler() {
-            @Override
-            public void log(LogRecord logRecord) {
-                logRecords.add(logRecord);
-            }
-        };
+        final LogHandler logHandler = logRecords::add;
         asciidoctor.registerLogHandler(logHandler);
 
         File inputFile = classpath.getResource("documentwithnotexistingfile.adoc");
@@ -311,13 +285,7 @@ public class WhenAsciidoctorLogsToConsole {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 
-        final LogHandler logHandler = new LogHandler() {
-            @Override
-            public void log(LogRecord logRecord) {
-                logRecords.add(logRecord);
-            }
-        };
-        asciidoctor.registerLogHandler(logHandler);
+        asciidoctor.registerLogHandler(logRecords::add);
         asciidoctor.javaExtensionRegistry().block(LoggingProcessor.class);
 
         String renderContent = asciidoctor.convert("= Test\n\n== Something different\n\n[big]\nHello World",

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ ext {
   pdfboxVersion = '1.8.10'
 
   // gem versions
-  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.2'
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.5'
   coderayGemVersion = '1.1.0'
 
   codenarcVersion = '0.24.1'


### PR DESCRIPTION
This PR implements the methods for the logger stub that were missing from its Ruby counterpart but which are called by Asciidoctor.
That way logging of invalid refs should work now without having to enable the $VERBOSE variable.
This change also appeared in https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/389

Additionally this PR upgrades Asciidoctor to 2.0.5 plus it should hopefully publish snapshot builds of master.