### PR TITLE
Moved docs about ExtensionRegistry to integrator guide with tests.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -597,6 +597,9 @@ assertThat(findBy, hasSize(2)); //<3>
 
 == Extension API
 
+[NOTE]
+If you are migrating existing extensions to a newer version of AsciidoctorJ please read the <<docs/extension-migration-guide#,Extension Migration Guide>>
+
 One of the major improvements to Asciidoctor recently is the extensions API.
 AsciidoctorJ brings this extension API to the JVM environment.
 {uri-repo}[AsciidoctorJ] allows us to write extensions in Java instead of Ruby.

--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-discuss: http://discuss.asciidoctor.org
-:artifact-version: 1.6.1
+:artifact-version: 2.0.0-RC.1
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
 :uri-maven-artifact-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}
@@ -668,47 +668,6 @@ class YellRubyBlock < Asciidoctor::Extensions::BlockProcessor
 end
 ----
 
-=== Extension SPI
-
-In previous examples, the extensions were registered manually.
-However, AsciidoctorJ provides another way to register extensions.
-If any implementation of the SPI interface is present on the classpath, it will be executed.
-
-To create an autoloadable extension you should do next steps.
-
-Create a class that implements `org.asciidoctor.extension.spi.ExtensionRegistry`.
-
-[source]
-.org.asciidoctor.extension.ArrowsAndBoxesExtension.java
-----
-public class ArrowsAndBoxesExtension implements ExtensionRegistry { // <1>
-
-  @Override
-  public void register(Asciidoctor asciidoctor) { // <2>
-
-    JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
-    javaExtensionRegistry.postprocessor(ArrowsAndBoxesIncludesPostProcessor.class); // <3>
-    javaExtensionRegistry.block("arrowsAndBoxes", ArrowsAndBoxesBlock.class);
-
-  }
-
-}
-----
-<1> To autoload extensions you need to implement `ExtensionRegistry`.
-<2> AsciidoctorJ will automatically run the `register` method. The method is responsible for registering all extensions.
-<3> All required Java extensions are registered.
-
-Next, you need to create a file called `org.asciidoctor.extension.spi.ExtensionRegistry` inside `META-INF/services` with the implementation's full qualified name.
-
-[source]
-.META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry
-----
-org.asciidoctor.extension.ArrowsAndBoxesExtension
-----
-
-And that's all.
-Now when a `.jar` file containing the previous structure is dropped inside classpath of AsciidoctorJ, the `register` method will be executed automatically and the extensions will be registered.
-
 == Logs handling API
 
 [NOTE]
@@ -1046,13 +1005,15 @@ If you want to use AsciidoctorJ in an application deployed on [app]_WildFly AS_,
 . Create the following folder tree: [path]_$JBOSS_HOME/modules/org/asciidoctor/main_.
 . Create the module descriptor file [path]_module.xml_.
 +
+[subs="+attributes"]
 [source,xml]
 .Asciidoctor module descriptor for WildFly AS
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.0" name="org.asciidoctor">
     <resources>
-        <resource-root path="asciidoctorj-1.5.4.jar"/>
+        <resource-root path="asciidoctorj-api-{artifact-version}.jar"/>
+        <resource-root path="asciidoctorj-{artifact-version}.jar"/>
         <resource-root path="jcommander-1.35.jar"/>
         <resource-root path="jruby-complete-1.7.21.jar"/>
     </resources>
@@ -1184,8 +1145,13 @@ Each subproject produces a primary artifact (e.g., jar or zip) and its supportin
 
 The subprojects are as follows:
 
+asciidoctorj-api::
+  The common API for AsciidoctorJ.
+  Other implementations for different platforms than JRuby may reuse and implement this API.
+  Produces the asciidoctorj-api.jar
+
 asciidoctorj::
-  The main Java bindings for the Asciidoctor RubyGem (asciidoctor).
+  The main Java bindings for the Asciidoctor RubyGem (asciidoctor) running on JRuby.
   Also bundles optional RubyGems needed at runtime, such as coderay, tilt, haml and slim.
   Produces the asciidoctorj jar.
 
@@ -1223,6 +1189,8 @@ gradle/
   publish.gradle
   sign.gradle
 asciidoctorj-arquillian-extension/
+  build.gradle
+asciidoctorj-api/
   build.gradle
 asciidoctorj-core/
   build.gradle
