### PR TITLE
Logs handling API - add javadoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -752,9 +752,9 @@ Severity level of the current record.
 Cursor cursor::
 Information about the location of the event, contains:
 * LineNumber: relative to the file where the message occurred.
-* Path: source file simple name, or `<stdin>` value when rending from a String.
-* Dir: absolute path to the source file parent directory, or the execution path when rending from a String.
-* File: absolute path to the source file, or `null` when rending from a String. +
+* Path: source file simple name, or `<stdin>` value when converting from a String.
+* Dir: absolute path to the source file parent directory, or the execution path when converting from a String.
+* File: absolute path to the source file, or `null` when converting from a String. +
 These will point to the correct source file, even when this is included from another.
 
 String message::
@@ -765,7 +765,7 @@ Contains the value `<script>`. +
 For the source filename see `Cursor` above.
 
 String sourceMethodName::
-The Asciidoctor Ruby engine method used to render the file; `convertFile` or `convert` whether you are rending a File or a String.
+The Asciidoctor Ruby engine method used to convert the file; `convertFile` or `convert` whether you are converting a File or a String.
 
 === Logs Handling SPI
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Cursor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Cursor.java
@@ -7,10 +7,19 @@ public interface Cursor {
      */
     int getLineNumber();
 
+    /**
+     * @return Source file simple name, or <code>&lt;stdin&gt;</code> value when rending from a String.
+     */
     String getPath();
 
+    /**
+     * @return Absolute path to the source file parent directory, or the execution path when rending from a String.
+     */
     String getDir();
 
+    /**
+     * @return Absolute path to the source file, or <code>null</code> when rending from a String. These will point to the correct source file, even when it is included from another.
+     */
     String getFile();
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Cursor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Cursor.java
@@ -8,17 +8,17 @@ public interface Cursor {
     int getLineNumber();
 
     /**
-     * @return Source file simple name, or <code>&lt;stdin&gt;</code> value when rending from a String.
+     * @return Source file simple name, or <code>&lt;stdin&gt;</code> value when converting from a String.
      */
     String getPath();
 
     /**
-     * @return Absolute path to the source file parent directory, or the execution path when rending from a String.
+     * @return Absolute path to the source file parent directory, or the execution path when converting from a String.
      */
     String getDir();
 
     /**
-     * @return Absolute path to the source file, or <code>null</code> when rending from a String. These will point to the correct source file, even when it is included from another.
+     * @return Absolute path to the source file, or <code>null</code> when converting from a String. These will point to the correct source file, even when it is included from another.
      */
     String getFile();
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/log/LogRecord.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/log/LogRecord.java
@@ -33,22 +33,37 @@ public class LogRecord {
         this.sourceMethodName = sourceMethodName;
     }
 
+    /**
+     * @return Severity level of the current record.
+     */
     public Severity getSeverity() {
         return severity;
     }
 
+    /**
+     * @return Information about the location of the event
+     */
     public Cursor getCursor() {
         return cursor;
     }
 
+    /**
+     * @return Descriptive message about the event.
+     */
     public String getMessage() {
         return message;
     }
 
+    /**
+     * @return The value <code>&lt;script&gt;</code>. For the source filename use {@link Cursor#getFile()} obtained with the {@link #getCursor()} method.
+     */
     public String getSourceFileName() {
         return sourceFileName;
     }
 
+    /**
+     * @return The Asciidoctor Ruby engine method used to render the file; <code>convertFile</code> or <code>convert</code> whether you are rending a File or a String.
+     */
     public String getSourceMethodName() {
         return sourceMethodName;
     }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/log/LogRecord.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/log/LogRecord.java
@@ -62,7 +62,7 @@ public class LogRecord {
     }
 
     /**
-     * @return The Asciidoctor Ruby engine method used to render the file; <code>convertFile</code> or <code>convert</code> whether you are rending a File or a String.
+     * @return The Asciidoctor Ruby engine method used to convert the file; <code>convertFile</code> or <code>convert</code> whether you are converting a File or a String.
      */
     public String getSourceMethodName() {
         return sourceMethodName;


### PR DESCRIPTION
I was creating my own logger, and I would have appreciated to find some Javadoc on the getters.
The text I wrote is based on what can be found in the README.adoc at the root of the repository.