### PR TITLE
chore(CLI): ugprade to JCommander 1.72

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 Improvement::
 
+  * Upgrade to JCommander 1.72 (@Fiouz) (#782)
   * Set logger name on logged log records (@lread) (#834)
 
 Build::

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -197,10 +197,10 @@ public class AsciidoctorInvoker {
 
         List<String> parameters = asciidoctorCliOptions.getParameters();
 
-        if (parameters.isEmpty()) {
-            System.err.println("asciidoctor: FAILED: input file missing");
+        if (parameters.stream().anyMatch(String::isEmpty)) {
+            System.err.println("asciidoctor: FAILED: empty input file name");
             throw new IllegalArgumentException(
-                    "asciidoctor: FAILED: input file missing");
+                    "asciidoctor: FAILED: empty input file name");
         }
 
         if (parameters.contains("-")) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -122,7 +122,7 @@ public class WhenAsciidoctorIsCalledUsingCli {
 	
 	
 	@Test(expected=IllegalArgumentException.class)
-	public void no_input_file_should_throw_an_exception() {
+	public void empty_input_file_name_should_throw_an_exception() {
 		new AsciidoctorInvoker().invoke("");
 	}
 	

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
   commonsioVersion = '2.4'
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
-  jcommanderVersion = '1.35'
+  jcommanderVersion = '1.72'
   jrubyVersion = '9.2.7.0'
   jsoupVersion = '1.10.2'
   junitVersion = '4.12'


### PR DESCRIPTION
Fixed the semantic of the error message to reflect an error on the file
name instead of a missing file.

The unit test had issues:
* Test name was misleading as it was not testing the absence of input
  file argument (which would trigger usage display) but the presence of
  an empty input file name
* It was validating a bug in the parsing library fixed in JCommander
  1.61 where empty arguments were lost - cbeust/jcommander#306

Fixes asciidoctor/asciidoctorj#782