### PR TITLE
closes #953: make SyntaxHighlighter test independent from highlight.js version

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == 2.4.1 (2020-09-10)
 
+Build::
+
+* Make SyntaxHighlighter test independent of highlight.js version (@abelsromero) (#955)
+
 Bug Fixes::
 
   * Fix NullPointerException when a document contains an empty table with PDF backend (@anthonyroussel) (#944)

--- a/asciidoctor-gem-installer.pom
+++ b/asciidoctor-gem-installer.pom
@@ -18,7 +18,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>rubygems-releases</id>
-            <url>http://rubygems-proxy.torquebox.org/releases</url>
+            <url>https://rubygems-proxy.torquebox.org/releases</url>
         </pluginRepository>
     </pluginRepositories>
     <properties>
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>de.saumya.mojo</groupId>
                 <artifactId>gem-maven-plugin</artifactId>
-                <version>1.1.7</version>
+                <version>1.1.8</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsHighlighter.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsHighlighter.groovy
@@ -11,7 +11,7 @@ abstract class AbstractHighlightJsHighlighter implements SyntaxHighlighterAdapte
 
     @Override
     String getDocinfo(LocationType location, Document document, Map<String, Object> options) {
-        String baseUrl = document.getAttribute('highlightjsdir', "${options['cdn_base_url']}/highlight.js/9.15.6")
+        String baseUrl = document.getAttribute('highlightjsdir', "${options['cdn_base_url']}/highlight.js/9.15.5")
         """<link rel="stylesheet" href="$baseUrl/styles/${document.getAttribute('highlightjs-theme', 'github')}.min.css"${options['self_closing_tag_slash']}>
 <script src="$baseUrl/highlight.min.js"></script>
 <script>hljs.initHighlighting()</script>"""

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAHighlightjsAdapterIsImplementedInGroovy.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAHighlightjsAdapterIsImplementedInGroovy.groovy
@@ -9,8 +9,9 @@ import org.jboss.arquillian.test.api.ArquillianResource
 import org.junit.runner.RunWith
 import spock.lang.Specification
 
-import static junit.framework.Assert.assertEquals
+import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.either
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.is
 import static org.junit.Assert.assertThat
 
@@ -63,10 +64,17 @@ func main() {
                 .attributes(AttributesBuilder.attributes().sourceHighlighter(HIGHLIGHTJS)))
 
         then:
+        assertThat(htmlJavaOld, containsString('highlight.js/9.15.5'))
+        assertThat(htmlJavaNew, containsString('highlight.js/9.15.6'))
         // Cannot use `htmlRuby == htmlJava` because it fails with OOM
         // Asciidoctor > 2.0.10 changed the location where the javascript is included,
         // therefore test against both possibilities to pass with 2.0.10 and upstream
-        assertThat(htmlRuby, either(is(htmlJavaNew)).or(is(htmlJavaOld)))
+        assertThat(stripHighlightjsVersion(htmlRuby),
+                either(is(stripHighlightjsVersion(htmlJavaNew))).or(is(stripHighlightjsVersion(htmlJavaOld))))
+    }
+
+    private String stripHighlightjsVersion(String htmlRuby) {
+        htmlRuby.replaceAll('highlight\\.js/(\\d)+\\.(\\d)+\\.(\\d)+/', 'highlight\\.js/ma\\.min\\.fix/')
     }
 
     def 'should autoregister from extension'() {
@@ -78,6 +86,6 @@ func main() {
                 .attributes(AttributesBuilder.attributes().sourceHighlighter(HighlightJsExtension.NAME_HIGHLIGHTER)))
 
         then:
-        assertEquals(2, ObservableHighlightJsHighlighter.called)
+        assertThat(ObservableHighlightJsHighlighter.called, is(equalTo(2)))
     }
 }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Fix https://github.com/asciidoctor/asciidoctorj/issues/953 by making the test do not depend on Asciidoctor highlight.js version.

How does it achieve that?

Test each file against the version used in each SyntaxHighlighterAdapter, and then test against real Asciidoctor but striping the version numbers,

Are there any alternative ways to implement this?

Maybe test don't need to match agains a real Asciidoctor conversion?

Are there any implications of this pull request? Anything a user must know?

No.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc