### PR TITLE
remove useless assignment and change the if condition

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
@@ -586,8 +586,8 @@ public class Attributes {
 
     private void addAttributes(String[] allAttributes) {
         for (String attribute : allAttributes) {
-            int equalsIndex = -1;
-            if ((equalsIndex = attribute.indexOf(ATTRIBUTE_SEPARATOR)) > -1) {
+            int equalsIndex = attribute.indexOf(ATTRIBUTE_SEPARATOR);
+            if (equalsIndex > -1) {
                 extractAttributeNameAndValue(attribute, equalsIndex);
             } else {
                 this.attributes.put(attribute, "");


### PR DESCRIPTION
hello i find a Code Quality Issue detected by SonarQube that Remove this useless assignment to local variable `equalsIndex`.
variable   `equalsIndex` will be assigned by `equalsIndex = attribute.indexOf(ATTRIBUTE_SEPARATOR)` , so the `int equalsIndex = -1` will be never used. so I change the condition to the assignment to fix the Code Quality Issue.
[https://rules.sonarsource.com/java/RSPEC-1854](url)