### PR TITLE
upgrade jruby to 9.2.8.0 as it fixed some assertions bugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.72'
-  jrubyVersion = '9.2.7.0'
+  jrubyVersion = '9.2.8.0'
   jsoupVersion = '1.10.2'
   junitVersion = '4.12'
   nettyVersion = '4.0.33.Final'


### PR DESCRIPTION
When investigating issue https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/337 I found that the latest ruby version fixes some assertions, see https://github.com/jruby/jruby/pull/5693.

As the test suite of AsciidoctorJ runs without errors on this new JRuby release, I suggest an update of JRuby with this PR.