### PR TITLE
Chocolatey: Upgrade packaging to 2.1.0.

### DIFF
--- a/chocolatey/README.adoc
+++ b/chocolatey/README.adoc
@@ -17,7 +17,7 @@ https://chocolatey.org/docs/create-packages .
 ----
 # Create the package
 > cd c:\to\this\directory
-> cpack
+> choco pack
 
 # Test the package. You'll probably have to run this as administrator.
 > choco install .\asciidoctorj.x.y.z.nupkg -dv -s .

--- a/chocolatey/asciidoctorj.nuspec
+++ b/chocolatey/asciidoctorj.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>asciidoctorj</id>
     <title>AsciidoctorJ (Install)</title>
-    <version>1.6.2</version>
+    <version>2.1.0</version>
     <!--
       https://github.com/asciidoctor/asciidoctorj/graphs/contributors
       https://github.com/asciidoctor/asciidoctor/graphs/contributors
@@ -16,7 +16,8 @@
     <description>Java wrapper and bindings for the Asciidoctor markup processor.
     Converts AsciiDoc to HTML5, EPUB3, PDF, DocBook, and other formats. To use, run
     "asciidoctorj" along with any Asciidoctor command line flags, e.g. "asciidoctorj
-    -b pdf mydocument.adoc".
+    -b pdf mydocument.adoc". Requires a Java runtime such as jre8, corretto8jre, or
+    adoptopenjdk8jre.
     </description>
     <projectUrl>http://asciidoctor.org/</projectUrl>
     <packageSourceUrl>https://github.com/geraldcombs/chocolatey-packages</packageSourceUrl>
@@ -29,9 +30,12 @@
     <licenseUrl>https://raw.githubusercontent.com/asciidoctor/asciidoctorj/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/asciidoctor/brand/master/logo/logo-fill-color.svg?sanitize=true</iconUrl>
+    <!--
+      XXX Add other JREs and JVMs when https://github.com/chocolatey/choco/issues/879 is fixed?
     <dependencies>
-      <dependency id="jre8" />
+      <dependency id="javaruntime" />
     </dependencies>
+    -->
     <releaseNotes>Initial Chocolatey package</releaseNotes>
     <!--<provides></provides>-->
   </metadata>

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
 
-$adocjVersion = '1.6.2'
+$adocjVersion = '2.1.0'
 $packageName= 'asciidoctorj' # arbitrary name for the package, used in messages
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 # Which is the preferred mirror? There are many listed at
@@ -18,7 +18,7 @@ $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   url           = $url
-  checksum      = 'b42f0efc4f61c57c5638b6e3aff746bb4df825c0d1824ad3065763e9aed2945c'
+  checksum      = '708bb954d09eeb862ed7627e743be8f96f2a67397c561ab56e85b6bc4650cc77'
   checksumType  = 'sha256' #default is md5, can also be sha1
   #checksum64    = ''
   #checksumType64= 'md5' #default is checksumType


### PR DESCRIPTION
Chocolatey offers a variety of JREs and JDKs but doesn't support alternate
dependencies[1]. Remove the jre8 dependency for now.

[1] https://github.com/chocolatey/choco/issues/879