### PR TITLE
adds support for github admonitions icons

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ Build::
 Documentation::
 
   * Update documentation to show how to create an Asciidoctor instance with GEM_PATH (#890)
+  * Adds GitHub icons to admonitions sections in README (#893)
 
 == 2.2.0 (2019-12-17)
 

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,16 @@ ifdef::awestruct[:toclevels: 1]
 //:table-caption!:
 :source-language: java
 :language: {source-language}
-ifdef::env-github[:badges:]
+ifndef::env-github[:icons: font]
+ifdef::env-github[]
+:badges:
+:!toc-title:
+:caution-caption: :fire:
+:important-caption: :exclamation:
+:note-caption: :paperclip:
+:tip-caption: :bulb:
+:warning-caption: :warning:
+endif::[]
 // Aliases:
 :dagger: &#8224;
 // URIs:


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

_Makes documentation clearer highlighting admonitions with icons. At least for me_
_Same icons used as in https://github.com/asciidoctor/asciidoctor/blob/master/README.adoc_

How does it achieve that?

_Uses github special tags as attributes_

Are there any alternative ways to implement this?

_Not that I know_

Are there any implications of this pull request? Anything a user must know?

_No_

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc