### PR TITLE
Don't skip tests in CI build

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           ./gradlew -S -Pskip.signing assemble
           unset GEM_PATH GEM_HOME JRUBY_OPTS
-          ./gradlew -S -Pskip.signing check -x test
+          ./gradlew -S -Pskip.signing check
       - name: Upstream Build
         if: matrix.os == 'ubuntu-latest' && matrix.java == '11'
         run: |


### PR DESCRIPTION
Accidentally skipped tests in Github Actions.
This PR adds them again.

I had them removed initially for quicker turnaround times when testing the upstream build.