### PR TITLE
update artifact versions in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,9 +20,10 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-discuss: http://discuss.asciidoctor.org
-:artifact-version: 2.1.0
-:asciidoctorj-pdf-version: 1.5.0-beta.5
-jruby-version: 9.2.8.0
+:artifact-version: 2.2.0
+:asciidoctorj-epub3-version: 1.5.0-alpha.9
+:asciidoctorj-pdf-version: 1.5.0-beta.8
+:jruby-version: 9.2.9.0
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
 :uri-maven-artifact-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}
@@ -78,7 +79,7 @@ The artifact information can be found in the tables below.
 
 |org.asciidoctor
 |asciidoctorj-epub3
-|1.5.0-alpha.9
+|{asciidoctorj-epub3-version}
 |{empty}
 
 |org.asciidoctor
@@ -104,12 +105,12 @@ The artifact information can be found in the tables below.
 
 |org.asciidoctor
 |asciidoctorj-epub3
-|1.5.0-alpha.9
+|{asciidoctorj-epub3-version}
 |{empty}
 
 |org.asciidoctor
 |asciidoctorj-pdf
-|1.5.0-alpha.18
+|{asciidoctorj-pdf-version}
 |{empty}
 |===
 
@@ -841,13 +842,13 @@ The version of the AsciidoctorJ EPUB3 jar aligns with the version of the Asciido
 
 Here's how you can add the AsciidoctorJ EPUB3 jar to your Maven dependencies:
 
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <dependencies>
   <dependency>
     <groupId>org.asciidoctor</groupId>
     <artifactId>asciidoctorj-epub3</artifactId>
-    <version>1.5.0-alpha.4</version>
+    <version>{asciidoctorj-epub3-version}</version>
     <scope>runtime</scope>
   </dependency>
 </dependencies>


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[ ] New non-breaking feature
[ ] New breaking feature
[X] Documentation update
[ ] Build improvement

## Description

What is the goal of this pull request?

Updates artifact versions in README to last published versions:
* core: 2.2.0,
* epub3: 1.5.0-alpha.9
* pdf 1.5.0-beta.8
. jruby 9.2.9.0

How does it achieve that?

Updates README with updated versions of artifacts & jruby.
Also:
* Defines new property `asciidoctorj-epub3-version` and uses it where before there was a constant.
* Fixes missing colon in `jruby-version` property.

Are there any alternative ways to implement this?

_No_

Are there any implications of this pull request? Anything a user must know?

_No_

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 

_Not applicable_

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc

_Not applicable_