@@ -1324,13 +1292,13 @@ To build, assemble (but not sign) and install the archives (jars and distributio
 To build, assemble, sign and publish the archives (jars and distribution zip) to Bintray, run:
 
  $ ./gradlew clean
-   ./gradlew -i -x pMNPTML bintrayUpload
+   ./gradlew -i -x pMNPTML asciidoctorj-api:bintrayUpload asciidoctorj:bintrayUpload asciidoctorj-distribution:bintrayUpload
 
 CAUTION: Don't run the `clean` task in the same execution as the `bintrayUpload` because it will not upload one of the signatures.
 
 If you want to first perform a dry run of the upload, add the `dryRun=true` property.
 
- $ ./gradlew -i -PdryRun=true -x pMNPTML bintrayUpload
+ $ ./gradlew -i -PdryRun=true -x pMNPTML asciidoctorj-api:bintrayUpload asciidoctorj:bintrayUpload asciidoctorj-distribution:bintrayUpload
 
 NOTE: The `-x pMNPTML` is necessary to work around a bug in the publishing plugin that prevents it from signing the archives.
 
@@ -1342,7 +1310,7 @@ Currently, Gradle is not configured to automatically tag a release, so *you have
 
 To publish a snapshot version simply run:
 
- $ ./gradlew artifactoryPublish
+ $ ./gradlew asciidoctorj-api:artifactoryPublish asciidoctorj:artifactoryPublish asciidoctorj-distribution:artifactoryPublish
 
 This will publish the all artifacts that have a snapshot version number to https://oss.jfrog.org.
 

--- a/asciidoctorj-documentation/src/main/asciidoc/extension-migration-guide.adoc
+++ b/asciidoctorj-documentation/src/main/asciidoc/extension-migration-guide.adoc
@@ -39,12 +39,82 @@ ifdef::awestruct,env-browser[]
 toc::[]
 endif::[]
 
+This document explains the necessary steps to lift an extension from an older version of AsciidoctorJ to a newer version.
+If you want to migrate from 1.5.x to the latest version, i.e. 2.0.x, please follow all individual sections, i.e. first <<Migrate15x-16x>> and then <<Migrate16x-20x>>.
+
+[[Migrate16x-20x]]
+== Migrating from AsciidoctorJ 1.6.x to 2.0.x
+
+Between 1.6.x and 2.0.x there are only very few API changes that affect an extension writer.
+
+You might have implemented the `org.asciidoctor.extension.spi.ExtensionRegistry` Service Interface to automatically register extensions as explained in the <<integrator-guide.adoc#ExtensionSPI,Integrator Guide>>.
+To achieve this you might have added these two artifacts:
+
+First the implementation:
+
+[source,java]
+.MyExtension.java for AsciidoctorJ 1.5.x or 1.6.x
+----
+package com.example;
+
+import org.asciidoctor.extension.spi.ExtensionRegistry;
+
+public class MyExtension implements ExtensionRegistry {
+  @Override
+  public void register(Asciidoctor asciidoctor) {
+    JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
+    javaExtensionRegistry.treeprocessor(MyTreeprocessor.class);
+  }
+}
+----
+
+Additionally you have added a file in `META-INF/services/` that declares your extensions and allows it to be discovered:
+
+./META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry for AsciidoctorJ 1.5.x or 1.6.x
+----
+com.example.MyExtension
+----
+
+Now the interface `org.asciidoctor.extension.spi.ExtensionRegistry` moved to `org.asciidoctor.jruby.extension.spi.ExtensionRegistry`.
+That means that you have to update the name of the interface and rename the file in `/META-INF/services/`.
+In particular the last step is easily overseen as the compiler will not warn you.
+
+Therefore the implementation has to look like this:
+
+[source,java]
+.MyExtension.java for AsciidoctorJ 2.0.x
+----
+package com.example;
+
+import org.asciidoctor.jruby.extension.spi.ExtensionRegistry; // <1>
+
+public class MyExtension implements ExtensionRegistry {
+  @Override
+  public void register(Asciidoctor asciidoctor) {
+    JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
+    javaExtensionRegistry.treeprocessor(MyTreeprocessor.class);
+  }
+}
+----
+<1> Import ExtensionRegistry from the new package
+
+Additionally the file `/META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry` has to be renamed to `/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry`.
+
+./META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry for AsciidoctorJ 2.0.x
+----
+com.example.MyExtension
+----
+
+
+[[Migrate15x-16x]]
+== Migrating from AsciidoctorJ 1.5.x to 1.6.x
+
 AsciidoctorJ 1.6.0 fixed many issues with extensions, but also brought some incompatible changes in comparison to 1.5.x.
 In fact these incompatible changes were necessary to fix some of these bugs.
 This guide explains how to migrate an existing extension for AsciidoctorJ 1.5.x to 1.6.0.
 We will take an existing extension from the 1.5.x test cases and migrate it step by step to 1.5.x.
 
-== The original extension
+=== The original extension
 
 As an example we are taking the `YellStaticBlock` extension.
 This is a BlockProcessor that transforms the contents of the corresponding block to upper case.
@@ -112,7 +182,7 @@ import org.asciidoctor.ast.AbstractBlock;
 This is because the AST interfaces were renamed to better represent their purpose.
 The next section shows how these have to be updated.
 
-== Update to new AST class names
+=== Update to new AST class names
 
 The following table shows the new AST class names with their counterparts in AsciidoctorJ 1.5.x.
 See the <<integrator-guide#,Integrator Guide>> for details about the purpose of the classes.
@@ -216,7 +286,7 @@ Finally it is rather ugly that the constructor has to take a parameter `config`,
 
 The next section shows how this can be done in a more concise way.
 
-== Instantiating and configuring extensions
+=== Instantiating and configuring extensions
 
 The configuration of an extension has to be known at the time of registration.
 With AsciidoctorJ 1.5.x the way to define the configuration was to pass it to the super constructor and every extension type had to implement one certain constructor.

--- a/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
+++ b/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
@@ -19,7 +19,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-discuss: http://discuss.asciidoctor.org
-:artifact-version: 1.6.0
+:artifact-version: 2.0.0-RC.1
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
 :uri-maven-artifact-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}
