### PR TITLE
Make highlight.js test independent of Asciidoctor Ruby highlight.js s…

### DIFF
--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsHighlighter.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/HighlightJsHighlighter.groovy
@@ -4,17 +4,19 @@ import org.asciidoctor.ast.Block
 import org.asciidoctor.ast.Document
 import org.asciidoctor.extension.LocationType
 
-abstract class AbstractHighlightJsHighlighter implements SyntaxHighlighterAdapter, Formatter {
+class HighlightJsHighlighter implements SyntaxHighlighterAdapter, Formatter {
 
-    @Override
-    abstract boolean hasDocInfo(LocationType location)
+    static DOCINFO_HEADER = '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">'
+    static DOCINFO_FOOTER = '''<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>'''
+
+    boolean hasDocInfo(LocationType location) {
+        true
+    }
 
     @Override
     String getDocinfo(LocationType location, Document document, Map<String, Object> options) {
-        String baseUrl = document.getAttribute('highlightjsdir', "${options['cdn_base_url']}/highlight.js/9.15.5")
-        """<link rel="stylesheet" href="$baseUrl/styles/${document.getAttribute('highlightjs-theme', 'github')}.min.css"${options['self_closing_tag_slash']}>
-<script src="$baseUrl/highlight.min.js"></script>
-<script>hljs.initHighlighting()</script>"""
+        location == LocationType.HEADER ? DOCINFO_HEADER : DOCINFO_FOOTER
     }
 
     @Override
@@ -23,41 +25,9 @@ abstract class AbstractHighlightJsHighlighter implements SyntaxHighlighterAdapte
     }
 }
 
-class OldHighlightJsHighlighter extends AbstractHighlightJsHighlighter {
-
-    @Override
-    boolean hasDocInfo(LocationType location) {
-        location == LocationType.FOOTER
-    }
-
-}
-
-class NewHighlightJsHighlighter extends AbstractHighlightJsHighlighter {
-
-    @Override
-    boolean hasDocInfo(LocationType location) {
-        true
-    }
-
-    @Override
-    String getDocinfo(LocationType location, Document document, Map<String, Object> options) {
-        String baseUrl = document.getAttribute('highlightjsdir', "${options['cdn_base_url']}/highlight.js/9.15.6")
-        location == LocationType.HEADER ?
-                """<link rel="stylesheet" href="$baseUrl/styles/${document.getAttribute('highlightjs-theme', 'github')}.min.css"${options['self_closing_tag_slash']}>""" :
-                """<script src="$baseUrl/highlight.min.js"></script>
-<script>hljs.initHighlighting()</script>"""
-    }
-
-}
-
-class ObservableHighlightJsHighlighter extends AbstractHighlightJsHighlighter {
+class ObservableHighlightJsHighlighter extends HighlightJsHighlighter {
 
     static int called = 0
-
-    @Override
-    boolean hasDocInfo(LocationType location) {
-        location == LocationType.FOOTER
-    }
 
     @Override
     String format(Block node, String lang, Map<String, Object> opts) {


### PR DESCRIPTION
…yntax highlighter.

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?
Make the Highlight.js syntax highlighter test independent of changes to the highlight.js syntax highlighter in Asciidoctor.

How does it achieve that?
Instead of comparing the result to the original Ruby implementation, the test now only checks that the relevant docinfo is in the result, and a block has been highlighted by adding the corresponding classes.

Are there any alternative ways to implement this?
The alternative is to maintain 2 versions of the Syntax highlighter, one for the current released version, and one for the upstream version of Asciidoctor.
However this is brittle and breaks with every change to Asciidoctor upstream.

Are there any implications of this pull request? Anything a user must know?
No.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc