### PR TITLE
Add first support for registering converter instances

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/converter/JavaConverterRegistry.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/converter/JavaConverterRegistry.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 public interface JavaConverterRegistry {
 
+    <U, T  extends Converter<U> & OutputFormatWriter<U>> void register(T converterClass, String... backends);
+
     <U, T  extends Converter<U> & OutputFormatWriter<U>> void register(Class<T> converterClass, String... backends);
 
     Class<?> resolve(String backend);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JavaConverterRegistryImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JavaConverterRegistryImpl.java
@@ -9,6 +9,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
+import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,28 +25,38 @@ public class JavaConverterRegistryImpl implements JavaConverterRegistry {
         this.rubyRuntime = asciidoctor.getRubyRuntime();
     }
 
+
+    @Override
+    public <U, T  extends Converter<U> & OutputFormatWriter<U>> void register(final T converter, String... backends) {
+        IRubyObject converterInstance = ConverterProxy.register(asciidoctor, converter);
+        ConverterFor converterForAnnotation = converter.getClass().getAnnotation(ConverterFor.class);
+        registerConverter(converterInstance, converterForAnnotation, backends);
+    }
+
     @Override
     public <U, T  extends Converter<U> & OutputFormatWriter<U>> void register(final Class<T> converterClass, String... backends) {
-
         RubyClass clazz = ConverterProxy.register(asciidoctor, converterClass);
-
         ConverterFor converterForAnnotation = converterClass.getAnnotation(ConverterFor.class);
+        registerConverter(clazz, converterForAnnotation, backends);
+    }
+
+    private void registerConverter(IRubyObject converter, ConverterFor converterForAnnotation, String[] backends) {
         if (converterForAnnotation != null) {
             // Backend annotation present => Register with name given in annotation
             String backend = !ConverterFor.UNDEFINED.equals(converterForAnnotation.format()) ? converterForAnnotation.format() : converterForAnnotation.value();
             getConverterFactory()
-                .callMethod("register", clazz, rubyRuntime.newString(backend));
+                .callMethod("register", converter, rubyRuntime.newString(backend));
 
         } else if (backends.length == 0) {
             // No backend annotation and no backend defined => register as default backend
             getConverterFactory()
-                .callMethod("register", clazz, rubyRuntime.newString("*"));
+                .callMethod("register", converter, rubyRuntime.newString("*"));
         }
         if (backends.length > 0) {
             // Always additionally register with names passed to this method
             for (String backend: backends) {
                 getConverterFactory()
-                        .callMethod("register", clazz, rubyRuntime.newString(backend));
+                        .callMethod("register", converter, rubyRuntime.newString(backend));
             }
         }
     }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableConverterTest.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableConverterTest.groovy
@@ -76,4 +76,29 @@ a|
 A HEADER       |Second column'''.readLines()
 
     }
+
+    def "should register a converter instance"() {
+
+        given:
+        String document = '''
+= Hello Asciidoctor Table
+
+[cols="2"]
+|====
+a|
+= A header
+| Second column
+|====
+'''
+        asciidoctor.javaConverterRegistry().register(new TableTestConverter(), 'tabletestconverter')
+
+        when:
+        String content = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false).backend('tabletestconverter'))
+
+        then:
+        content.readLines().collect {it - ~/\s+$/ } == '''HELLO ASCIIDOCTOR TABLE
+
+A HEADER       |Second column'''.readLines()
+
+    }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableTestConverter.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableTestConverter.groovy
@@ -13,6 +13,10 @@ class TableTestConverter extends StringConverter {
     public static final String NEWLINE = '\n'
     public static final String NEWLINE_2 = NEWLINE * 2
 
+    TableTestConverter() {
+        super('???', null)
+    }
+
     TableTestConverter(String backend, Map<String, Object> opts) {
         super(backend, opts)
     }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [X] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

The goal is to allow registering converter instances. Today it is only possible to register classes, that are instantiated by Asciidoctor for each document conversion.

How does it achieve that?

The ConverterProxy creates a single Ruby class for the class of the registered instance, and instantiates that on every registration call, passing the concrete Java converter to the initializeInstance method.

Are there any alternative ways to implement this?

Yes, similar to how the extensions work today, which is not ideal now that I have a different view on it, I could have created a new class for every registration, and each RubyClass would use the same registered Java instance.
But I think the new approach is a bit better.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #932 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc

Note:

The PR is not final yet. There have to be a lot more tests, and there is still the problem how the ConverterRegistry should look like for looking up converters without breaking the API. Right now `JavaConverterRegistry.resolve()` and `JavaConverterRegistry.converters()` return classes, not instances or objects.
We might need to go to AsciidoctorJ 3.0.0 to support getting instances from the converter registry.

I already opened the PR early in case somebody wants to test this too.