### PR TITLE
AST now provides access to document catalog footnotes and refs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Improvement::
+
+* AST now provides access to footnotes (@lread) (TBD)
+
 == 2.4.1 (2020-09-10)
 
 Build::

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 Improvement::
 
-* AST now provides access to footnotes (@lread) (TBD)
+* AST now provides access to document catalog footnotes and refs (@lread) (#968)
 
 == 2.4.1 (2020-09-10)
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Catalog.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Catalog.java
@@ -1,0 +1,18 @@
+package org.asciidoctor.ast;
+
+import java.util.List;
+
+/**
+ * The asciidoctor catalog contains data collected by asciidoctor that is useful to a converter.
+ * The catalog is considered an internal structure by asciidoctor, and subject to change.
+ */
+public interface Catalog {
+
+    /**
+     * Note that asciidoctor does not populate footnotes until after the
+     * Document's content has been converted.
+     *
+     * @return footnotes occurring in document.
+     */
+    List<Footnote> getFootnotes();
+}

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Catalog.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Catalog.java
@@ -2,15 +2,11 @@ package org.asciidoctor.ast;
 
 import java.util.List;
 
-/**
- * The asciidoctor catalog contains data collected by asciidoctor that is useful to a converter.
- * The catalog is considered an internal structure by asciidoctor, and subject to change.
- */
+
 public interface Catalog {
 
     /**
-     * Note that asciidoctor does not populate footnotes until after the
-     * Document's content has been converted.
+     * Note that footnotes are only available after `Document.getContent()` has been called.
      *
      * @return footnotes occurring in document.
      */

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Catalog.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Catalog.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.ast;
 
 import java.util.List;
+import java.util.Map;
 
 
 public interface Catalog {
@@ -8,7 +9,24 @@ public interface Catalog {
     /**
      * Note that footnotes are only available after `Document.getContent()` has been called.
      *
+     * A converter uses cataloged footnotes to render them, presumably, at the bottom of a document.
+     *
      * @return footnotes occurring in document.
      */
     List<Footnote> getFootnotes();
+
+    /**
+     * Refs is a map of asciidoctor ids to asciidoctor document elements.
+     *
+     * For example, by default, each section is automatically assigned an id.
+     * In this case the id would map to a {@link Section} element.
+     *
+     * Ids can also be explicitly assigned by document authors to any document element.
+     * See https://asciidoctor.org/docs/user-manual/#id
+     *
+     * A converter might use cataloged refs to lookup ids to support rendering inline anchors.
+     *
+     * @return a map of ids to elements that asciidoctor has collected from the document.
+     */
+    Map<String, Object> getRefs();
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
@@ -75,4 +75,7 @@ public interface Document extends StructuralNode {
      * @param state The state in which to put the sourcemap (true = on, false = off).
      */
     void setSourcemap(boolean state);
+
+
+    Catalog getCatalog();
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
@@ -77,5 +77,12 @@ public interface Document extends StructuralNode {
     void setSourcemap(boolean state);
 
 
+    /**
+     * The catalog contains data collected by asciidoctor that is useful to a converter.
+     *
+     * Note that the catalog is not part of the asciidoctor public API and is subject to change.
+     *
+     * @return catalog
+     */
     Catalog getCatalog();
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Footnote.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Footnote.java
@@ -1,0 +1,10 @@
+package org.asciidoctor.ast;
+
+public interface Footnote {
+
+   Long getIndex();
+
+   String getId();
+
+   String getText();
+}

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Footnote.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Footnote.java
@@ -2,9 +2,24 @@ package org.asciidoctor.ast;
 
 public interface Footnote {
 
+   /**
+    * The index is the number asciidoctor has assigned to the footnote.
+    * Footnotes start at 1 and are numbered consecutively throughout the document.
+    *
+    * @return footnote number
+    */
    Long getIndex();
 
+   /**
+    * Each footnote can optionally have an id.
+    * Ids are used when a document author wants to reference a single footnote more than once.
+    *
+    * @return footnote id or null
+    */
    String getId();
 
+   /**
+    * @return the text the document author has specified for the footnote
+    */
    String getText();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/CatalogImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/CatalogImpl.java
@@ -2,10 +2,13 @@ package org.asciidoctor.jruby.ast.impl;
 
 import org.asciidoctor.ast.Catalog;
 import org.asciidoctor.ast.Footnote;
+import org.asciidoctor.jruby.internal.RubyHashMapDecorator;
 import org.jruby.RubyArray;
+import org.jruby.RubyHash;
 import org.jruby.RubyStruct;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -25,5 +28,11 @@ public class CatalogImpl implements Catalog  {
             footnotes.add(FootnoteImpl.getInstance((RubyStruct) f));
         }
         return footnotes;
+    }
+
+    @Override
+    public Map<String, Object> getRefs() {
+        Map <String,Object> refs = new RubyHashMapDecorator((RubyHash) catalog.get("refs"), String.class);
+        return Collections.unmodifiableMap(refs);
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/CatalogImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/CatalogImpl.java
@@ -1,0 +1,29 @@
+package org.asciidoctor.jruby.ast.impl;
+
+import org.asciidoctor.ast.Catalog;
+import org.asciidoctor.ast.Footnote;
+import org.jruby.RubyArray;
+import org.jruby.RubyStruct;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CatalogImpl implements Catalog  {
+
+    private final Map<String, Object> catalog;
+
+    public CatalogImpl(Map<String, Object> catalog) {
+        this.catalog = catalog;
+    }
+
+    @Override
+    public List<Footnote> getFootnotes() {
+        RubyArray<?> rubyFootnotes = (RubyArray<?>) catalog.get("footnotes");
+        List<Footnote> footnotes = new ArrayList<>();
+        for (Object f : rubyFootnotes) {
+            footnotes.add(FootnoteImpl.getInstance((RubyStruct) f));
+        }
+        return footnotes;
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentImpl.java
@@ -2,8 +2,10 @@ package org.asciidoctor.jruby.ast.impl;
 
 import java.util.Map;
 
+import org.asciidoctor.ast.Catalog;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Title;
+import org.asciidoctor.jruby.internal.RubyHashMapDecorator;
 import org.asciidoctor.jruby.internal.RubyHashUtil;
 import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
@@ -75,5 +77,10 @@ public class DocumentImpl extends StructuralNodeImpl implements Document {
     @Override
     public void setSourcemap(boolean state) {
         setBoolean("sourcemap", state);
+    }
+
+    @Override
+    public Catalog getCatalog() {
+        return new CatalogImpl(new RubyHashMapDecorator((RubyHash) getProperty("catalog")));
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/FootnoteImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/FootnoteImpl.java
@@ -16,7 +16,7 @@ public class FootnoteImpl implements Footnote {
     private String text;
 
     private static Object aref(RubyStruct s, String key)  {
-       return JavaEmbedUtils.rubyToJava(s.aref(JavaEmbedUtils.javaToRuby(s.getRuntime(), key)));
+       return JavaEmbedUtils.rubyToJava(s.aref(s.getRuntime().newString(key)));
     }
 
     public static Footnote getInstance(Long index, String id, String text)  {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/FootnoteImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/FootnoteImpl.java
@@ -1,0 +1,45 @@
+package org.asciidoctor.jruby.ast.impl;
+
+import org.jruby.RubyStruct;
+
+import org.asciidoctor.ast.Footnote;
+import org.jruby.javasupport.JavaEmbedUtils;
+
+public class FootnoteImpl implements Footnote {
+
+    private static final String INDEX_KEY_NAME = "index";
+    private static final String ID_KEY_NAME = "id";
+    private static final String TEXT_KEY_NAME = "text";
+
+    private Long index;
+    private String id;
+    private String text;
+
+    private static Object aref(RubyStruct s, String key)  {
+       return JavaEmbedUtils.rubyToJava(s.aref(JavaEmbedUtils.javaToRuby(s.getRuntime(), key)));
+    }
+
+    public static Footnote getInstance(Long index, String id, String text)  {
+        FootnoteImpl footnote = new FootnoteImpl();
+        footnote.index = index;
+        footnote.id = id;
+        footnote.text = text;
+        return footnote;
+    }
+
+    public static Footnote getInstance(RubyStruct rubyFootnote) {
+        return FootnoteImpl.getInstance(
+                (Long) aref(rubyFootnote, INDEX_KEY_NAME),
+                (String) aref(rubyFootnote, ID_KEY_NAME),
+                (String) aref(rubyFootnote, TEXT_KEY_NAME));
+    }
+
+    @Override
+    public Long getIndex() { return index; }
+
+    @Override
+    public String getId() { return id; }
+
+    @Override
+    public String getText() { return text; }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyHashMapDecorator.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyHashMapDecorator.java
@@ -46,9 +46,9 @@ public class RubyHashMapDecorator implements Map<String, Object> {
         this.rubyKeyType = rubyKeyType;
     }
 
-    private Object coerceKey(Object key) {
+    private Object coerceKey(String key) {
         if (rubyKeyType == RubySymbol.class) {
-            return rubyHash.getRuntime().getSymbolTable().getSymbol((String) key);
+            return rubyHash.getRuntime().getSymbolTable().getSymbol(key);
         }
         return key;
     }
@@ -68,7 +68,7 @@ public class RubyHashMapDecorator implements Map<String, Object> {
         if (!(key instanceof String)) {
             return false;
         }
-        return rubyHash.containsKey(coerceKey(key));
+        return rubyHash.containsKey(coerceKey((String) key));
     }
 
     @Override
@@ -81,7 +81,7 @@ public class RubyHashMapDecorator implements Map<String, Object> {
         if (!(key instanceof String)) {
             return false;
         }
-        Object value = rubyHash.get(coerceKey(key));
+        Object value = rubyHash.get(coerceKey((String) key));
         return convertRubyValue(value);
     }
 
@@ -98,7 +98,7 @@ public class RubyHashMapDecorator implements Map<String, Object> {
             return null;
         }
         Object oldValue = get(key);
-        rubyHash.remove(coerceKey(key));
+        rubyHash.remove(coerceKey((String) key));
         return convertRubyValue(oldValue);
     }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/CatalogOfRefsAreAvailable.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/CatalogOfRefsAreAvailable.groovy
@@ -1,0 +1,171 @@
+package org.asciidoctor.converter
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.ast.ContentNode
+import org.asciidoctor.ast.Document
+import org.asciidoctor.ast.StructuralNode
+import org.hamcrest.BaseMatcher
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+import static org.hamcrest.Matchers.contains
+import static org.hamcrest.Matchers.containsInAnyOrder
+import static org.hamcrest.Matchers.empty
+import static org.junit.Assert.assertThat
+
+/**
+ * Tests that refs can be accessed from converter.
+ */
+@RunWith(ArquillianSputnik)
+class CatalogOfRefsAreAvailable extends Specification {
+    static final String CONVERTER_BACKEND = 'refs'
+    static final String NODE_NAME_SECTION = 'section'
+    static final String NODE_NAME_PARAGRAPH = 'paragraph'
+    static final String NODE_NAME_ULIST = 'ulist'
+    static final String NODE_NAME_INLINE_ANCHOR = 'inline_anchor'
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+    private static Map<String,Object> refs
+
+    static class Converter extends StringConverter {
+        Converter(String backend, Map<String, Object> opts) {
+            super(backend, opts)
+        }
+
+        /*
+         * For this conversion test we do not care about the conversion result,
+         * we simply want to to verify that refs are available and as expected.
+         */
+        @Override
+        String convert(ContentNode node, String transform, Map<Object, Object> opts) {
+            if (node instanceof Document) {
+                def doc = (Document) node
+                refs = doc.catalog.refs
+            }
+            else if (node instanceof StructuralNode) {
+                ((StructuralNode) node).content
+            }
+        }
+    }
+
+    def setup() {
+        refs = null
+        asciidoctor.javaConverterRegistry().register(Converter, CONVERTER_BACKEND)
+    }
+
+    def convert(String document) {
+        asciidoctor.convert(document, OptionsBuilder.options().backend(CONVERTER_BACKEND))
+    }
+
+    def 'when there are no refs in source doc, refs should be empty'() {
+        given:
+        String document = 'no refs here'
+
+        when:
+        convert(document)
+
+        then:
+        assertThat(refs.entrySet(), empty())
+    }
+
+    def 'when a ref is is in source doc, it should be accessible from converter'() {
+        given:
+        def idSectionA = '_a_section'
+        String document = '== A Section'
+
+        when:
+        convert(document)
+
+        then:
+        assertThat(refs.keySet(), contains(idSectionA))
+        assertThat(refs, hasIdPointingToNodeNamed(idSectionA, NODE_NAME_SECTION))
+    }
+
+    def 'when refs are in source doc, they should be accessible from the converter'() {
+        given:
+        def idSectionA = '_section_a'
+        def idSectionB = 'override-section-b'
+        def idSectionC = 'section-c-primary'
+        def idPara1 = 'para1'
+        def idPara2 = 'para2'
+        def idInline = 'inlineref'
+        def idList = 'list'
+        def idInList = 'in-list'
+        String document = """
+This document has a variety of ref ids.
+
+== Section A
+
+A section, by default, is assigned an id.
+
+[[${idSectionB},Override default section id]]
+== Section B
+
+== Section C[[section-c2]][[section-c3]] [[${idSectionC}]]
+
+Section C heading has multiple anchors, note that the secondary
+anchors do not seem to show up in refs.
+
+[[${idPara1}]]
+My paragraph
+
+[#${idPara2}]
+Shorthand syntax
+
+An [#${idInline}]*quoted text*
+
+[[${idList},some ref text]]
+* item1
+* [[${idInList}]] item2
+* item3
+
+// This ref will be excluded as it points to nothing
+[[reftonada]]
+"""
+        when:
+        convert(document)
+
+        then:
+        assertThat(refs.keySet(), containsInAnyOrder(idSectionA, idSectionB, idSectionC,
+                idPara1, idPara2, idList, idInList))
+        assertThat(refs, hasIdPointingToNodeNamed(idSectionA, NODE_NAME_SECTION))
+        assertThat(refs, hasIdPointingToNodeNamed(idSectionB, NODE_NAME_SECTION))
+        assertThat(refs, hasIdPointingToNodeNamed(idSectionC, NODE_NAME_SECTION))
+        assertThat(refs, hasIdPointingToNodeNamed(idPara1, NODE_NAME_PARAGRAPH))
+        assertThat(refs, hasIdPointingToNodeNamed(idPara2, NODE_NAME_PARAGRAPH))
+        assertThat(refs, hasIdPointingToNodeNamed(idList, NODE_NAME_ULIST))
+        assertThat(refs, hasIdPointingToNodeNamed(idInList, NODE_NAME_INLINE_ANCHOR))
+    }
+
+    private hasIdPointingToNodeNamed(final id, final expectedNodeName) {
+        [
+            matches: { refs ->
+                if (refs.get(id)) {
+                    refs.get(id).nodeName == expectedNodeName
+                }
+            },
+            describeTo: { description ->
+                description.appendText('ref id ')
+                        .appendValue(id)
+                        .appendText(' pointing to node named ')
+                        .appendValue(expectedNodeName)
+            },
+            describeMismatch: { refs, description ->
+                if (!refs.get(id)) {
+                    description.appendText('did not find id ')
+                            .appendValue(id)
+                            .appendText(' in refs')
+                } else {
+                    description.appendText('instead found id pointing to ')
+                            .appendValue(refs.get(id).nodeName)
+                }
+            }
+        ] as BaseMatcher<Map<String, Object>>
+    }
+
+
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/WhenFootnotesAreUsed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/WhenFootnotesAreUsed.groovy
@@ -1,0 +1,115 @@
+package org.asciidoctor.converter
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.ast.ContentNode
+import org.asciidoctor.ast.Document
+import org.asciidoctor.ast.Footnote
+import org.asciidoctor.ast.StructuralNode
+import org.asciidoctor.jruby.ast.impl.FootnoteImpl
+import org.jboss.arquillian.spock.ArquillianSputnik
+import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+import static org.hamcrest.Matchers.contains
+import static org.hamcrest.Matchers.empty
+import static org.hamcrest.Matchers.samePropertyValuesAs
+import static org.junit.Assert.assertThat
+
+/**
+ * Tests that footnotes can be accessed from converter.
+ *
+ * Note that it is a current limitation of asciidoctor that footnotes are not available until
+ * after they have been converted for the document.
+ */
+@RunWith(ArquillianSputnik)
+class WhenFootnotesAreUsed extends Specification {
+
+    @ArquillianResource
+    private Asciidoctor asciidoctor
+    private static List<Footnote> footnotesBeforeConvert
+    private static List<Footnote> footnotesAfterConvert
+
+    static class Converter extends StringConverter {
+        Converter(String backend, Map<String, Object> opts) {
+            super(backend, opts)
+        }
+
+        /*
+         * For this conversion test we do not care about the conversion result,
+         * we simply want to force the conversion to verify that footnotes
+         * are populated.
+         */
+        @Override
+        String convert(ContentNode node, String transform, Map<Object, Object> opts) {
+            if (node instanceof Document) {
+                def doc = (Document) node
+                footnotesBeforeConvert = doc.catalog.footnotes.collect()
+                doc.content
+                footnotesAfterConvert = doc.catalog.footnotes.collect()
+            }
+            else if (node instanceof StructuralNode) {
+                ((StructuralNode) node).content
+            }
+        }
+    }
+
+    def setup() {
+        footnotesBeforeConvert = null
+        footnotesAfterConvert = null
+        asciidoctor.javaConverterRegistry().register(Converter, 'footnote')
+    }
+
+    def convert(String document) {
+        asciidoctor.convert(document, OptionsBuilder.options().backend("footnote"))
+    }
+
+    def footnote(Long index, String id, String text) {
+        FootnoteImpl.getInstance(index, id, text)
+    }
+
+    def 'when there are no footnotes in source doc, footnotes should be empty'() {
+        given:
+        String document = 'no footnotes here'
+
+        when:
+        convert(document)
+
+        then:
+        assertThat(footnotesBeforeConvert, empty())
+        assertThat(footnotesAfterConvert, empty())
+    }
+
+    def 'when a footnote is is in source doc, it should be accessible from converter'() {
+        given:
+        String document = 'Do footnotes work?footnote:fid[we shall find out!]'
+
+        when:
+        convert(document)
+
+        then:
+        assertThat(footnotesBeforeConvert, empty())
+        assertThat(footnotesAfterConvert,
+                contains(samePropertyValuesAs(footnote(1,"fid","we shall find out!"))))
+    }
+
+    def 'when footnotes are in source doc, they should be accessible from the converter'() {
+        given:
+        String document = '''
+This document has a variety of footnotes.
+
+Ids can be assigned to footnotes.footnote:myid1[first footnote]
+Footnotes can also be id-less.footnote:[second footnote]
+An existing footnote can be referenced.footnote:myid1[]
+'''
+        when:
+        convert(document)
+
+        then:
+        assertThat(footnotesBeforeConvert, empty())
+        assertThat(footnotesAfterConvert,
+                contains(samePropertyValuesAs(footnote(1,"myid1","first footnote")),
+                         samePropertyValuesAs(footnote(2, null, "second footnote"))))
+    }
+}

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/WhenFootnotesAreUsed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/WhenFootnotesAreUsed.groovy
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThat
  */
 @RunWith(ArquillianSputnik)
 class WhenFootnotesAreUsed extends Specification {
+    static final String CONVERTER_BACKEND = 'footnote'
 
     @ArquillianResource
     private Asciidoctor asciidoctor
@@ -58,11 +59,11 @@ class WhenFootnotesAreUsed extends Specification {
     def setup() {
         footnotesBeforeConvert = null
         footnotesAfterConvert = null
-        asciidoctor.javaConverterRegistry().register(Converter, 'footnote')
+        asciidoctor.javaConverterRegistry().register(Converter, CONVERTER_BACKEND)
     }
 
     def convert(String document) {
-        asciidoctor.convert(document, OptionsBuilder.options().backend("footnote"))
+        asciidoctor.convert(document, OptionsBuilder.options().backend(CONVERTER_BACKEND))
     }
 
     def footnote(Long index, String id, String text) {
@@ -91,7 +92,7 @@ class WhenFootnotesAreUsed extends Specification {
         then:
         assertThat(footnotesBeforeConvert, empty())
         assertThat(footnotesAfterConvert,
-                contains(samePropertyValuesAs(footnote(1,"fid","we shall find out!"))))
+                contains(samePropertyValuesAs(footnote(1,'fid','we shall find out!'))))
     }
 
     def 'when footnotes are in source doc, they should be accessible from the converter'() {
@@ -109,7 +110,7 @@ An existing footnote can be referenced.footnote:myid1[]
         then:
         assertThat(footnotesBeforeConvert, empty())
         assertThat(footnotesAfterConvert,
-                contains(samePropertyValuesAs(footnote(1,"myid1","first footnote")),
-                         samePropertyValuesAs(footnote(2, null, "second footnote"))))
+                contains(samePropertyValuesAs(footnote(1,'myid1','first footnote')),
+                         samePropertyValuesAs(footnote(2, null, 'second footnote'))))
     }
 }

--- a/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
+++ b/asciidoctorj-documentation/src/main/asciidoc/integrator-guide.adoc
@@ -1253,6 +1253,18 @@ It is also possible to provide converters for binary formats.
 In this case the converter should extend the generic class `org.asciidoctor.converter.AbstractConverter<T>` where `T` is the return type of the method `convert()`.
 `StringConverter` is actually a concrete subclass for the type `String`.
 
+Asciidoctor makes some useful information available to the converter via the catalog.
+The catalog is exposed in AsciidoctorJ under the `Document` via `getCatalog()` and offers :
+
+- `getFootnotes()` - returns a list of footnotes that occur in the document.
+Footnotes are available after `Document` `getContent()` has been called.
+A converter will typically use this data to render footnotes at the bottom of a document.
+- `getRefs()` - returns a map of ids to document elements.
+Ids are used as a document element target reference 1) to link to and/or 2) for styling, for example by CSS.
+By default, ids are automatically generated and assigned to sections.
+They can also be explicitly assigned by the document author to any document element.
+A converter will typically use this data to lookup ids in support of rendering inline anchors.
+
 == Logs handling API
 
 [NOTE]

--- a/docs/integrator-guide.adoc
+++ b/docs/integrator-guide.adoc
@@ -1764,6 +1764,18 @@ It is also possible to provide converters for binary formats.
 In this case the converter should extend the generic class `org.asciidoctor.converter.AbstractConverter<T>` where `T` is the return type of the method `convert()`.
 `StringConverter` is actually a concrete subclass for the type `String`.
 
+Asciidoctor makes some useful information available to the converter via the catalog.
+The catalog is exposed in AsciidoctorJ under the `Document` via `getCatalog()` and offers :
+
+- `getFootnotes()` - returns a list of footnotes that occur in the document.
+Footnotes are available after `Document` `getContent()` has been called.
+A converter will typically use this data to render footnotes at the bottom of a document.
+- `getRefs()` - returns a map of ids to document elements.
+Ids are used as a document element target reference 1) to link to and/or 2) for styling, for example by CSS.
+By default, ids are automatically generated and assigned to sections.
+They can also be explicitly assigned by the document author to any document element.
+A converter will typically use this data to lookup ids in support of rendering inline anchors.
+
 == Logs handling API
 
 [NOTE]


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

Adds AST access to document footnotes and refs so that a converter may refer to them.

Access is provided under `Document` via:

- `getCatalog()`
     - `getFootnotes()`
     - `getRefs()`

## Issue

Fixes #958

## Release notes

CHANGELOG has been updated accordingly.