@@ -1025,6 +1025,35 @@ include::src/test/java/org/asciidoctor/integrationguide/extension/RobotsDocinfoP
 <3> Docinfo Processors will only be called by Asciidoctor if the safe mode is at least `SECURE`.
 <4> Test via the Jsoup HTML parsing library that our meta tag was correctly added to the resulting document.
 
+=== Extension SPI
+
+In previous examples, the extensions were registered manually.
+However, AsciidoctorJ provides another way to register extensions.
+If any implementation of the SPI interface is present on the classpath, it will be executed.
+
+To create an autoloadable extension you should do the next steps:
+
+Create a class that implements `org.asciidoctor.jruby.extension.spi.ExtensionRegistry`.
+
+[source]
+.org.asciidoctor.extension.integratorguide.TerminalCommandExtension.java
+----
+include::src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandExtension.java[tags=include-extension-registry]
+----
+<1> To autoload extensions you need to implement `ExtensionRegistry`.
+<2> AsciidoctorJ will automatically run the `register` method. The method is responsible for registering all extensions.
+<3> All required Java extensions are registered.
+
+Next, you need to create a file called `org.asciidoctor.jruby.extension.spi.ExtensionRegistry` inside `META-INF/services` with the implementation's full qualified name.
+
+[source]
+.META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
+----
+include::src/test/resources/extensionregistry/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry[]
+----
+
+And that's all.
+Now when a `.jar` file containing the previous structure is dropped inside classpath of AsciidoctorJ, the `register` method will be executed automatically and the extensions will be registered.
 
 
 == Publish everywhere: Adapt Asciidoctor to your own target format

--- a/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
+++ b/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
@@ -1025,6 +1025,7 @@ include::src/test/java/org/asciidoctor/integrationguide/extension/RobotsDocinfoP
 <3> Docinfo Processors will only be called by Asciidoctor if the safe mode is at least `SECURE`.
 <4> Test via the Jsoup HTML parsing library that our meta tag was correctly added to the resulting document.
 
