### PR TITLE
adding close to Asciidoctor to avoid to leak when creating an asciidoctor instance

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 /**
  * @author lordofthejars
  */
-public interface Asciidoctor {
+public interface Asciidoctor extends AutoCloseable {
 
     String STRUCTURE_MAX_LEVEL = "STRUCTURE_MAX_LEVEL";
 
@@ -531,4 +531,8 @@ public interface Asciidoctor {
         throw new IllegalArgumentException("Cannot unwrap to " + clazz.getName());
     }
 
+    @Override
+    default void close() {
+        // no-op
+    }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -45,8 +45,6 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     private List<LogHandler> logHandlers = new ArrayList<>();
 
-    private final static Logger LOGGER = Logger.getLogger("asciidoctorj");
-
     public JRubyAsciidoctor() {
         this(createRubyRuntime(Collections.singletonMap(GEM_PATH, null), new ArrayList<>(), null));
         processRegistrations(this);
@@ -138,6 +136,13 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     private static RubyInstanceConfig createOptimizedConfiguration() {
         return new RubyInstanceConfig();
+    }
+
+    @Override
+    public void close() {
+        if (rubyRuntime != null) {
+            rubyRuntime.tearDown();
+        }
     }
 
     @Override


### PR DESCRIPTION
Currently Asciidoctor instance can't be released.
With JRuby it means at least 2 pools are leaking each time an instance is created.
It leads to a lot of issues in several environments.
This PR adds a close() method to Asciidoctor and ensures JRuby instance is properly released when called.

Saved ~1mn on 1mn16s of execution with exec-maven-plugin for instance and avoids leakage in EE context.