### PR TITLE
Fixes #926. Make sure that symbols stay symbols in extension config.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Bug Fixes::
+
+* Inline macro attribute parsing changes after first document conversion (@wilkinsona) (#926)
+
 == 2.3.0 (2020-05-02)
 
 Improvement::

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyHashMapDecorator.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyHashMapDecorator.java
@@ -144,7 +144,7 @@ public class RubyHashMapDecorator implements Map<String, Object> {
                 return NodeConverter.createASTNode(rubyObject);
             }
             if (rubyObject instanceof RubySymbol) {
-                return ((RubySymbol) rubyObject).asJavaString();
+                return ":" + rubyObject.asString();
             }
             return JavaEmbedUtils.rubyToJava((IRubyObject) rubyValue);
         } else {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenTheInlineMacroProcessorRunsTwice.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenTheInlineMacroProcessorRunsTwice.java
@@ -1,0 +1,36 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.ast.ContentNode;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class WhenTheInlineMacroProcessorRunsTwice {
+
+    // See https://github.com/asciidoctor/asciidoctorj/issues/926
+    @Test
+    public void inlineMacroAttributes() {
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().inlineMacro(new InlineMacroProcessor("example") {
+
+            @Override
+            public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+                return createPhraseNode(parent, "quoted", attributes.toString(), attributes, new HashMap<>());
+            }
+
+        });
+        assertThat(convert(asciidoctor), containsString("{format=test}"));
+        assertThat(convert(asciidoctor), containsString("{format=test}"));
+    }
+
+    private String convert(Asciidoctor asciidoctor) {
+        return asciidoctor.convert("example:alpha.bravo[format=test]", Collections.emptyMap());
+    }
+
+}


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [X] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

This is a fix for #926.

How does it achieve that?

The problem here is that symbols in the extension config currently are converted to strings and then change the behaviour if an extension is used multiple times.

Are there any alternative ways to implement this?

Probably, the whole mapping of Symbols and Strings between Ruby and Java is quite complex if Symbols should appear as Strings in the Java space, but have to remain Symbols in the Ruby space, but I couldn't figure out a cleaner way yet.

Are there any implications of this pull request? Anything a user must know?

If somebody uses the extension config and relies on the "default" values not being returned as plain strings, but with the prefix `:`, then this might break the expectations.
But right now I'd still consider this as a bugfix that could go into a 2.3.1.

## Issue

Fixes #926


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc