### PR TITLE
Clarify classpath in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,13 +20,19 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-discuss: http://discuss.asciidoctor.org
-:artifact-version: 2.0.0-RC.1
+:artifact-version: 2.0.0-RC.3
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
 :uri-maven-artifact-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}
+:uri-maven-artifact-api-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj-api%22%20AND%20v%3A%22{artifact-version}%22
+:uri-maven-artifact-api-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj-api%7C{artifact-version}%7Cjar
+:uri-maven-artifact-api-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj-api/{artifact-version}/asciidoctorj-api-{artifact-version}
 :uri-bintray-artifact-query: https://bintray.com/asciidoctor/maven/asciidoctorj/view/general
 :uri-bintray-artifact-detail: https://bintray.com/asciidoctor/maven/asciidoctorj/{artifact-version}/view
 :uri-bintray-artifact-file: http://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}
+:uri-bintray-artifact-api-query: https://bintray.com/asciidoctor/maven/asciidoctorj-api/view/general
+:uri-bintray-artifact-api-detail: https://bintray.com/asciidoctor/maven/asciidoctorj-api/{artifact-version}/view
+:uri-bintray-artifact-api-file: http://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj-api/{artifact-version}/asciidoctorj-api-{artifact-version}
 :uri-jruby-startup: http://github.com/jruby/jruby/wiki/Improving-startup-time
 :uri-maven-guide: {uri-docs}/install-and-use-asciidoctor-maven-plugin
 :uri-gradle-guide: {uri-docs}/install-and-use-asciidoctor-gradle-plugin
@@ -64,6 +70,11 @@ The artifact information can be found in the tables below.
 |{uri-bintray-artifact-file}.pom[pom] {uri-bintray-artifact-file}.jar[jar] {uri-bintray-artifact-file}-javadoc.jar[javadoc (jar)] {uri-bintray-artifact-file}-sources.jar[sources (jar)]
 
 |org.asciidoctor
+|{uri-bintray-artifact-api-query}[asciidoctorj-api]
+|{uri-bintray-artifact-api-detail}[{artifact-version}]
+|{uri-bintray-artifact-api-file}.pom[pom] {uri-bintray-artifact-api-file}.jar[jar] {uri-bintray-artifact-api-file}-javadoc.jar[javadoc (jar)] {uri-bintray-artifact-api-file}-sources.jar[sources (jar)]
+
+|org.asciidoctor
 |asciidoctorj-epub3
 |1.5.0-alpha.8.1
 |{empty}
@@ -83,6 +94,11 @@ The artifact information can be found in the tables below.
 |{uri-maven-artifact-query}[asciidoctorj]
 |{uri-maven-artifact-detail}[{artifact-version}]
 |{uri-maven-artifact-file}.pom[pom] {uri-maven-artifact-file}.jar[jar] {uri-maven-artifact-file}-javadoc.jar[javadoc (jar)] {uri-maven-artifact-file}-sources.jar[sources (jar)]
+
+|org.asciidoctor
+|{uri-maven-artifact-api-query}[asciidoctorj-api]
+|{uri-maven-artifact-api-detail}[{artifact-version}]
+|{uri-maven-artifact-api-file}.pom[pom] {uri-maven-artifact-api-file}.jar[jar] {uri-maven-artifact-api-file}-javadoc.jar[javadoc (jar)] {uri-maven-artifact-api-file}-sources.jar[sources (jar)]
 
 |org.asciidoctor
 |asciidoctorj-epub3

--- a/README.adoc
+++ b/README.adoc
@@ -50,7 +50,6 @@ endif::[]
 
 == Distribution
 
-The version of AsciidoctorJ matches the version of Asciidoctor RubyGem it bundles.
 AsciidoctorJ is published to Maven Central and Bintray.
 The artifact information can be found in the tables below.
 
@@ -100,8 +99,8 @@ CAUTION: The artifactId changed to `asciidoctorj` starting in 1.5.0.
 
 == Installation
 
-AsciidoctorJ is a standard `.jar` file.
-To start using it, you need to add the library to your project's classpath.
+To start using AsciidoctorJ, you need to add the required dependency to the dependency management system of your choice, Maven, Gradle or Apache Ivy.
+If you don't use a Dependency Management system please check the dependency graph and add all jars in it to your classpath.
 
 // SW: Need functional tests for a java maven project and a java gradle project
 
@@ -152,6 +151,12 @@ In addition to using AsciidoctorJ directly, you can invoke it as part of your bu
 - {uri-maven-guide}[How to Install and Use the Asciidoctor Maven Plugin]
 - {uri-gradle-guide}[How to Install and Use the Asciidoctor Gradle Plugin]
 ====
+
+[NOTE]
+The versions of Asciidoctor and AsciidoctorJ no longer align since version 1.6.0 of AsciidoctorJ.
+Please check the corresponding release notes to find out which version of Asciidoctor is packaged if you are embedding the library.
+If you use the distribution you can call `asciidoctorj --version` to get the version of Asciidoctor that is embedded in AsciidoctorJ.
+
 
 === Windows Installation
 


### PR DESCRIPTION
Resolves #802.

Clarify in the README that it is not sufficient to exclusively add asciidoctorj.jar to the class path to use it.

Clarify that versions of AsciidoctorJ and Asciidoctor no longer match.