### PR TITLE
Fix 790 register log handler

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,8 @@ Improvements::
 
 Bug Fixes::
 
+  * Fix logger registration when creating AsciidoctorJ instance with Asciidoctor.Factory.create(@ahus1) (#790)
+
 
 == 2.0.0-RC.2 (2019-04-09)
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -90,6 +90,9 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
         registerExtensions(asciidoctor);
         registerConverters(asciidoctor);
         registerLogHandlers(asciidoctor);
+
+        JavaLogger.install(asciidoctor.getRubyRuntime(), asciidoctor);
+
         return asciidoctor;
     }
 
@@ -107,9 +110,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     private static JRubyAsciidoctor createJRubyAsciidoctorInstance(Map<String, String> environmentVars, List<String> loadPaths, ClassLoader classloader) {
         Ruby rubyRuntime = createRubyRuntime(environmentVars, loadPaths, classloader);
-        JRubyAsciidoctor jrubyAsciidoctor = new JRubyAsciidoctor(rubyRuntime);
-        JavaLogger.install(rubyRuntime, jrubyAsciidoctor);
-        return jrubyAsciidoctor;
+        return new JRubyAsciidoctor(rubyRuntime);
     }
 
     private static Ruby createRubyRuntime(Map<String, String> environmentVars, List<String> loadPaths, ClassLoader classloader) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/JavaLogger.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/JavaLogger.java
@@ -91,7 +91,7 @@ public class JavaLogger extends RubyObject {
     return getRuntime().getNil();
   }
 
-  @JRubyMethod(name = "fatal", required = 1, optional = 1)
+  @JRubyMethod(name = "fatal", required = 0, optional = 2)
   public IRubyObject fatal(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
     return log(threadContext, args, block, Severity.FATAL);
   }
@@ -101,7 +101,7 @@ public class JavaLogger extends RubyObject {
     return getRuntime().getTrue();
   }
 
-  @JRubyMethod(name = "error", required = 1, optional = 1)
+  @JRubyMethod(name = "error", required = 0, optional = 2)
   public IRubyObject error(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
     return log(threadContext, args, block, Severity.ERROR);
   }
@@ -111,7 +111,7 @@ public class JavaLogger extends RubyObject {
     return getRuntime().getTrue();
   }
 
-  @JRubyMethod(name = "warn", required = 1, optional = 1)
+  @JRubyMethod(name = "warn", required = 0, optional = 2)
   public IRubyObject warn(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
     return log(threadContext, args, block, Severity.WARN);
   }
@@ -121,7 +121,7 @@ public class JavaLogger extends RubyObject {
     return getRuntime().getTrue();
   }
 
-  @JRubyMethod(name = "info", required = 1, optional = 1)
+  @JRubyMethod(name = "info", required = 0, optional = 2)
   public IRubyObject info(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
     return log(threadContext, args, block, Severity.INFO);
   }
@@ -131,7 +131,7 @@ public class JavaLogger extends RubyObject {
     return getRuntime().getTrue();
   }
 
-  @JRubyMethod(name = "debug", required = 1, optional = 1)
+  @JRubyMethod(name = "debug", required = 0, optional = 2)
   public IRubyObject debug(final ThreadContext threadContext, final IRubyObject[] args, Block block) {
     return log(threadContext, args, block, Severity.DEBUG);
   }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -1,12 +1,10 @@
 package org.asciidoctor;
 
-import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.ast.Cursor;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.BlockProcessor;
 import org.asciidoctor.extension.Name;
 import org.asciidoctor.extension.Reader;
-import org.asciidoctor.jruby.internal.JRubyAsciidoctor;
 import org.asciidoctor.log.LogHandler;
 import org.asciidoctor.log.LogRecord;
 import org.asciidoctor.log.Severity;
@@ -49,12 +47,11 @@ public class WhenAsciidoctorLogsToConsole {
     @ArquillianResource
     private TemporaryFolder testFolder;
 
-    @ArquillianResource(Unshared.class)
     private Asciidoctor asciidoctor;
 
     @Before
     public void before() {
-        asciidoctor = JRubyAsciidoctor.create();
+        asciidoctor = Asciidoctor.Factory.create();
         TestLogHandlerService.clear();
     }
 


### PR DESCRIPTION
This PR fixes #790, where loggers were not configured when Asciidoctor was created simply with `Asciidoctor.Factory.create()`.

Additionally I squashed another bug where the logger proxy did not accept calls like `logger.info` with 0 arguments but a block yielding the message.