### PR TITLE
Fix 878 osgi symbolicname

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,7 @@ Bug Fixes::
   * Remove exception protection from LogHandler in `JRubyAsciidoctor` to align behaviour with `AbstractConverter`  (@abelsromero) (#844)
   * Make Asciidoctor API AutoClosable (@rmannibucau) (#849)
   * Fix reading input from stdin and writing to stdout (@nicerloop) (#865)
+  * Assign distinct Osgi Bundle-SymbolicNames to asciidoctorj-api.jar and asciidoctorj.jar (@rmannibucau) (#878)
 
 Build::
 

--- a/asciidoctorj-api/build.gradle
+++ b/asciidoctorj-api/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 jar {
   bnd(
     ('Bundle-Name'): 'asciidoctorj-api',
-    ('Bundle-SymbolicName'): 'org.asciidoctor',
+    ('Bundle-SymbolicName'): 'org.asciidoctor.asciidoctorj-api',
   )
 }
 

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -52,7 +52,7 @@ javadoc {
 jar {
   bnd(
     ('Bundle-Name'): 'asciidoctorj',
-    ('Bundle-SymbolicName'): 'org.asciidoctor',
+    ('Bundle-SymbolicName'): 'org.asciidoctor.asciidoctorj',
     ('Import-Package'):
       'com.beust.jcommander;resolution:=optional, *'
   )


### PR DESCRIPTION
## Kind of change

[X] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[ ] Build improvement

## Description

This PR associates distinct Symbolic-BundleNames to the archives asciidoctorj-api.jar and asciidoctorj.jar.
These names now reflect the Maven coordinates, i.e. `org.asciidoctor.asciidoctorj-api` and `org.asciidoctor.asciidoctorj`.
