### PR TITLE
Documentation: link to tarball; add Quick Win section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -151,7 +151,7 @@ Linux: asciidoctorj-{artifact-version}/bin/asciidoctorj -b pdf -o READTHIS.pdf R
 Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat -b pdf -o READTHIS.pdf README.adoc
 ----
 
-The rest of the document addresses the asciidoctorj API, for doing such conversions
+The rest of the document addresses the asciidoctorj API, for doing more complex conversions
 from within a JVM-based application.
 
 == Installation

--- a/README.adoc
+++ b/README.adoc
@@ -68,7 +68,7 @@ The artifact information can be found in the tables below.
 |org.asciidoctor
 |{uri-bintray-artifact-query}[asciidoctorj]
 |{uri-bintray-artifact-detail}[{artifact-version}]
-|{uri-bintray-artifact-file}.pom[pom] {uri-bintray-artifact-file}.jar[jar] {uri-bintray-artifact-file}-javadoc.jar[javadoc (jar)] {uri-bintray-artifact-file}-sources.jar[sources (jar)] {uri-bintray-artifact-file}-bin.zip[distribution (zip)]
+|{uri-bintray-artifact-file}.pom[pom] {uri-bintray-artifact-file}.jar[jar] {uri-bintray-artifact-file}-javadoc.jar[javadoc (jar)] {uri-bintray-artifact-file}-sources.jar[sources (jar)] distribution ({uri-bintray-artifact-file}-bin.zip[zip] {uri-bintray-artifact-file}-bin.tar[tar])
 
 |org.asciidoctor
 |{uri-bintray-artifact-api-query}[asciidoctorj-api]
@@ -94,7 +94,7 @@ The artifact information can be found in the tables below.
 |org.asciidoctor
 |{uri-maven-artifact-query}[asciidoctorj]
 |{uri-maven-artifact-detail}[{artifact-version}]
-|{uri-maven-artifact-file}.pom[pom] {uri-maven-artifact-file}.jar[jar] {uri-maven-artifact-file}-javadoc.jar[javadoc (jar)] {uri-maven-artifact-file}-sources.jar[sources (jar)] {uri-maven-artifact-file}-bin.zip[distribution (zip)]
+|{uri-maven-artifact-file}.pom[pom] {uri-maven-artifact-file}.jar[jar] {uri-maven-artifact-file}-javadoc.jar[javadoc (jar)] {uri-maven-artifact-file}-sources.jar[sources (jar)] distribution ({uri-maven-artifact-file}-bin.zip[zip] {uri-maven-artifact-file}-bin.tar[tar])
 
 |org.asciidoctor
 |{uri-maven-artifact-api-query}[asciidoctorj-api]
@@ -113,6 +113,40 @@ The artifact information can be found in the tables below.
 |===
 
 CAUTION: The artifactId changed to `asciidoctorj` starting in 1.5.0.
+
+== Quick win: using the command line interface
+
+If you download from a distribution link above (zip or tar), you can get started straight away from the command line.
+
+First, expand the downloaded file. That puts everything in directory asciidoctorj-{artifact-version}.
+Within that directory are `bin` and `lib` directories.  `bin` contains the executables -- `asciidoctorj` for
+Linux and macOS, and `asciidoctorj.bat` for Windows.  `lib` contains the supporting libraries.
+
+Verify the application runs by specifying the appropriate executable with no parameters;
+it should display the various run options available (i.e., help).
+
+----
+Linux: asciidoctorj-{artifact-version}/bin/asciidoctorj
+Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat
+----
+
+Next, say you want to convert an ASCIIDOC (.adoc) file -- such as this README -- to a pdf.
+
+----
+Linux: asciidoctorj-{artifact-version}/bin/asciidoctorj -b pdf README.adoc
+Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat -b pdf README.adoc
+----
+
+Boom! That should convert the README to a PDF named README.pdf.
+To create a PDF with a different name -- say, READTHIS.pdf -- just add the -o switch:
+
+----
+Linux: asciidoctorj-{artifact-version}/bin/asciidoctorj -b pdf -o READTHIS.pdf README.adoc
+Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat -b pdf -o READTHIS.pdf README.adoc
+----
+
+The rest of the document addresses the asciidoctorj API, for doing such conversions
+from within a JVM-based application.
 
 == Installation
 

--- a/README.adoc
+++ b/README.adoc
@@ -118,13 +118,15 @@ CAUTION: The artifactId changed to `asciidoctorj` starting in 1.5.0.
 
 If you download from a distribution link above (zip or tar), you can get started straight away from the command line.
 
-First, expand the downloaded file. That puts everything in directory asciidoctorj-{artifact-version}.
+First, expand the downloaded file. That puts everything in directory `asciidoctorj-{artifact-version}`.
 Within that directory are `bin` and `lib` directories.  `bin` contains the executables -- `asciidoctorj` for
 Linux and macOS, and `asciidoctorj.bat` for Windows.  `lib` contains the supporting libraries.
 
 Verify the application runs by specifying the appropriate executable with no parameters;
 it should display the various run options available (i.e., help).
 
+[source]
+[subs="specialcharacters,attributes,callouts"]
 ----
 Linux: asciidoctorj-{artifact-version}/bin/asciidoctorj
 Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat
@@ -132,6 +134,8 @@ Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat
 
 Next, say you want to convert an ASCIIDOC (.adoc) file -- such as this README -- to a pdf.
 
+[source]
+[subs="specialcharacters,attributes,callouts"]
 ----
 Linux: asciidoctorj-{artifact-version}/bin/asciidoctorj -b pdf README.adoc
 Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat -b pdf README.adoc
@@ -140,6 +144,8 @@ Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat -b pdf README.adoc
 Boom! That should convert the README to a PDF named README.pdf.
 To create a PDF with a different name -- say, READTHIS.pdf -- just add the -o switch:
 
+[source]
+[subs="specialcharacters,attributes,callouts"]
 ----
 Linux: asciidoctorj-{artifact-version}/bin/asciidoctorj -b pdf -o READTHIS.pdf README.adoc
 Windows: asciidoctorj-{artifact-version}\bin\asciidoctorj.bat -b pdf -o READTHIS.pdf README.adoc


### PR DESCRIPTION
This is a documentation-only update.

Added tarball links to the Distribution section.

Added a Quick Win section so users could get started straight away with doing a conversion, whether that's the end goal, or to get an idea of how the results would look after integrating the API.