### PR TITLE
Update asciidoctorj-epub3 to v1.5.0-alpha.16

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 Improvement::
 
   * Add asciidoctor-revealjs to distribution (#910)
+  * Upgrade to Asciidoctor PDF 1.5.3
+  * Upgrade to Asciidoctor EPUB3 1.5.0-alpha.16
+  * Upgrade to Asciidoctor Diagram 2.0.1
 
 Build::
 
@@ -25,9 +28,6 @@ Documentation::
 
   * Update documentation to show how to create an Asciidoctor instance with GEM_PATH (#890)
   * Adds GitHub icons to admonitions sections in README (#893)
-  * Upgrade to Asciidoctor PDF 1.5.0-rc.2
-  * Upgrade to Asciidoctor EPUB3 1.5.0-alpha.15
-  * Upgrade to Asciidoctor Diagram 2.0.1
 
 Build::
 

--- a/README.adoc
+++ b/README.adoc
@@ -30,8 +30,8 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-issues: {uri-repo}/issues
 :uri-discuss: http://discuss.asciidoctor.org
 :artifact-version: 2.2.0
-:asciidoctorj-epub3-version: 1.5.0-alpha.15
-:asciidoctorj-pdf-version: 1.5.0-beta.8
+:asciidoctorj-epub3-version: 1.5.0-alpha.16
+:asciidoctorj-pdf-version: 1.5.3
 :jruby-version: 9.2.9.0
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ ext {
   // jar versions
   arquillianVersion = '1.1.10.Final'
   arquillianSpockVersion = '1.0.0.Beta3'
-  asciidoctorjPdfVersion = '1.5.0-rc.2'
-  asciidoctorjEpub3Version = '1.5.0-alpha.15'
+  asciidoctorjPdfVersion = '1.5.3'
+  asciidoctorjEpub3Version = '1.5.0-alpha.16'
   asciidoctorjDiagramVersion = '2.0.1'
   asciidoctorjRevealJsVersion = '4.0.1'
   commonsioVersion = '2.4'


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [X] New non-breaking feature
- [ ] New breaking feature
- [X] Documentation update
- [ ] Build improvement

## Description

Upgrade AsciidoctorJ-epub3 to the latest and greatest 1.5.0-alpha.16