### PR TITLE
Fixes #931. Add method StructuralNode.setLevel()

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Improvement::
+
+ * Add method StructuralNode.setLevel() (@Mogztter) (#931)
+
 == 2.3.1 (2020-06-17)
 
 Bug Fixes::

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
@@ -87,7 +87,10 @@ public interface StructuralNode extends ContentNode {
     Object getContent();
     String convert();
     List<StructuralNode> findBy(Map<Object, Object> selector);
+
     int getLevel();
+
+    void setLevel(int level);
 
     /**
      * Returns the content model.

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/StructuralNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/StructuralNodeImpl.java
@@ -98,6 +98,11 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     }
 
     @Override
+    public void setLevel(int level) {
+        setInt("level", level);
+    }
+
+    @Override
     public Cursor getSourceLocation() {
         IRubyObject object = getRubyProperty("source_location");
         if (object == null || object.isNil()) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyObjectWrapper.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyObjectWrapper.java
@@ -86,9 +86,14 @@ public class RubyObjectWrapper {
         if (result instanceof RubyNil) {
             return 0;
         } else {
-            return (int) ((RubyNumeric) result).getLongValue();
+            return (int) ((RubyNumeric) result).getIntValue();
         }
     }
+
+    public void setInt(String propertyName, int value) {
+        setRubyProperty(propertyName, runtime.newFixnum(value));
+    }
+
 
     public <T> List<T> getList(String propertyName, Class<T> elementClass, Object... args) {
         IRubyObject result = getRubyProperty(propertyName, args);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/LevelConverter.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/LevelConverter.java
@@ -1,0 +1,31 @@
+package org.asciidoctor.converter;
+
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.Section;
+
+import java.util.Map;
+
+public class LevelConverter extends StringConverter {
+
+    public LevelConverter(String backend, Map<String, Object> opts) {      // <2>
+        super(backend, opts);
+    }
+
+    @Override
+    public String convert(
+            ContentNode node, String transform, Map<Object, Object> o) {
+
+        if (node instanceof Document) {
+            Document document = (Document) node;
+            return document.getContent().toString();
+        } else if (node instanceof Section) {
+            Section section = (Section) node;
+            return new StringBuilder()
+                    .append("== ").append(section.getLevel()).append(" ").append(section.getTitle()).append(" ==")
+                    .toString();
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [X] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

This PR adds the missing method to set the level of a structural node (`StructuralNode.setLevel(int)`)

How does it achieve that?

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #931 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc