### PR TITLE
Change AsciidoctorJRuby to AsciidoctorJ in version output

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -39,7 +39,7 @@ public class AsciidoctorInvoker {
             JRubyAsciidoctor asciidoctor = buildAsciidoctorJInstance(asciidoctorCliOptions);
             
             if (asciidoctorCliOptions.isVersion()) {
-                System.out.println("AsciidoctorJRuby " + getAsciidoctorJVersion() + " (Asciidoctor " + asciidoctor.asciidoctorVersion() + ") [https://asciidoctor.org]");
+                System.out.println("AsciidoctorJ " + getAsciidoctorJVersion() + " (Asciidoctor " + asciidoctor.asciidoctorVersion() + ") [https://asciidoctor.org]");
                 Object rubyVersionString = JRubyRuntimeContext.get(asciidoctor).evalScriptlet("\"#{JRUBY_VERSION} (#{RUBY_VERSION})\"");
                 System.out.println("Runtime Environment: jruby " + rubyVersionString);
                 return;


### PR DESCRIPTION
As proposed [here](https://github.com/asciidoctor/asciidoctorj/pull/795#issuecomment-483078104) `asciidoctorj --version` should show itself as AsciidoctorJ instead of AsciidoctorJRuby.

Apparently I got confused myself after the discussions about package names. 