### PR TITLE
Release 2.4.3

### DIFF
--- a/.github/workflows/upstream-build.yaml
+++ b/.github/workflows/upstream-build.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
-          ref: ${{ github.event.client_payload.branch }} 
+          ref: ${{ github.event.client_payload.branch }}
       - uses: actions/setup-java@v1
         with:
           java-version: '1.8'

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,8 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/master[
 
 == Unreleased
 
+== 2.4.3 (2021-02-12)
+
 Improvement::
 
 * Upgrade to asciidoctorj-pdf 1.5.4 (#986)
@@ -25,6 +27,7 @@ Improvement::
 Build Improvement::
 
 * Publish directly to Maven Central (#988)
+* Upgrade Gradle to 6.8.2 (#988)
 
 == 2.4.2 (2020-11-10)
 

--- a/asciidoctorj-api/build.gradle
+++ b/asciidoctorj-api/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'biz.aQute.bnd.builder'
-apply plugin: 'de.marcphilipp.nexus-publish'
 
 dependencies {
   compileOnly "org.osgi:osgi.annotation:$osgiVersion"
@@ -17,9 +16,3 @@ ext.publicationName = "mavenAsciidoctorJApi"
 
 apply from: rootProject.file('gradle/publish.gradle')
 apply from: rootProject.file('gradle/signing.gradle')
-
-publishing {
-  publications.findByName(project.ext.publicationName).each {
-    it.from(components.java)
-  }
-}

--- a/asciidoctorj-arquillian-extension/build.gradle
+++ b/asciidoctorj-arquillian-extension/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'de.marcphilipp.nexus-publish'
-
 dependencies {
   compileOnly project(':asciidoctorj')
   compile project(':asciidoctorj-test-support')
@@ -20,9 +18,3 @@ project.ext.publicationName = "mavenAsciidoctorJArquillianExtension"
 
 apply from: rootProject.file('gradle/publish.gradle')
 apply from: rootProject.file('gradle/signing.gradle')
-
-publishing {
-  publications.findByName(project.ext.publicationName).each {
-    it.from(rootProject.project('asciidoctorj-arquillian-extension').components.java)
-  }
-}

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -2,6 +2,11 @@ apply plugin: 'java'
 apply plugin: 'groovy'
 apply plugin: 'biz.aQute.bnd.builder'
 
+project.ext.publicationName = "mavenAsciidoctorJ"
+
+apply from: rootProject.file('gradle/publish.gradle')
+apply from: rootProject.file('gradle/signing.gradle')
+
 dependencies {
   compile project(path: ':asciidoctorj-api')
   compile "org.jruby:jruby:$jrubyVersion"
@@ -120,14 +125,5 @@ task pollutedTest(type: Test) {
 
 test.dependsOn pollutedTest
 
-project.ext.publicationName = "mavenAsciidoctorJ"
 
-apply from: rootProject.file('gradle/publish.gradle')
-apply from: rootProject.file('gradle/signing.gradle')
-
-publishing {
-  publications.findByName(project.ext.publicationName).each {
-    it.from(components.java)
-  }
-}
 

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'application'
 
-if (project.statusIsRelease) {
+if (project.statusIsRelease && project.hasProperty("sdkman_consumer_key")) {
     apply from: rootProject.file('gradle/sdkman.gradle')
 }
 

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -57,9 +57,13 @@ startScripts {
 }
 
 project.ext.publicationName = "mavenAsciidoctorJ"
-
-publishing {
-  publications.findByName(project.ext.publicationName).each {
-    it.artifact(distZip)
-  }
+// This module wants to add an artifact to the publication configured for the module asciidoctorj
+// I am unaware right now how to enforce the configuration order, so it could theoretically happen that
+// the publication is not available yet. In that case fail the build and find some other way to fix it...
+def publication = rootProject.project('asciidoctorj').extensions.findByName('publishing').publications.findByName(project.ext.publicationName)
+if (!publication) {
+  throw new ProjectConfigurationException("Publication ${project.ext.publicationName} not configured yet", [])
+}
+publication.each {
+    it.artifact distZip
 }

--- a/asciidoctorj-test-support/build.gradle
+++ b/asciidoctorj-test-support/build.gradle
@@ -10,3 +10,8 @@ def junitURL = "https://junit.org/junit4/javadoc/latest"
 javadoc {
     options.links(javaApiUrl, junitURL)
 }
+
+ext.publicationName = "mavenAsciidoctorJTestSupport"
+
+apply from: rootProject.file('gradle/publish.gradle')
+apply from: rootProject.file('gradle/signing.gradle')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.4.3
+version=2.4.4-SNAPSHOT
 sourceCompatibility=1.8
 targetCompatibility=1.8
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.4.3-SNAPSHOT
+version=2.4.3
 sourceCompatibility=1.8
 targetCompatibility=1.8
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,15 +1,18 @@
-nexusPublishing {
-    repositories {
-        sonatype()
-    }
-}
+apply plugin: 'de.marcphilipp.nexus-publish'
 
 publishing {
     publications.create(project.ext.publicationName, MavenPublication) {
+
+        from components.java
+
         pom {
             name = project.name
             description = project.description
             url = 'https://github.com/asciidoctor/asciidoctorj'
+
+            scm {
+                url = 'https://github.com/asciidoctor/asciidoctorj'
+            }
 
             licenses {
                 license {
@@ -78,6 +81,12 @@ publishing {
             def snapshotsRepoUrl = "${rootProject.buildDir}/repos/snapshots"
             url = version.endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
         }
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype()
     }
 }
 


### PR DESCRIPTION
This PR hopefully completely fixes the publishing to Maven Central.
With these changes I have published AsciidoctorJ 2.4.3 to a staging repository, that means it is not really published yet, but can be tested by everyone first.

To use this version add the following repository to your Maven config (every publish gets its own repo):
```xml
    <repositories>
        <repository>
            <id>staging</id>
            <url>https://oss.sonatype.org/content/repositories/orgasciidoctor-1240</url>
            <releases>
                <enabled>true</enabled>
            </releases>
        </repository>
    </repositories>
```

Before merging it would be great if somebody else could also check this. 

One point where I need help is in asciidoctorj-distribution/build.gradle.
In that file the build has to add the result of the distZip task to the publication configured in the asciidoctorj module.
Right now I don't know if the configuration order is random and it just works accidentally. However I added at least some check so that the build should fail if the zip cannot be added to the publication.
That said, I wonder though if we maybe should switch to publishing distributions to Github releases

To stage a release simple run 
```
./gradlew publishToSonatype -i
```
After that you should find an open staging repository at https://oss.sonatype.org/#stagingRepositories.

The repository can be closed after the push with 
```
./gradlew closeRepository -i
```
Finally, if everything is fine it should be possible to release this to Maven central with 
```
./gradlew releaseRepository -i
```

The following properties should be set, for example in ~/.gradle/gradle.properties:
```
# Settings required for signing the artifacts
signing.keyId=***
signing.password=***
signing.secretKeyRingFile=***

# Settings required for publishing to sdkman
sdkman_consumer_key=***
sdkman_consumer_token=***

# Settings required for publishing to sonatype
sonatypeUsername=***
sonatypePassword=***
```

I'll update the README with a release description once everybody is fine with this.
