### PR TITLE
Chocolatey: Upgrade packaging to 2.4.3.

### DIFF
--- a/chocolatey/asciidoctorj.nuspec
+++ b/chocolatey/asciidoctorj.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>asciidoctorj</id>
     <title>AsciidoctorJ (Install)</title>
-    <version>2.4.2</version>
+    <version>2.4.3</version>
     <!--
       https://github.com/asciidoctor/asciidoctorj/graphs/contributors
       https://github.com/asciidoctor/asciidoctor/graphs/contributors
@@ -16,8 +16,8 @@
     <description>Java wrapper and bindings for the Asciidoctor markup processor.
     Converts AsciiDoc to HTML5, EPUB3, PDF, DocBook, and other formats. To use, run
     "asciidoctorj" along with any Asciidoctor command line flags, e.g. "asciidoctorj
-    -b pdf mydocument.adoc". Requires a Java runtime such as jre8, corretto8jre, or
-    adoptopenjdk8jre.
+    -b pdf mydocument.adoc". You MUST install a Java runtime such as jre8, corretto8jre, or
+    adoptopenjdk8jre yourself. This package doesn't presume to choose for you.
     </description>
     <projectUrl>http://asciidoctor.org/</projectUrl>
     <packageSourceUrl>https://github.com/geraldcombs/chocolatey-packages</packageSourceUrl>

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -4,12 +4,10 @@
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
 
-$adocjVersion = '2.4.2'
-$packageName= 'asciidoctorj' # arbitrary name for the package, used in messages
-$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-# Which is the preferred mirror? There are many listed at
-# http://www.apache.org/dyn/closer.cgi/xmlgraphics/fop
-$url        = "https://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/$($adocjVersion)/asciidoctorj-$($adocjVersion)-bin.zip" # download url
+$adocjVersion = '2.4.3'
+$packageName  = 'asciidoctorj' # arbitrary name for the package, used in messages
+$toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url          = "https://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/$($adocjVersion)/asciidoctorj-$($adocjVersion)-bin.zip"
 #$url64      = '' # 64bit URL here or remove - if installer is both, use $url
 #$fileLocation = Join-Path $toolsDir 'NAME_OF_EMBEDDED_INSTALLER_FILE'
 #$fileLocation = Join-Path $toolsDir 'SHARE_LOCATION_OF_INSTALLER_FILE'
@@ -18,7 +16,7 @@ $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   url           = $url
-  checksum      = '3b5cb8d3a31aa88b3152f4a6983d4f56b3f3fda913328ffa4e3d451aba5697ea'
+  checksum      = '3f51281ac38a13cf277215dc14381de4a035862e5d99bbbbf1f0cd6216403a2b'
   checksumType  = 'sha256' #default is md5, can also be sha1
   #checksum64    = ''
   #checksumType64= 'md5' #default is checksumType
@@ -28,5 +26,7 @@ $packageArgs = @{
 ## see https://github.com/chocolatey/choco/wiki/HelpersReference
 
 Install-ChocolateyZipPackage @packageArgs
+
+# XXX Check for java.exe
 
 Install-BinFile -name 'asciidoctorj' -path "$toolsDir\asciidoctorj-$($adocjVersion)\bin\asciidoctorj.bat"


### PR DESCRIPTION
Switch the download URL to search.maven.org.

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

Upgrade the Chocolatey packaging to 2.4.3, including switching the download URL to Maven Central.