### PR TITLE
Upgrade OSGi plugin biz.aQute.bnd to 5.2.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,8 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/master[
 
 Build Improvement::
 
-* Fix URL for distribution in sdkman
+* Fix URL for distribution in sdkman (#990)
+* Update gradle plugin biz.aQute.bnd to 5.2.0 (#991)
 
 == 2.4.3 (2021-02-12)
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@
 */
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -15,7 +14,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.io.sdkman:gradle-sdkvendor-plugin:1.1.0"
-        classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:4.3.0"
+        classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:5.2.0"
     }
 }
 


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [X] Build improvement

## Description

What is the goal of this pull request?

Upgrade the gradle plugin to create the OSGi manifests to the latest version 5.2.0 and get rid of the last dependency on jcenter.

How does it achieve that?

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc