### PR TITLE
Fix reading input from stdin and writing to stdout

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -19,6 +19,7 @@ public class Options {
     public static final String MKDIRS = "mkdirs";
     public static final String SAFE = "safe";
     public static final String SOURCEMAP = "sourcemap";
+    public static final String STANDALONE = "standalone";
     public static final String ERUBY = "eruby";
     public static final String CATALOG_ASSETS = "catalog_assets";
     public static final String COMPACT = "compact";

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorCliOptions.java
@@ -248,6 +248,10 @@ public class AsciidoctorCliOptions {
         return this.version;
     }
 
+    private boolean isInputStdin() {
+        return getParameters().size() == 1 && "-".equals(getParameters().get(0));
+    }
+
     private boolean isOutputStdout() {
         return "-".equals(getOutFile());
     }
@@ -257,21 +261,31 @@ public class AsciidoctorCliOptions {
     }
 
     public Options parse() {
-        OptionsBuilder optionsBuilder = OptionsBuilder.options();
         AttributesBuilder attributesBuilder = AttributesBuilder.attributes();
 
-        optionsBuilder.backend(this.backend).safe(this.safeMode).eruby(this.eruby);
+        OptionsBuilder optionsBuilder = OptionsBuilder.options()
+            .backend(this.backend)
+            .safe(this.safeMode)
+            .eruby(this.eruby)
+            .option(Options.STANDALONE, true);
 
         if (isDoctypeOption()) {
             optionsBuilder.docType(this.doctype);
+        }
+
+        if (isInputStdin()) {
+            optionsBuilder.toStream(System.out);
+            if (outFile == null) {
+                outFile = "-";
+            }
         }
 
         if (isOutFileOption() && !isOutputStdout()) {
             optionsBuilder.toFile(new File(this.outFile));
         }
 
-        if (isOutFileOption() && isOutputStdout()) {
-            optionsBuilder.toFile(false);
+        if (isOutputStdout()) {
+            optionsBuilder.toStream(System.out);
         }
 
         if (this.safe) {
@@ -279,7 +293,7 @@ public class AsciidoctorCliOptions {
         }
 
         if (this.noHeaderFooter) {
-            optionsBuilder.headerFooter(false);
+            optionsBuilder.option(Options.STANDALONE, false);
         }
 
         if (this.sectionNumbers) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorCliOptions.java
@@ -113,7 +113,7 @@ public class AsciidoctorCliOptions {
     @Parameter(names = { LOAD_PATHS, "--load-path" }, description = "add a directory to the $LOAD_PATH may be specified more than once")
     private String loadPath;
 
-    @Parameter(description = "input files")
+    @Parameter(description = "input files; use - to read from STDIN")
     private List<String> parameters = new ArrayList<String>();
 
     public boolean isQuiet() {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -78,7 +78,7 @@ public class AsciidoctorInvoker {
                 timings.callMethod(JRubyRuntimeContext.get(asciidoctor).getCurrentContext(), "print_report");
             }
 
-            if (!"".equals(output.trim())) {
+            if (output != null && !"".equals(output.trim())) {
                 System.out.println(output);
             }
         }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -150,14 +150,10 @@ public class AsciidoctorInvoker {
     }
 
     private String renderInput(Asciidoctor asciidoctor, Options options, List<File> inputFiles) {
-        
 
-        // jcommander bug makes this code not working.
-        /*
-        if("-".equals(inputFile)) {
+        if(inputFiles.size() == 1 && "-".equals(inputFiles.get(0).getName())) {
             return asciidoctor.convert(readInputFromStdIn(), options);
         }
-        */
 
         StringBuilder output = new StringBuilder();
 
@@ -186,8 +182,8 @@ public class AsciidoctorInvoker {
     }
 
     private String readInputFromStdIn() {
-        Scanner in = new Scanner(System.in);
-        String content = in.nextLine();
+        Scanner in = new Scanner(System.in).useDelimiter("\\A");
+        String content = in.next();
         in.close();
 
         return content;
@@ -201,13 +197,6 @@ public class AsciidoctorInvoker {
             System.err.println("asciidoctor: FAILED: empty input file name");
             throw new IllegalArgumentException(
                     "asciidoctor: FAILED: empty input file name");
-        }
-
-        if (parameters.contains("-")) {
-            System.err
-                    .println("asciidoctor:  FAILED: input file is required instead of an argument.");
-            throw new IllegalArgumentException(
-                    "asciidoctor:  FAILED: input file is required instead of an argument.");
         }
 
         List<File> filesToBeRendered = new ArrayList<File>();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -15,6 +15,7 @@ import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.jruby.DirectoryWalker;
 import org.asciidoctor.jruby.GlobDirectoryWalker;
 import org.asciidoctor.Options;
+import org.asciidoctor.jruby.internal.IOUtils;
 import org.asciidoctor.jruby.internal.JRubyAsciidoctor;
 import org.asciidoctor.jruby.internal.JRubyRuntimeContext;
 import org.asciidoctor.jruby.internal.RubyUtils;
@@ -182,9 +183,12 @@ public class AsciidoctorInvoker {
     }
 
     private String readInputFromStdIn() {
-        Scanner in = new Scanner(System.in).useDelimiter("\\A");
-        String content = in.next();
-        in.close();
+        String content = IOUtils.readFull(System.in);
+        try {
+            System.in.close();
+        } catch (IOException e) {
+            // swallow
+        }
 
         return content;
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -70,16 +70,12 @@ public class AsciidoctorInvoker {
             
             setVerboseLevel(asciidoctor, asciidoctorCliOptions);
 
-            String output = renderInput(asciidoctor, options, inputFiles);
+            renderInput(asciidoctor, options, inputFiles);
 
             if (asciidoctorCliOptions.isTimings()) {
                 Map<String, Object> optionsMap = options.map();
                 IRubyObject timings = (IRubyObject) optionsMap.get("timings");
                 timings.callMethod(JRubyRuntimeContext.get(asciidoctor).getCurrentContext(), "print_report");
-            }
-
-            if (output != null && !"".equals(output.trim())) {
-                System.out.println(output);
             }
         }
     }
@@ -183,14 +179,7 @@ public class AsciidoctorInvoker {
     }
 
     private String readInputFromStdIn() {
-        String content = IOUtils.readFull(System.in);
-        try {
-            System.in.close();
-        } catch (IOException e) {
-            // swallow
-        }
-
-        return content;
+        return IOUtils.readFull(System.in);
     }
 
     private List<File> getInputFiles(AsciidoctorCliOptions asciidoctorCliOptions) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/IOUtils.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/IOUtils.java
@@ -13,11 +13,15 @@ public class IOUtils {
     }
 
     public static String readFull(InputStream inputStream) {
-        return new Scanner(inputStream).useDelimiter("\\A").next();
+        try (Scanner scanner = new Scanner(inputStream).useDelimiter("\\A")){
+            return scanner.next();
+        }
     }
 
     public static String readFull(Reader reader) {
-        return new Scanner(reader).useDelimiter("\\A").next();
+        try (Scanner scanner = new Scanner(reader).useDelimiter("\\A")){
+            return scanner.next();
+        }
     }
 
     public static void writeFull(Writer writer, String content) throws IOException {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -379,6 +379,11 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
             rubyRuntime.setCurrentDirectory((String) options.get(Options.BASEDIR));
         }
 
+        final Object toFileOption = options.get(Options.TO_FILE);
+        if (toFileOption instanceof OutputStream) {
+            options.put(Options.TO_FILE, RubyOutputStreamWrapper.wrap(getRubyRuntime(), (OutputStream) toFileOption));
+        }
+
         RubyHash rubyHash = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
 
         try {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -209,8 +209,8 @@ public class WhenAsciidoctorIsCalledUsingCli {
 		
 		ByteArrayOutputStream output = redirectStdout();
 		
-        File inputFile = classpath.getResource("rendersample.asciidoc");
-        String inputPath = inputFile.getPath().substring(pwd.length() + 1);
+		File inputFile = classpath.getResource("rendersample.asciidoc");
+		String inputPath = inputFile.getPath().substring(pwd.length() + 1);
 		new AsciidoctorInvoker().invoke("-o", "-", inputPath);
 		
 		Document doc = Jsoup.parse(output.toString(), "UTF-8");


### PR DESCRIPTION
## Kind of change

[X] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[ ] Build improvement

## Description

### What is the goal of this pull request?

This PR builds on the awesome changes from @nicerloop in #864 
On top of that I added a few fixes where that PR deviated from the behaviour in asciidoctor:

`echo "Hello World"|asciidoctorj -` will create a full document including header and footer, just like asciidoctor does.

`echo "Hello World"|asciidoctorj - -b pdf` writes the pdf document to stdout.

### How does it achieve that?

In addition to the changes in #864 this PR by default sets the option `:standalone` to `true`, that's also what the Asciidoctor CLI does [here](https://github.com/asciidoctor/asciidoctor/blob/4155916105b3276e5971349b1730b9d095d29db3/lib/asciidoctor/cli/options.rb#L15).
If the cli argument `-s/--no-header-footer` is passed, `:standalone` is set to `false`, also similar to what the Asciidoctor CLI does [here](https://github.com/asciidoctor/asciidoctor/blob/4155916105b3276e5971349b1730b9d095d29db3/lib/asciidoctor/cli/options.rb#L73-L75)

Then, instead of printing out the output, it sets the outfile option to the stdout stream, so that also PDFs are correctly converted to stdout instead of printing the result of the PDF converter, which is the PDF converter object itself.

Are there any alternative ways to implement this?

Yes, using the Asciidoctor command line parsing directly, but there are some caveats that I have to think about, like additional options for setting sth like a classpath, which doesn't exist in Asciidoctor/Ruby.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #865  

