### PR TITLE
Fix/914/incorrect path for converter example

### DIFF
--- a/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
+++ b/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
@@ -1177,7 +1177,7 @@ include::src/test/java/org/asciidoctor/integrationguide/converter/TextConverterR
 
 The jar file must also contain the services file containing the fully qualified class name of the `ConverterRegistry` implementation to make this service implementation available:
 
-.META-INF/services/META-INF/services/org.asciidoctor.jruby.converter.spi.ConverterRegistry
+.META-INF/services/org.asciidoctor.jruby.converter.spi.ConverterRegistry
 ----
 include::src/test/resources/converterregistry/META-INF/services/org.asciidoctor.jruby.converter.spi.ConverterRegistry[]
 ----

--- a/docs/integrator-guide.adoc
+++ b/docs/integrator-guide.adoc
@@ -1770,7 +1770,7 @@ public class TextConverterRegistry implements ConverterRegistry {
 
 The jar file must also contain the services file containing the fully qualified class name of the `ConverterRegistry` implementation to make this service implementation available:
 
-.META-INF/services/META-INF/services/org.asciidoctor.jruby.converter.spi.ConverterRegistry
+.META-INF/services/org.asciidoctor.jruby.converter.spi.ConverterRegistry
 ----
 org.asciidoctor.integrationguide.converter.TextConverterRegistry
 ----

--- a/docs/integrator-guide.adoc
+++ b/docs/integrator-guide.adoc
@@ -1089,7 +1089,6 @@ That means that our block processor will convert blocks like this:
 ----
 [yell]
 I really mean it
-
 ----
 
 After the processing this block will look like this
@@ -1171,7 +1170,6 @@ The processor could look like this:
 .LsIncludeProcessor.java
 [source,java,indent=0]
 ----
-
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.IncludeProcessor;
 import org.asciidoctor.extension.PreprocessorReader;
@@ -1252,7 +1250,6 @@ Normal content.
 ////
 RP: This is a comment and should only appear in draft documents
 ////
-
 ----
 
 The preprocessor will render the document as if it looked like this:
@@ -1266,7 +1263,6 @@ Normal content.
 --
 RP: This is a comment and should only appear in draft documents
 --
-
 ----
 
 The implementation of the preprocessor simply gets the AST node for the document to be created as well as a `PreprocessorReader`.
@@ -1739,7 +1735,6 @@ Finally the converter can be registered and used for conversion of AsciiDoc docu
                     OptionsBuilder.options()
                             .backend("text")                                   // <1>
                             .toFile(false));
-
 ----
 <1> Registers the converter class `TextConverter` for this Asciidoctor instance.
     The given converter is responsible for converting to the target format `text` because the `@ConverterFor` annotation of the converter class defines this name.
@@ -1765,7 +1760,6 @@ public class TextConverterRegistry implements ConverterRegistry {
 
     }
 }
-
 ----
 
 The jar file must also contain the services file containing the fully qualified class name of the `ConverterRegistry` implementation to make this service implementation available:
@@ -2079,7 +2073,6 @@ For scenarios where it should also be possible to read the document while offlin
 
 [source,java]
 ----
-
 public class HighlightJsWithOfflineStylesHighlighter implements SyntaxHighlighterAdapter, Formatter, StylesheetWriter { // <1>
 
     @Override
@@ -2382,7 +2375,6 @@ Next, you need to create a file called `org.asciidoctor.jruby.syntaxhighlighter.
 .META-INF/services/org.asciidoctor.jruby.syntaxhighlighter.spi.SyntaxHighlighterRegistry
 ----
 org.asciidoctor.integrationguide.syntaxhighlighter.HighlightJsExtension
-
 ----
 
 And that's all.


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [X] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

* Correct minnor error seen in converters examples

How does it achieve that?

* Corrects path in the example label
* Also removes some unnecessary linebreaks in some other examples. Given that most don't have them, I assume those linebreaks are not on purpose.

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #914 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc

* Don't think such a minor correction is worth mentioning.