### PR TITLE
fix: hack for Gradle 5 + signed artifacts + gradle-bintray-plugin 1.8.4

### DIFF
--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -32,6 +32,24 @@ if ( !project.hasProperty('skip.signing') ) {
   signPom.enabled = false
 }
 
+/*
+UGLY HACK to workaround gradle-bintray-plugin compatibility with Gradle 5+
+
+https://github.com/asciidoctor/asciidoctorj/issues/861
+https://github.com/bintray/gradle-bintray-plugin/issues/300
+
+WARNING: since the Groovy Gradle API is modified, this breaks build isolation when sharing a common Gradle daemon instance
+
+This works because gradle-bintray-plugin is using Groovy dynamic compilation hence it is affected by Groovy runtime meta-programming
+
+Tested with: Gradle 5.6.3 / gradle-bintray-plugin 1.8.4
+
+TODO: remove as soon as bintray/gradle-bintray-plugin#300 is fixed and integrated
+*/
+Signature.metaClass.getToSignArtifact = { ->
+  return (delegate as Signature).source
+}
+
 configurations.archives.with {
   //We need to remove the (non-existing) jar artifact, otherwise signing will fail
   artifacts.removeAll{ it.type.equals("jar") }


### PR DESCRIPTION
WARNING: since the Groovy Gradle API is modified, this breaks build
isolation when sharing a common Gradle daemon instance.

This hack works because gradle-bintray-plugin is using Groovy dynamic
compilation (i.e. compiled in Groovy without @CompileStatic) hence it is
affected by Groovy runtime meta-programming.

Tested with: Gradle 5.6.3 / gradle-bintray-plugin 1.8.4

asciidoctor/asciidoctorj#861
bintray/gradle-bintray-plugin#300