### PR TITLE
Run CI build using Github Actions

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,46 @@
+name: Build Master
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      max-parallel: 2
+      matrix:
+        java:
+          - '1.8'
+          - '11'
+        os:
+          - ubuntu-latest
+          - macos-latest
+        exclude:
+          - os: macos-latest
+            java: '1.8'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build
+        run: |
+          ./gradlew -S -Pskip.signing assemble
+          unset GEM_PATH GEM_HOME JRUBY_OPTS
+          ./gradlew -S -Pskip.signing check -x test
+      - name: Upstream Build
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '11'
+        run: |
+          unset GEM_PATH GEM_HOME JRUBY_OPTS
+          ./test-asciidoctor-upstream.sh
+
+

--- a/test-asciidoctor-upstream.sh
+++ b/test-asciidoctor-upstream.sh
@@ -24,7 +24,7 @@ sed "s;<version></version>;<version>$ASCIIDOCTOR_VERSION</version>;" pom.xml > p
   mv -f pom.xml.sedtmp pom.xml
 
 #we override the jruby version here with one supported by java9, additionally java9 needs some add-opens arguments that need to be ignored on older jvms
-mvn install -Dgemspec=asciidoctor.gemspec -Djruby.version=9.1.14.0 -Djruby.jvmargs="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util.zip=ALL-UNNAMED"
+mvn install --no-transfer-progress -Dgemspec=asciidoctor.gemspec -Djruby.version=9.2.9.0 -Djruby.jvmargs="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util.zip=ALL-UNNAMED"
 
 cd ../..
 #rm -rf maven


### PR DESCRIPTION
This PR adds CI builds using Github Actions.
Right now it runs a build on master on push to master and every day at 9AM UTC.
PRs are also built.

In the beginning we can keep this in parallel to the build on TravisCI until we are confident that Github works as we need it.

Open points:
- Github Actions also supports building on Windows, I plan to add this later
- I have to look up how to implement the trigger that we currently use for the asciidoctor upstream build. Until we have that we have the scheduled daily build though which should also capture changes, even though it is of course not easy to track down the breaking changes if there were multiple commits to Asciidoctor within a day.