### PR TITLE
upgrade rouge to prevent exception (fixes #925)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Bug Fixes::
+
+  * Upgrade to Rouge 3.20.0, fixing error `uninitialized constant Rouge::Lexers` problem (@ahus1) (#925)
+
 == 2.3.0 (2020-05-02)
 
 Improvement::

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext {
   // gem versions
   asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.10'
   coderayGemVersion = '1.1.2'
-  rougeGemVersion = '3.12.0'
+  rougeGemVersion = '3.20.0'
 
   codenarcVersion = '0.24.1'
   groovyVersion = '2.4.13'


### PR DESCRIPTION
upgrade rouge to prevent exception about uninitialized constant Rouge::Lexers. See https://github.com/asciidoctor/asciidoctorj/issues/925 and https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/505 for a discussion where this happens.

When I build this new version of AsciidoctorJ and test it in my local setup (AsciiDoc plugin for IntelliJ), this change fixes the error. 

What is strange for me: the test WhenSourceHighlightingIsUsed#should_render_with_rouge worked before and after the change. I wasn't able to provide a test that fails before the upgrade and succeeds after the upgrade.

I am looking forward to a bugfix release to use it in the AsciiDoc plugin for IntelliJ. 

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Fix error when using Rouge highlighter when creating HTML

How does it achieve that?
Upgrading Rouge 

Are there any alternative ways to implement this?
no

Are there any implications of this pull request? Anything a user must know?
no

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #925

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc