### PR TITLE
Fix NPE when a document contains an empty table

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Bug Fixes::
+
+  * Fix NullPointerException when a document contains an empty table with PDF backend (#944)
+
 == 2.4.0 (2020-07-19)
 
 Improvement::

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/JavaLogger.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/JavaLogger.java
@@ -205,7 +205,9 @@ public class JavaLogger extends RubyObject {
     if (getRuntime().getHash().equals(msg.getType())) {
       final RubyHash hash = (RubyHash) msg;
       final Object sourceLocation = hash.get(getRuntime().newSymbol(LOG_PROPERTY_SOURCE_LOCATION));
-      return new CursorImpl((IRubyObject) sourceLocation);
+      if (sourceLocation != null) {
+        return new CursorImpl((IRubyObject) sourceLocation);
+      }
     }
     return null;
   }

--- a/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
+++ b/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
@@ -83,4 +83,13 @@ public class WhenBackendIsPdf {
         outputFile1.delete();
     }
 
+    @Test
+    public void pdf_should_not_fail_with_empty_tables() {
+        String filename = "empty-table";
+        File inputFile = this.classpath.getResource(filename + ".adoc");
+        File outputFile1 = new File(inputFile.getParentFile(), filename + ".pdf");
+
+        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.SAFE).get());
+        assertThat(outputFile1.exists(), is(true));
+    }
 }

--- a/asciidoctorj-distribution/src/test/resources/empty-table.adoc
+++ b/asciidoctorj-distribution/src/test/resources/empty-table.adoc
@@ -1,0 +1,5 @@
+=== Empty table
+
+[cols="2s,3", grid="none", frame="none"]
+|===
+|===


### PR DESCRIPTION
Fixes #944.

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

The goal of this pull request is to fix the issue #944 


When I convert the following asciidoctor file with Asciidoctorj 2.3 (or 2.4) and the pdf backend:

```asciidoctor
=== Empty table

|===
|===
```

Asciidoctorj fail with the following NullPointerException stacktrace:

```console
java.lang.NullPointerException
	at org.asciidoctor.jruby.internal.RubyObjectWrapper.<init>(RubyObjectWrapper.java:23)
	at org.asciidoctor.jruby.ast.impl.CursorImpl.<init>(CursorImpl.java:10)
	at org.asciidoctor.jruby.log.internal.JavaLogger.getSourceLocation(JavaLogger.java:209)
	at org.asciidoctor.jruby.log.internal.JavaLogger.log(JavaLogger.java:152)
	at org.asciidoctor.jruby.log.internal.JavaLogger.warn(JavaLogger.java:116)
	at org.asciidoctor.jruby.log.internal.JavaLogger$INVOKER$i$0$2$warn.call(JavaLogger$INVOKER$i$0$2$warn.gen)
	at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:204)
```

Instead, I expect Asciidoctorj to not to fail and to have no table in the rendered PDF (like in Asciidoctorj 2.2).

Are there any alternative ways to implement this?
Possibly! I have also to fix my code to not generate empty tables :)

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #944 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc