### PR TITLE
chore(OSGi): switch to biz.aQute.bnd plugin

### DIFF
--- a/asciidoctorj-api/build.gradle
+++ b/asciidoctorj-api/build.gradle
@@ -1,20 +1,15 @@
-apply plugin: 'osgi'
+apply plugin: 'biz.aQute.bnd.builder'
 
 dependencies {
+  compileOnly "org.osgi:osgi.annotation:$osgiVersion"
 }
 
 
 jar {
-  manifest {
-    symbolicName = 'org.asciidoctor'
-    instruction 'Export-Package',
-      "org.asciidoctor;version=\"${version}\"",
-      "org.asciidoctor.ast;version=\"${version}\"",
-      "org.asciidoctor.converter;version=\"${version}\"",
-      "org.asciidoctor.extension;version=\"${version}\"",
-      "org.asciidoctor.log;version=\"${version}\"",
-      "org.asciidoctor.spi;version=\"${version}\""
-  }
+  bnd(
+    ('Bundle-Name'): 'asciidoctorj-api',
+    ('Bundle-SymbolicName'): 'org.asciidoctor',
+  )
 }
 
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/package-info.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.asciidoctor.ast;
+
+import org.osgi.annotation.bundle.Export;

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/converter/package-info.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/converter/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.asciidoctor.converter;
+
+import org.osgi.annotation.bundle.Export;

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/package-info.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.asciidoctor.extension;
+
+import org.osgi.annotation.bundle.Export;

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/log/package-info.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/log/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.asciidoctor.log;
+
+import org.osgi.annotation.bundle.Export;

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/package-info.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.asciidoctor;
+
+import org.osgi.annotation.bundle.Export;

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/syntaxhighlighter/package-info.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/syntaxhighlighter/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.asciidoctor.syntaxhighlighter;
+
+import org.osgi.annotation.bundle.Export;

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'osgi'
+apply plugin: 'biz.aQute.bnd.builder'
 
 dependencies {
   compile project(path: ':asciidoctorj-api')
@@ -21,6 +21,7 @@ dependencies {
   testCompile "org.jsoup:jsoup:$jsoupVersion"
   testCompile "io.netty:netty-all:$nettyVersion"
   testCompile project(path: ':asciidoctorj-arquillian-extension')
+  compileOnly "org.osgi:osgi.annotation:$osgiVersion"
 }
 
 def gemFiles = fileTree(jruby.gemInstallDir) {
@@ -49,14 +50,12 @@ javadoc {
 //}
 
 jar {
-  manifest {
-    symbolicName = 'org.asciidoctor'
-    instruction 'Export-Package',
-      "org.asciidoctor.jruby;version=\"${version}\""
-    instruction 'Import-Package',
-      'com.beust.jcommander;resolution:=optional',
-      '*'
-  }
+  bnd(
+    ('Bundle-Name'): 'asciidoctorj',
+    ('Bundle-SymbolicName'): 'org.asciidoctor',
+    ('Import-Package'):
+      'com.beust.jcommander;resolution:=optional, *'
+  )
   metaInf { from "$buildDir/version-info/" }
 }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/package-info.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.asciidoctor.jruby;
+
+import org.osgi.annotation.bundle.Export;

--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,13 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        mavenCentral()
     }
     dependencies {
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.10"
         classpath "gradle.plugin.io.sdkman:gradle-sdkvendor-plugin:1.1.0"
+        classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:4.3.0"
     }
 }
 
@@ -68,6 +70,7 @@ ext {
   spockVersion = '0.7-groovy-2.0'
   threadSafeGemVersion = '0.3.6'
   tiltGemVersion = '2.0.9'
+  osgiVersion = '7.0.0'
 }
 
 allprojects {


### PR DESCRIPTION
- Native Gradle OSGi integration is deprecated in Gradle 5.x
  https://docs.gradle.org/5.0/release-notes.html#deprecated-osgi-plugin
- Use OSGi annotations to lower manifest synchronization cost
  https://bnd.bndtools.org/chapters/230-manifest-annotations.html
- Adjusted `Export-Package` for asciidoctorj-api:
  - `org.asciidoctor.spi` removed as it seems an overlook of bc753140206
  - added `org.asciidoctor.syntaxhighlighter` as generation was
    reporting the following warning:
    `warning: Export org.asciidoctor,  has 1,  private references [org.asciidoctor.syntaxhighlighter]`
    (may have been an overlook of 3e9d47e73)

On a side note, the Bundle-SymbolicName conflict reported at #772 still
exists.