### PR TITLE
Fixes #791. Print version of AsciidoctorJ when calling asciidoctorj -…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,15 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Enhancements::
+
+  * Extended version info printed by `asciidoctorj --version` to show versions of Asciidoctor and AsciidoctorJ separately (@abelsromero) (#791)
+
+Improvements::
+
+
+Bug Fixes::
+
 
 == 2.0.0-RC.2 (2019-04-09)
 

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -56,6 +56,7 @@ jar {
       'com.beust.jcommander;resolution:=optional',
       '*'
   }
+  metaInf { from "$buildDir/version-info/" }
 }
 
 test {
@@ -63,6 +64,20 @@ test {
     excludeCategories 'org.asciidoctor.categories.Polluted'
   }
 }
+
+task createVersionFile {
+  inputs.property('version.asciidoctor', asciidoctorGemVersion)
+  inputs.property('version.asciidoctorj', project.version)
+  outputs.dir("$buildDir/version-info")
+
+  doLast {
+    file("$buildDir/version-info/asciidoctorj-version.properties").text = """
+version.asciidoctorj: ${project.version}
+version.asciidoctor: $asciidoctorGemVersion
+"""
+  }
+}
+jar.dependsOn createVersionFile
 
 task pollutedTest(type: Test) {
   useJUnit {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -1,11 +1,14 @@
 package org.asciidoctor.jruby.cli;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Scanner;
 
 import org.asciidoctor.Asciidoctor;
@@ -36,7 +39,7 @@ public class AsciidoctorInvoker {
             JRubyAsciidoctor asciidoctor = buildAsciidoctorJInstance(asciidoctorCliOptions);
             
             if (asciidoctorCliOptions.isVersion()) {
-                System.out.println("AsciidoctorJRuby " + asciidoctor.asciidoctorVersion() + " [http://asciidoctor.org]");
+                System.out.println("AsciidoctorJRuby " + getAsciidoctorJVersion() + " (Asciidoctor " + asciidoctor.asciidoctorVersion() + ") [https://asciidoctor.org]");
                 Object rubyVersionString = JRubyRuntimeContext.get(asciidoctor).evalScriptlet("\"#{JRUBY_VERSION} (#{RUBY_VERSION})\"");
                 System.out.println("Runtime Environment: jruby " + rubyVersionString);
                 return;
@@ -78,6 +81,21 @@ public class AsciidoctorInvoker {
                 System.out.println(output);
             }
         }
+    }
+
+    private String getAsciidoctorJVersion() {
+        InputStream in = getClass().getResourceAsStream("/META-INF/asciidoctorj-version.properties");
+        if (in == null) {
+            return "N/A";
+        }
+        Properties versionProps = new Properties();
+        try {
+            versionProps.load(in);
+            return versionProps.getProperty("version.asciidoctorj");
+        } catch (IOException e) {
+            return "N/A";
+        }
+
     }
 
     private void setTimingsMode(Asciidoctor asciidoctor, AsciidoctorCliOptions asciidoctorCliOptions, Options options) {

--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,7 @@ configure(subprojects.findAll { !it.isDistribution() }) {
     javadoc {
       // Oracle JDK8 likes to fail the build over spoiled HTML
       options.addStringOption('Xdoclint:none', '-quiet')
+      options.source('8')
     }
   }
 }


### PR DESCRIPTION
…-version

With this PR the output of `asciidoctorj --version` looks like this:
```
AsciidoctorJRuby 2.0.0-SNAPSHOT (Asciidoctor 2.0.6) [https://asciidoctor.org]
Runtime Environment: jruby 9.2.7.0 (2.5.3)
```

I have no clue though if the modifications to the gradle build to create a properties file with the version of AsciidoctorJ is ok, I felt stupid adding this.