### PR TITLE
Add rouge source-highlighter to asciidoctorj.jar

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   compile "com.beust:jcommander:$jcommanderVersion"
   gems "rubygems:asciidoctor:$asciidoctorGemVersion"
   gems "rubygems:coderay:$coderayGemVersion"
+  gems "rubygems:rouge:$rougeGemVersion"
   gems "rubygems:erubis:$erubisGemVersion"
   gems "rubygems:haml:$hamlGemVersion"
   gems "rubygems:open-uri-cached:$openUriCachedGemVersion"

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenSourceHighlightingIsUsed.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenSourceHighlightingIsUsed.java
@@ -1,0 +1,61 @@
+package org.asciidoctor;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Arquillian.class)
+public class WhenSourceHighlightingIsUsed {
+
+    private static final String DOCUMENT = "[source,java]\n" +
+        "----\n" +
+        "public class Main {\n" +
+        "  public static void main(String[] args) {\n" +
+        "    println(\"Hello World\")\n" +
+        "  }\n" +
+        "}\n" +
+        "----\n";
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor;
+
+    @Test
+    public void should_render_with_rouge() throws Exception {
+        String html = asciidoctor.convert(DOCUMENT,
+            OptionsBuilder.options()
+                .headerFooter(true)
+                .safe(SafeMode.UNSAFE)
+                .attributes(
+                    AttributesBuilder.attributes()
+                        .sourceHighlighter("rouge")));
+
+        Document doc = Jsoup.parse(html);
+
+        assertThat("No elements were highlighted", doc.select("pre.rouge span.kd").size(), greaterThan(0));
+        assertThat("CSS was not added", html, containsString("pre.rouge .kd"));
+    }
+
+    @Test
+    public void should_render_with_coderay() throws Exception {
+        String html = asciidoctor.convert(DOCUMENT,
+            OptionsBuilder.options()
+                .headerFooter(true)
+                .safe(SafeMode.UNSAFE)
+                .attributes(
+                    AttributesBuilder.attributes()
+                        .sourceHighlighter("coderay")));
+
+
+        Document doc = Jsoup.parse(html);
+
+        assertThat("No elements were highlighted", doc.select("pre.CodeRay span.class").size(), greaterThan(0));
+        assertThat("CSS was not added", html, containsString(".CodeRay .class"));
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,8 @@ ext {
 
   // gem versions
   asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.8'
-  coderayGemVersion = '1.1.0'
+  coderayGemVersion = '1.1.2'
+  rougeGemVersion = '3.3.0'
 
   codenarcVersion = '0.24.1'
   groovyVersion = '2.4.13'


### PR DESCRIPTION
This PR adds the rouge source highlighter to the asciidoctorj.jar.
There's also 2 tests checking that rouge and coderay work.

The distribution tests will also test that rouge still work in PDF, as we distribute a different version of rouge (2.0.7) in the asciidoctorj-pdf.jar.