### PR TITLE
Add upstream build trigger

### DIFF
--- a/.github/workflows/upstream-build.yaml
+++ b/.github/workflows/upstream-build.yaml
@@ -1,0 +1,19 @@
+name: Build Upstream
+on: repository_dispatch
+
+jobs:
+  build-upstream:
+    name: ${{ github.event.client_payload.message }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.client_payload.branch }} 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '1.8'
+      - name: Build
+        run: |
+          unset GEM_PATH GEM_HOME JRUBY_OPTS
+          ./test-asciidoctor-upstream.sh


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[x] Build improvement

## Description

What is the goal of this pull request?

This PR adds a build trigger for the upstream build, so that asciidoctor/asciidoctor can trigger upstream builds on every commit, similar to what we have today with travis.

How does it achieve that?

Registers a workflow that is triggered on `repository_dispatch`.
An upstream build can be triggered like this now:
```
curl -XPOST https://api.github.com/repos/asciidoctor/asciidoctorj/dispatches \
  -H 'Accept: application/vnd.github.everest-preview+json' \
  -H 'authorization: token <token>' \
  -H 'content-type: application/json' \
  --data '{
  "event_type":"test_upstream", 
  "client_payload": {
    "message":"Triggered by commit xyz", 
    "branch": "master"
  }
}'
```
The token must have the `repo` scope.

Are there any alternative ways to implement this?

Staying on Travis or moving to some other CI system.

Are there any implications of this pull request? Anything a user must know?

No

