### PR TITLE
Fix upstream build

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Build::
+
+* Fix upstream build to adapt for changes to highlightjs syntax highlighter. (#954)
+
 == 2.4.1 (2020-09-10)
 
 Bug Fixes::

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsHighlighter.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsHighlighter.groovy
@@ -41,7 +41,7 @@ class NewHighlightJsHighlighter extends AbstractHighlightJsHighlighter {
 
     @Override
     String getDocinfo(LocationType location, Document document, Map<String, Object> options) {
-        String baseUrl = document.getAttribute('highlightjsdir', "${options['cdn_base_url']}/highlight.js/9.15.6")
+        String baseUrl = document.getAttribute('highlightjsdir', "${options['cdn_base_url']}/highlight.js/9.15.10")
         location == LocationType.HEADER ?
                 """<link rel="stylesheet" href="$baseUrl/styles/${document.getAttribute('highlightjs-theme', 'github')}.min.css"${options['self_closing_tag_slash']}>""" :
                 """<script src="$baseUrl/highlight.min.js"></script>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?
This PR fixes the upstream build which does not succeed anymore since the upstream version of highlights has changed.

How does it achieve that?
It's an intermediate step of updating the version number used by the test highlighter.

Are there any alternative ways to implement this?
Yes, as suggested in (#953) the version number should not be checked for exact equality.
Unfortunately I don't have the time right now, but still want to unblock the upstream built.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc