### PR TITLE
Fix javadoc in Block

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Block.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Block.java
@@ -34,8 +34,8 @@ public interface Block extends StructuralNode {
     String getSource();
 
     /**
-     * Sets the source of the ListItem.
-     * @param source The source of this ListItem, substitutions will still be applied.
+     * Sets the source of the Block.
+     * @param source The source of this Block, substitutions will still be applied.
      */
     void setSource(String source);
 


### PR DESCRIPTION
Small copy paste issue in the Javadoc probably from `ListItem`.