### PR TITLE
Exclude test relying on Nashorn from Java 15+

### DIFF
--- a/asciidoctorj-documentation/build.gradle
+++ b/asciidoctorj-documentation/build.gradle
@@ -12,6 +12,16 @@ dependencies {
     }
 }
 
+compileTestJava {
+    // PrismJsHighlighterTest relies on Nashorn which is not supported anymore since Java 15
+    // Either include it as an external library and configure the module path accordingly as it must be included via the module path
+    // to run, or just exclude the test entirely. We're doing the latter, it's just a test.
+    def javaMajorVersion = Integer.parseInt(System.getProperty('java.version').split("[.]")[0])
+    if (javaMajorVersion >= 15) {
+        exclude('**/PrismJsHighlighter*.java')
+    }
+}
+
 task copyBaseExamplesToDocs(type: Copy) {
     group = 'documentation'
 


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

One of the tests relies on Nashorn, which is not supported anymore with Java 15+.
This PR fixes that.

How does it achieve that?

It entirely excludes the test from compilation.

Are there any alternative ways to implement this?

Include Nashorn as an external dependency and use it on the module path.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc