### PR TITLE
Add logging support for converters

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/converter/AbstractConverter.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/converter/AbstractConverter.java
@@ -1,5 +1,9 @@
 package org.asciidoctor.converter;
 
+import org.asciidoctor.log.LogHandler;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Logging;
+
 import java.util.Map;
 
 /**
@@ -8,13 +12,15 @@ import java.util.Map;
  * <p>For converters producing string output consider extending the {@link StringConverter} class.
  * @param <T> The type of result this converter produces, e.g. {@link String}.
  */
-public abstract class AbstractConverter<T> implements Converter<T>, OutputFormatWriter<T> {
+public abstract class AbstractConverter<T> implements Converter<T>, OutputFormatWriter<T>, Logging, LogHandler {
 
     private String backend;
 
     private Map<String, Object> options;
 
     private String outfilesuffix = null;
+
+    private LogHandler logHandler;
 
     public AbstractConverter(String backend, Map<String, Object> opts) {
         this.backend = backend;
@@ -40,4 +46,15 @@ public abstract class AbstractConverter<T> implements Converter<T>, OutputFormat
         this.outfilesuffix = outfilesuffix;
     }
 
+    @Override
+    public void log(LogRecord logRecord) {
+        if (logHandler != null) {
+            logHandler.log(logRecord);
+        }
+    }
+
+    @Override
+    public void setLogHandler(LogHandler logHandler) {
+        this.logHandler = logHandler;
+    }
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/log/Logging.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/log/Logging.java
@@ -1,0 +1,7 @@
+package org.asciidoctor.log;
+
+public interface Logging {
+
+    void setLogHandler(LogHandler logHandler);
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -233,7 +233,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     @Override
     public JavaConverterRegistry javaConverterRegistry() {
-        return new JavaConverterRegistryImpl(rubyRuntime);
+        return new JavaConverterRegistryImpl(this);
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JavaConverterRegistryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JavaConverterRegistryImpl.java
@@ -17,14 +17,17 @@ public class JavaConverterRegistryImpl implements JavaConverterRegistry {
 
     private Ruby rubyRuntime;
 
-    public JavaConverterRegistryImpl(Ruby rubyRuntime) {
-        this.rubyRuntime = rubyRuntime;
+    private JRubyAsciidoctor asciidoctor;
+
+    public JavaConverterRegistryImpl(JRubyAsciidoctor asciidoctor) {
+        this.asciidoctor = asciidoctor;
+        this.rubyRuntime = asciidoctor.getRubyRuntime();
     }
 
     @Override
     public <U, T  extends Converter<U> & OutputFormatWriter<U>> void register(final Class<T> converterClass, String... backends) {
 
-        RubyClass clazz = ConverterProxy.register(rubyRuntime, converterClass);
+        RubyClass clazz = ConverterProxy.register(asciidoctor, converterClass);
 
         ConverterFor converterForAnnotation = converterClass.getAnnotation(ConverterFor.class);
         if (converterForAnnotation != null) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
@@ -6,6 +6,8 @@ import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.ListItem;
 import org.asciidoctor.ast.List;
 import org.asciidoctor.ast.Section;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
 
 import java.util.Map;
 
@@ -23,11 +25,13 @@ public class TextConverter extends StringConverter {
     @Override
     public String convert(ContentNode node, String transform, Map<Object, Object> o) {
 
+
         if (transform == null) {
             transform = node.getNodeName();
         }
  
         if (node instanceof Document) {
+            log(new LogRecord(Severity.INFO, "Now we're logging"));
             Document document = (Document) node;
             return (String) document.getContent();
         } else if (node instanceof Section) {


### PR DESCRIPTION
This PR is a proposal for adding logging support for converters.
If a converter implements the interface `org.asciidoctor.log.Logging`, then Asciidoctor will set a `org.asciidoctor.log.LogHandler` via `Logging.setLogHandler(logHandler)` after the converter was created.

The AbstractConverter already implements this interface and provides the method `log(LogRecord)` to log.