+[[ExtensionSPI]]
 === Extension SPI
 
 In previous examples, the extensions were registered manually.

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandExtension.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandExtension.java
@@ -1,0 +1,16 @@
+package org.asciidoctor.integrationguide.extension;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.extension.JavaExtensionRegistry;
+
+//tag::include-extension-registry[]
+import org.asciidoctor.jruby.extension.spi.ExtensionRegistry;
+
+public class TerminalCommandExtension implements ExtensionRegistry { // <1>
+  @Override
+  public void register(Asciidoctor asciidoctor) { // <2>
+    JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
+    javaExtensionRegistry.treeprocessor(TerminalCommandTreeprocessor.class); // <3>
+  }
+}
+//end::include-extension-registry[]

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessorTest.java
@@ -9,6 +9,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -49,6 +51,44 @@ public class TerminalCommandTreeprocessorTest {
 //end::include[]
 
         assertThat(result, is(referenceResult));
+    }
+
+    @Test
+    public void should_process_terminal_listings_after_registering_via_extension_registry() throws Exception {
+
+        File referenceDocument = classpathResources.getResource("treeprocessorresult.adoc");
+
+        String referenceResult = asciidoctor.convertFile(
+                referenceDocument,
+                OptionsBuilder.options()
+                        .headerFooter(false)
+                        .toFile(false));
+
+//tag::include-extension-registry[]
+        File src = //...
+//end::include-extension-registry[]
+            classpathResources.getResource("treeprocessorcontent.adoc");
+
+
+        ClassLoader oldTCCL = Thread.currentThread().getContextClassLoader();
+
+        try {
+            URL serviceDir = classpathResources.getResource("extensionregistry").toURI().toURL();
+            URLClassLoader tccl = new URLClassLoader(new URL[]{serviceDir});
+            Thread.currentThread().setContextClassLoader(tccl);
+
+            Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+//tag::include-extension-registry[]
+        String result = asciidoctor.convertFile(
+            src,
+            OptionsBuilder.options()
+                .headerFooter(false)
+                .toFile(false));
+//end::include-extension-registry[]
+            assertThat(result, is(referenceResult));
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldTCCL);
+        }
     }
 
 

--- a/asciidoctorj-documentation/src/test/resources/extensionregistry/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
+++ b/asciidoctorj-documentation/src/test/resources/extensionregistry/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
@@ -1,0 +1,1 @@
+org.asciidoctor.integrationguide.extension.TerminalCommandExtension

--- a/docs/extension-migration-guide.adoc
+++ b/docs/extension-migration-guide.adoc
@@ -39,12 +39,82 @@ ifdef::awestruct,env-browser[]
 toc::[]
 endif::[]
 
+This document explains the necessary steps to lift an extension from an older version of AsciidoctorJ to a newer version.
+If you want to migrate from 1.5.x to the latest version, i.e. 2.0.x, please follow all individual sections, i.e. first <<Migrate15x-16x>> and then <<Migrate16x-20x>>.
+
+[[Migrate16x-20x]]
+== Migrating from AsciidoctorJ 1.6.x to 2.0.x
+
+Between 1.6.x and 2.0.x there are only very few API changes that affect an extension writer.
+
+You might have implemented the `org.asciidoctor.extension.spi.ExtensionRegistry` Service Interface to automatically register extensions as explained in the <<integrator-guide.adoc#ExtensionSPI,Integrator Guide>>.
+To achieve this you might have added these two artifacts:
+
+First the implementation:
+
+[source,java]
+.MyExtension.java for AsciidoctorJ 1.5.x or 1.6.x
+----
+package com.example;
+
+import org.asciidoctor.extension.spi.ExtensionRegistry;
+
+public class MyExtension implements ExtensionRegistry {
+  @Override
+  public void register(Asciidoctor asciidoctor) {
+    JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
+    javaExtensionRegistry.treeprocessor(MyTreeprocessor.class);
+  }
+}
+----
+
+Additionally you have added a file in `META-INF/services/` that declares your extensions and allows it to be discovered:
+
+./META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry for AsciidoctorJ 1.5.x or 1.6.x
+----
+com.example.MyExtension
+----
+
+Now the interface `org.asciidoctor.extension.spi.ExtensionRegistry` moved to `org.asciidoctor.jruby.extension.spi.ExtensionRegistry`.
+That means that you have to update the name of the interface and rename the file in `/META-INF/services/`.
+In particular the last step is easily overseen as the compiler will not warn you.
+
+Therefore the implementation has to look like this:
+
+[source,java]
+.MyExtension.java for AsciidoctorJ 2.0.x
+----
+package com.example;
+
+import org.asciidoctor.jruby.extension.spi.ExtensionRegistry; // <1>
+
+public class MyExtension implements ExtensionRegistry {
+  @Override
+  public void register(Asciidoctor asciidoctor) {
+    JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
+    javaExtensionRegistry.treeprocessor(MyTreeprocessor.class);
+  }
+}
+----
+<1> Import ExtensionRegistry from the new package
+
+Additionally the file `/META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry` has to be renamed to `/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry`.
+
+./META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry for AsciidoctorJ 2.0.x
+----
+com.example.MyExtension
+----
+
+
+[[Migrate15x-16x]]
+== Migrating from AsciidoctorJ 1.5.x to 1.6.x
+
 AsciidoctorJ 1.6.0 fixed many issues with extensions, but also brought some incompatible changes in comparison to 1.5.x.
 In fact these incompatible changes were necessary to fix some of these bugs.
 This guide explains how to migrate an existing extension for AsciidoctorJ 1.5.x to 1.6.0.
 We will take an existing extension from the 1.5.x test cases and migrate it step by step to 1.5.x.
 
