### PR TITLE
Fix upstream test to adapt to changes in HighlightJS syntax highlighter.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,10 @@ Improvement::
  * Upgrade to JRuby 9.2.12.0 removing the last illegal access warnings (#935)
  * Upgrade to Asciidoctor EPUB3 1.5.0-alpha.16 (#939)
 
+Build::
+
+* Fix upstream build to adapt to changes in Ruby Highlightjs syntax highlighter (#940)
+
 == 2.3.1 (2020-06-17)
 
 Bug Fixes::

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsExtension.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsExtension.groovy
@@ -9,7 +9,7 @@ class HighlightJsExtension implements org.asciidoctor.jruby.syntaxhighlighter.sp
     @Override
     void register(Asciidoctor asciidoctor) {
         asciidoctor.syntaxHighlighterRegistry()
-            .register(HighlightJsHighlighter, NAME_HIGHLIGHTER)
+            .register(ObservableHighlightJsHighlighter, NAME_HIGHLIGHTER)
     }
 
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsHighlighter.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsHighlighter.groovy
@@ -4,12 +4,10 @@ import org.asciidoctor.ast.Block
 import org.asciidoctor.ast.Document
 import org.asciidoctor.extension.LocationType
 
-class HighlightJsHighlighter implements SyntaxHighlighterAdapter, Formatter {
+abstract class AbstractHighlightJsHighlighter implements SyntaxHighlighterAdapter, Formatter {
 
     @Override
-    boolean hasDocInfo(LocationType location) {
-        location == LocationType.FOOTER
-    }
+    abstract boolean hasDocInfo(LocationType location)
 
     @Override
     String getDocinfo(LocationType location, Document document, Map<String, Object> options) {
@@ -22,5 +20,48 @@ class HighlightJsHighlighter implements SyntaxHighlighterAdapter, Formatter {
     @Override
     String format(Block node, String lang, Map<String, Object> opts) {
         """<pre class="highlightjs highlight"><code data-lang="$lang" class="language-$lang hljs">${node.content}</code></pre>"""
+    }
+}
+
+class OldHighlightJsHighlighter extends AbstractHighlightJsHighlighter {
+
+    @Override
+    boolean hasDocInfo(LocationType location) {
+        location == LocationType.FOOTER
+    }
+
+}
+
+class NewHighlightJsHighlighter extends AbstractHighlightJsHighlighter {
+
+    @Override
+    boolean hasDocInfo(LocationType location) {
+        true
+    }
+
+    @Override
+    String getDocinfo(LocationType location, Document document, Map<String, Object> options) {
+        String baseUrl = document.getAttribute('highlightjsdir', "${options['cdn_base_url']}/highlight.js/9.15.6")
+        location == LocationType.HEADER ?
+                """<link rel="stylesheet" href="$baseUrl/styles/${document.getAttribute('highlightjs-theme', 'github')}.min.css"${options['self_closing_tag_slash']}>""" :
+                """<script src="$baseUrl/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>"""
+    }
+
+}
+
+class ObservableHighlightJsHighlighter extends AbstractHighlightJsHighlighter {
+
+    static int called = 0
+
+    @Override
+    boolean hasDocInfo(LocationType location) {
+        location == LocationType.FOOTER
+    }
+
+    @Override
+    String format(Block node, String lang, Map<String, Object> opts) {
+        called++
+        super.format(node, lang, opts)
     }
 }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Fix the upstream build

How does it achieve that?

The test for simulating the HighlightJS syntax highlighter in Java/Groovy was failing due to changes in the Ruby original.
This PR changes the test to simulate both behaviours and expect one of them.

