### PR TITLE
marks templateDir in OptionsBuilder as deprecated

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -83,8 +83,8 @@ public class Options {
      * Enable writing output to a file. The file includes header and footer by default.
      *
      * @param toFile The path to the output file. If the path is not absolute, it is
-     *               interpreted relative to what was set via {@link #setToDir()}
-     *               or {@link #setBaseDir()}, in that order.
+     *               interpreted relative to what was set via {@link #setToDir(String)}}
+     *               or {@link #setBaseDir(String)}}, in that order.
      *
      */
     public void setToFile(String toFile) {
@@ -102,7 +102,7 @@ public class Options {
      *               as the input file, including header and footer into the output. If
      *               <code>false</code>, return output as a string without any header or
      *               footer. The default header and footer visibility can be overridden
-     *               using {@link #setHeaderFooter()}.
+     *               using {@link #setHeaderFooter(boolean)}.
      *
      */
     public void setToFile(boolean toFile) {

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
@@ -71,7 +71,9 @@ public class OptionsBuilder {
 
     /**
      * Sets template directory.
-     * 
+     *
+     * @deprecated Use {@link #templateDirs(File...)} instead.
+     *
      * @param templateDir
      *            directory where templates are stored.
      * @return this instance.


### PR DESCRIPTION
Aligning with asciidoctor description of `:template_dir` (https://asciidoctor.org/docs/user-manual/#ruby-api-options) this PR marks `templareDir` method as deprecated pointing users to use `templateDirs` instead.

Additionally, fixes a couple of javadoc references in `Options`.