### PR TITLE
Chocolatey: Upgrade packaging to 2.2.0.

### DIFF
--- a/chocolatey/README.adoc
+++ b/chocolatey/README.adoc
@@ -28,5 +28,5 @@ https://chocolatey.org/docs/create-packages .
 # Log into https://chocolatey.org/account and copy your API key.
 # (This assumes you don't have a key set in your Chocolatey config.)
 # Push the package to chocolatey.org.
-> choco push --api-key=you-api-key asciidoctorj.x.y.z.nupkg
+> choco push --api-key=your-api-key asciidoctorj.x.y.z.nupkg
 ----

--- a/chocolatey/asciidoctorj.nuspec
+++ b/chocolatey/asciidoctorj.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>asciidoctorj</id>
     <title>AsciidoctorJ (Install)</title>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <!--
       https://github.com/asciidoctor/asciidoctorj/graphs/contributors
       https://github.com/asciidoctor/asciidoctor/graphs/contributors

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
 
-$adocjVersion = '2.1.0'
+$adocjVersion = '2.2.0'
 $packageName= 'asciidoctorj' # arbitrary name for the package, used in messages
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 # Which is the preferred mirror? There are many listed at
@@ -18,7 +18,7 @@ $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   url           = $url
-  checksum      = '708bb954d09eeb862ed7627e743be8f96f2a67397c561ab56e85b6bc4650cc77'
+  checksum      = 'd5240240a4e39f4f9c56abab2da3e960a4784b7d8e7befa323fc9f64890f0029'
   checksumType  = 'sha256' #default is md5, can also be sha1
   #checksum64    = ''
   #checksumType64= 'md5' #default is checksumType


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Upgrade the Chocolatey packaging assets for AsciidoctorJ version 2.2.0

How does it achieve that?

Bumps version numbers and the SHA256 sum.

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

The Chocolatey package page is at https://chocolatey.org/packages/asciidoctorj/