### PR TITLE
Generate docs when associated Java source is changed

### DIFF
--- a/asciidoctorj-documentation/build.gradle
+++ b/asciidoctorj-documentation/build.gradle
@@ -11,6 +11,8 @@ dependencies {
 }
 
 task processAsciidocFiles(type: Copy) {
+    inputs.files fileTree(dir: 'src')
+    outputs.files fileTree(dir: rootProject.file('docs'), include: '*.adoc')
 
     dependsOn test
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

Please see #963

## Issue

Fixes #963 

## Release notes

I don't think this deserves a  CHANGELOG entry, but lemme know.