### PR TITLE
Configure build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz; fi
 
-install: ./gradlew -S -Pskip.signing assemble
+install: ./gradlew -S -Pskip.signing assemble --scan
 
 before_script: unset GEM_PATH GEM_HOME JRUBY_OPTS
 
-script: ./gradlew -S -Pskip.signing check && bash test-asciidoctor-upstream.sh
-after_success: if [ "${TRAVIS_BRANCH}" = "master" -a "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_JDK_VERSION}" = "oraclejdk8" ]; then ./gradlew clean build artifactoryPublish -x test ; fi
+script: ./gradlew -S -Pskip.signing check --scan && bash test-asciidoctor-upstream.sh
+after_success: if [ "${TRAVIS_BRANCH}" = "master" -a "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_JDK_VERSION}" = "oraclejdk8" ]; then ./gradlew clean build artifactoryPublish -x test --scan; fi
 notifications:
   email: false
   irc:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,6 @@ install:
   - java -version
   - gradlew.bat --version
 build_script:
-  - gradlew.bat -u -i assemble
+  - gradlew.bat -u -i assemble --scan
 test_script:
-  - gradlew.bat -u -i -S check
+  - gradlew.bat -u -i -S check --scan

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,12 @@ buildscript {
 // modern plugins config
 plugins {
   id 'com.github.jruby-gradle.base' version '1.4.0'
+  id 'com.gradle.build-scan' version '1.16'
+}
+
+buildScan {
+  termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+  apply from: 'gradle/build-scans.gradle'
 }
 
 // TIP use -PpublishRelease=true to active release behavior regardless of the version

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -1,0 +1,33 @@
+def acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/asciidoctorj/gradle-scans-license-agree.txt")
+def env = System.getenv()
+boolean isCI = env.CI || env.TRAVIS
+boolean hasAccepted = isCI || env.ASCIIDOCTORJ_GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.ASCIIDOCTORJ_GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+
+buildScan {
+    if (hasAccepted) {
+        termsOfServiceAgree = 'yes'
+    } else if (!hasRefused) {
+        gradle.buildFinished {
+            println """
+This build uses Gradle Build Scans to gather statistics, share information about 
+failures, environmental issues, dependencies resolved during the build and more.
+Build scans will be published after each build, if you accept the terms of 
+service, and in particular the privacy policy.
+
+Please read 
+   
+    https://gradle.com/terms-of-service 
+    https://gradle.com/legal/privacy
+
+and then:
+
+  - set the `ASCIIDOCTORJ_GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
+
+And we'll not bother you again. Note that build scans are only made public if 
+you share the URL at the end of the build.
+"""
+        }
+    }
+}


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.

Here's an example scan https://scans.gradle.com/s/rfbcjuu3gqvkk