### PR TITLE
Add test case with inlineMacro with substitutions

### DIFF
--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/SayMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/SayMacro.java
@@ -1,0 +1,27 @@
+package org.asciidoctor.extension;
+
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.StructuralNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SayMacro extends InlineMacroProcessor {
+
+    public SayMacro(String macroName) {
+        super(macroName);
+    }
+
+    public SayMacro(String macroName, Map<String, Object> config) {
+        super(macroName, config);
+    }
+
+    @Override
+    public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+        String text = "*" + target + "*";
+        Map<String, Object> phraseNodeAttributes = new HashMap<>();
+        phraseNodeAttributes.put("subs", ":normal");
+        return createPhraseNode(parent, "quoted", text, phraseNodeAttributes);
+    }
+
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -741,6 +741,28 @@ public class WhenJavaExtensionIsRegistered {
     }
 
     @Test
+    public void an_inline_macro_with_subs_should_be_executed_when_an_inline_macro_is_detected() {
+
+        JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();
+
+        javaExtensionRegistry.inlineMacro("say", "org.asciidoctor.extension.SayMacro");
+
+        String adoc = "Hello say:word[]!";
+        String content = asciidoctor.convert(adoc,
+                options().toFile(false));
+
+        org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
+        Element p = doc.getElementsByTag("p").first();
+        assertThat(p, notNullValue());
+        Element strong = p.getElementsByTag("strong").first();
+        assertThat(strong, notNullValue());
+        assertThat(strong.text(), is("word"));
+
+        final List<LogRecord> logRecords = TestLogHandlerService.getLogRecords();
+        assertThat(logRecords, hasSize(0));
+    }
+
+    @Test
     public void should_unregister_all_current_registered_extensions() throws IOException {
 
         JavaExtensionRegistry javaExtensionRegistry = this.asciidoctor.javaExtensionRegistry();


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement
- [x] Additional test case


## Description

If you want that to apply the substitutions in an Inline macro, you need to use following attribute:

* `key`: `"subs"`
* `value`: `":normal"`

See this [StackOverflow question](https://stackoverflow.com/questions/65017746/how-to-have-the-returned-inline-being-formatted-in-an-asciidoctorj-inlinemacropr) and the related discussion with @mojavelinux on [twitter](https://twitter.com/mojavelinux/status/1331935753593491456).

This PR adds a test case to ensure this approach is working (as guaranty there will be no regression in the future).

This correspond to this reference test in the ruby asciidoctor project:
https://github.com/asciidoctor/asciidoctor/blob/master/test/extensions_test.rb#L1415-L1431

On the long term, some convenience could be added to the attribute builder to set substitutions.
