### PR TITLE
Build on Windows

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -42,5 +42,23 @@ jobs:
         run: |
           unset GEM_PATH GEM_HOME JRUBY_OPTS
           ./test-asciidoctor-upstream.sh
+  build-windows:
+    name: Build on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Assemble
+        shell: cmd
+        run: |
+          gradlew.bat -i assemble
+      - name: Check
+        shell: cmd
+        run: |
+          gradlew.bat -i -S check
 
 


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[X] Build improvement

## Description

What is the goal of this pull request?

Run the CI builds on Windows on GH actions.

How does it achieve that?

Add the respective build config.

Are there any alternative ways to implement this?

No

Are there any implications of this pull request? Anything a user must know?

No
## Issue

