### PR TITLE
Remove torquebox proxy

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Build
     strategy:
+      fail-fast: false
       max-parallel: 2
       matrix:
         java:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         java:
           - '1.8'
-          - '11'
+          - '11.0.5'
         os:
           - ubuntu-latest
           - macos-latest
@@ -39,7 +39,7 @@ jobs:
           unset GEM_PATH GEM_HOME JRUBY_OPTS
           ./gradlew -S -Pskip.signing check
       - name: Upstream Build
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '11'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '1.8'
         run: |
           unset GEM_PATH GEM_HOME JRUBY_OPTS
           ./test-asciidoctor-upstream.sh

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Build::
+
+  * Load Gems directly from rubygems.org instead of using torquebox Maven proxy.
+
 == 2.2.0 (2019-12-17)
 
 Improvement::

--- a/build.gradle
+++ b/build.gradle
@@ -187,15 +187,12 @@ configure(subprojects.findAll { !it.isDistribution() }) {
   apply from: rootProject.file('gradle/eclipse.gradle')
   apply plugin: 'idea'
 
+  jruby {
+    defaultRepositories false
+  }
+
   repositories {
-    maven {
-      name 'rubygems-release'
-      url 'http://rubygems-proxy.torquebox.org/releases'
-    }
-    maven {
-      name 'rubygems-prerelease'
-      url 'http://rubygems-proxy.torquebox.org/prereleases'
-    }
+    rubygems('https://rubygems.org')
   }
 
   if (JavaVersion.current().isJava8Compatible()) {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 // modern plugins config
 plugins {
-  id 'com.github.jruby-gradle.base' version '1.4.0'
+  id 'com.github.jruby-gradle.base' version '1.7.0'
 }
 
 // TIP use -PpublishRelease=true to active release behavior regardless of the version

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 version=2.3.0-SNAPSHOT
 sourceCompatibility=1.8
 targetCompatibility=1.8
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

Apparently the torquebox Maven proxy does not work anymore.
That means that all builds currently fail because gems cannot be downloaded.

This PR tries to circumvent the problem by using the functionality of the ruby-gradle-plugin to start an internal server that runs the torquebox proxy servlet.

