### PR TITLE
Fixes #942. When an Asciidoctor instance is created with a classloade…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Bug Fixes::
+
+* When creating an AsciidoctorJ instance with classloader parameter, extensions are not discovered (@ahus1) (#942)
+
 == 2.4.0 (2020-07-19)
 
 Improvement::

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/converter/internal/ConverterRegistryExecutor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/converter/internal/ConverterRegistryExecutor.java
@@ -14,8 +14,12 @@ public class ConverterRegistryExecutor {
     }
 
     public void registerAllConverters() {
+        registerAllConverters(Thread.currentThread().getContextClassLoader());
+    }
+
+    public void registerAllConverters(ClassLoader classloader) {
         ServiceLoader<ConverterRegistry> converterRegistryServiceLoader = ServiceLoader
-                .load(ConverterRegistry.class);
+                .load(ConverterRegistry.class, classloader);
 
         for (ConverterRegistry converterRegistry : converterRegistryServiceLoader) {
             converterRegistry.register(asciidoctor);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/internal/ExtensionRegistryExecutor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/internal/ExtensionRegistryExecutor.java
@@ -14,9 +14,13 @@ public class ExtensionRegistryExecutor {
     }
 
     public void registerAllExtensions() {
+        registerAllExtensions(Thread.currentThread().getContextClassLoader());
+    }
+
+    public void registerAllExtensions(ClassLoader classloader) {
         ServiceLoader<ExtensionRegistry> extensionRegistryServiceLoader = ServiceLoader
-                .load(ExtensionRegistry.class);
-        
+                .load(ExtensionRegistry.class, classloader);
+
         for (ExtensionRegistry extensionRegistry : extensionRegistryServiceLoader) {
             extensionRegistry.register(asciidoctor);
         }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -74,11 +74,15 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
     }
 
     public static JRubyAsciidoctor create(ClassLoader classloader) {
-        return processRegistrations(createJRubyAsciidoctorInstance(null, new ArrayList<>(), classloader));
+        return processRegistrations(
+                createJRubyAsciidoctorInstance(null, new ArrayList<>(), classloader),
+                classloader);
     }
 
     public static JRubyAsciidoctor create(ClassLoader classloader, String gemPath) {
-        return processRegistrations(createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), new ArrayList<>(), classloader));
+        return processRegistrations(
+                createJRubyAsciidoctorInstance(Collections.singletonMap(GEM_PATH, gemPath), new ArrayList<>(), classloader),
+                classloader);
     }
 
     public static JRubyAsciidoctor create(List<String> loadPaths, String gemPath) {
@@ -96,20 +100,47 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
         return asciidoctor;
     }
 
+    private static JRubyAsciidoctor processRegistrations(JRubyAsciidoctor asciidoctor, ClassLoader classloader) {
+        registerExtensions(asciidoctor, classloader);
+        registerConverters(asciidoctor, classloader);
+        registerSyntaxHighlighters(asciidoctor, classloader);
+        registerLogHandlers(asciidoctor, classloader);
+
+        JavaLogger.install(asciidoctor.getRubyRuntime(), asciidoctor);
+
+        return asciidoctor;
+    }
+
     private static void registerConverters(AsciidoctorJRuby asciidoctor) {
         new ConverterRegistryExecutor(asciidoctor).registerAllConverters();
+    }
+
+    private static void registerConverters(AsciidoctorJRuby asciidoctor, ClassLoader classloader) {
+        new ConverterRegistryExecutor(asciidoctor).registerAllConverters(classloader);
     }
 
     private static void registerExtensions(AsciidoctorJRuby asciidoctor) {
         new ExtensionRegistryExecutor(asciidoctor).registerAllExtensions();
     }
 
+    private static void registerExtensions(AsciidoctorJRuby asciidoctor, ClassLoader classloader) {
+        new ExtensionRegistryExecutor(asciidoctor).registerAllExtensions(classloader);
+    }
+
     private static void registerSyntaxHighlighters(AsciidoctorJRuby asciidoctor) {
         new SyntaxHighlighterRegistryExecutor(asciidoctor).registerAllSyntaxHighlighter();
     }
 
+    private static void registerSyntaxHighlighters(AsciidoctorJRuby asciidoctor, ClassLoader classloader) {
+        new SyntaxHighlighterRegistryExecutor(asciidoctor).registerAllSyntaxHighlighter(classloader);
+    }
+
     private static void registerLogHandlers(AsciidoctorJRuby asciidoctor) {
         new LogHandlerRegistryExecutor(asciidoctor).registerAllLogHandlers();
+    }
+
+    private static void registerLogHandlers(AsciidoctorJRuby asciidoctor, ClassLoader classloader) {
+        new LogHandlerRegistryExecutor(asciidoctor).registerAllLogHandlers(classloader);
     }
 
     private static JRubyAsciidoctor createJRubyAsciidoctorInstance(Map<String, String> environmentVars, List<String> loadPaths, ClassLoader classloader) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/LogHandlerRegistryExecutor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/LogHandlerRegistryExecutor.java
@@ -6,8 +6,6 @@ import org.asciidoctor.log.LogHandler;
 import java.util.ServiceLoader;
 
 public class LogHandlerRegistryExecutor {
-    private static ServiceLoader<LogHandler> logHandlerServiceLoader = ServiceLoader
-        .load(LogHandler.class);
 
     private AsciidoctorJRuby asciidoctor;
 
@@ -16,6 +14,13 @@ public class LogHandlerRegistryExecutor {
     }
 
     public void registerAllLogHandlers() {
+        registerAllLogHandlers(Thread.currentThread().getContextClassLoader());
+    }
+
+    public void registerAllLogHandlers(ClassLoader classloader) {
+        ServiceLoader<LogHandler> logHandlerServiceLoader = ServiceLoader
+                .load(LogHandler.class, classloader);
+
         for (LogHandler logHandler: logHandlerServiceLoader) {
             asciidoctor.registerLogHandler(logHandler);
         }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/syntaxhighlighter/internal/SyntaxHighlighterRegistryExecutor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/syntaxhighlighter/internal/SyntaxHighlighterRegistryExecutor.java
@@ -15,9 +15,13 @@ public class SyntaxHighlighterRegistryExecutor {
     }
 
     public void registerAllSyntaxHighlighter() {
+        registerAllSyntaxHighlighter(Thread.currentThread().getContextClassLoader());
+    }
+
+    public void registerAllSyntaxHighlighter(ClassLoader classLoader) {
         ServiceLoader<SyntaxHighlighterRegistry> serviceLoader = ServiceLoader
-                .load(SyntaxHighlighterRegistry.class);
-        
+                .load(SyntaxHighlighterRegistry.class, classLoader);
+
         for (SyntaxHighlighterRegistry extensionRegistry : serviceLoader) {
             extensionRegistry.register(asciidoctor);
         }


### PR DESCRIPTION
…r parameter, use this classloader also to autoregister extensions, converters, syntax highlighters and loggers.

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

When an Asciidoctor instance is created with AsciidoctorJRuby.create(ClassLoader), the given classloader should not also be used to let JRuby find the Asciidoctor gem, but also to auto register extensions etc.

Are there any alternative ways to implement this?

Possibly.

Are there any implications of this pull request? Anything a user must know?

Yes!
This should be thoroughly tested in the different environments like the gradle plugin, maven plugin and Osgi, as all of these environments might behave differently wrt class loading.


## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #942


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc