### PR TITLE
Upgrade JRuby plugin to 2.0.0-alpha.7

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 Build::
 
-  * Load Gems directly from rubygems.org instead of using torquebox Maven proxy.
+  * Upgrade jruby-gradle-plugin to 2.0.0-alpha.7 and load Gems directly from rubygems.org instead of using torquebox Maven proxy.
 
 == 2.2.0 (2019-12-17)
 

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   compileOnly "org.osgi:osgi.annotation:$osgiVersion"
 }
 
-def gemFiles = fileTree(jruby.gemInstallDir) {
+def gemFiles = fileTree("${project.buildDir}/.gems") {
   include 'specifications/*.gemspec'
   include 'gems/*/lib/**'
   include "gems/asciidoctor-*/data/**"

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 // modern plugins config
 plugins {
-  id 'com.github.jruby-gradle.base' version '1.7.0'
+  id 'com.github.jruby-gradle.base' version '2.0.0-alpha.7'
 }
 
 // TIP use -PpublishRelease=true to active release behavior regardless of the version
@@ -192,7 +192,7 @@ configure(subprojects.findAll { !it.isDistribution() }) {
   }
 
   repositories {
-    rubygems('https://rubygems.org')
+    ruby.gems()
   }
 
   if (JavaVersion.current().isJava8Compatible()) {
@@ -226,7 +226,6 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') && ! it.name.
   jruby {
     defaultRepositories = false
     defaultVersion = jrubyVersion
-    execVersion = jrubyVersion
     // TODO I'd like to be able to customize the name of the gemInstallDir
   }
 


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[ ] Documentation update
[X] Build improvement

## Description

Upgrade the jruby-gradle-plugin to end the fiasco around the torquebox proxy and different Java version.

I checked manually that the table of contents of the asciidoctorj-2.2.0.jar is the same as the toc from the jar built with this PR.