-== The original extension
+=== The original extension
 
 As an example we are taking the `YellStaticBlock` extension.
 This is a BlockProcessor that transforms the contents of the corresponding block to upper case.
@@ -112,7 +182,7 @@ import org.asciidoctor.ast.AbstractBlock;
 This is because the AST interfaces were renamed to better represent their purpose.
 The next section shows how these have to be updated.
 
-== Update to new AST class names
+=== Update to new AST class names
 
 The following table shows the new AST class names with their counterparts in AsciidoctorJ 1.5.x.
 See the <<integrator-guide#,Integrator Guide>> for details about the purpose of the classes.
@@ -216,7 +286,7 @@ Finally it is rather ugly that the constructor has to take a parameter `config`,
 
 The next section shows how this can be done in a more concise way.
 
-== Instantiating and configuring extensions
+=== Instantiating and configuring extensions
 
 The configuration of an extension has to be known at the time of registration.
 With AsciidoctorJ 1.5.x the way to define the configuration was to pass it to the super constructor and every extension type had to implement one certain constructor.

--- a/docs/integrator-guide.adoc
+++ b/docs/integrator-guide.adoc
@@ -19,7 +19,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-discuss: http://discuss.asciidoctor.org
-:artifact-version: 1.6.0
+:artifact-version: 2.0.0-RC.1
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
 :uri-maven-artifact-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}
@@ -1538,6 +1538,43 @@ To make AsciidoctorJ use our processor it also has to be registered at the `Java
 <3> Docinfo Processors will only be called by Asciidoctor if the safe mode is at least `SECURE`.
 <4> Test via the Jsoup HTML parsing library that our meta tag was correctly added to the resulting document.
 
+=== Extension SPI
+
+In previous examples, the extensions were registered manually.
+However, AsciidoctorJ provides another way to register extensions.
+If any implementation of the SPI interface is present on the classpath, it will be executed.
+
+To create an autoloadable extension you should do the next steps:
+
+Create a class that implements `org.asciidoctor.jruby.extension.spi.ExtensionRegistry`.
+
+[source]
+.org.asciidoctor.extension.integratorguide.TerminalCommandExtension.java
+----
+import org.asciidoctor.jruby.extension.spi.ExtensionRegistry;
+
+public class TerminalCommandExtension implements ExtensionRegistry { // <1>
+  @Override
+  public void register(Asciidoctor asciidoctor) { // <2>
+    JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
+    javaExtensionRegistry.treeprocessor(TerminalCommandTreeprocessor.class); // <3>
+  }
+}
+----
+<1> To autoload extensions you need to implement `ExtensionRegistry`.
+<2> AsciidoctorJ will automatically run the `register` method. The method is responsible for registering all extensions.
+<3> All required Java extensions are registered.
+
+Next, you need to create a file called `org.asciidoctor.jruby.extension.spi.ExtensionRegistry` inside `META-INF/services` with the implementation's full qualified name.
+
+[source]
+.META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
+----
+org.asciidoctor.integrationguide.extension.TerminalCommandExtension
+----
+
+And that's all.
+Now when a `.jar` file containing the previous structure is dropped inside classpath of AsciidoctorJ, the `register` method will be executed automatically and the extensions will be registered.
 
 
 == Publish everywhere: Adapt Asciidoctor to your own target format

--- a/docs/integrator-guide.adoc
+++ b/docs/integrator-guide.adoc
@@ -1538,6 +1538,7 @@ To make AsciidoctorJ use our processor it also has to be registered at the `Java
 <3> Docinfo Processors will only be called by Asciidoctor if the safe mode is at least `SECURE`.
 <4> Test via the Jsoup HTML parsing library that our meta tag was correctly added to the resulting document.
 
+[[ExtensionSPI]]
 === Extension SPI
 
 In previous examples, the extensions were registered manually.


### PR DESCRIPTION
Other minor updates to the README.

This PR moves the documentation about the ExtensionRegistry to the Integrator Guide so that we are also able to test this documentation.

Additionally updated the current artifact version in the README and some other minor fixes.