### PR TITLE
Run Wildfly IT with Java16

### DIFF
--- a/asciidoctorj-wildfly-integration-test/build.gradle
+++ b/asciidoctorj-wildfly-integration-test/build.gradle
@@ -1,10 +1,15 @@
 jar.enabled = false
 
 ext {
-    arquillianVersion = '1.1.13.Final'
-    arquillianWildflyVersion = '2.1.1.Final'
+    arquillianVersion = '1.6.0.Final'
+    arquillianWildflyVersion = '3.0.1.Final'
 
     wildflyVersion = '23.0.0.Final'
+}
+
+repositories {
+    // Required by arquillian
+    maven { url "https://maven.repository.redhat.com/ga/" }
 }
 
 configurations {
@@ -23,7 +28,7 @@ dependencies {
     jbossmodule "org.jruby:jruby-complete:$jrubyVersion"
 
     jbossdist group: 'org.wildfly', name: 'wildfly-dist', version: wildflyVersion, ext: 'zip'
-    
+
     testImplementation "javax:javaee-api:7.0"
     testCompileOnly project(':asciidoctorj')
     testImplementation "junit:junit:$junitVersion"
@@ -85,9 +90,7 @@ test {
     systemProperty('jboss.home', jbossHome)
     systemProperty('module.path', jbossHome + "/modules" + File.pathSeparator + file('build/modules').absolutePath)
 
-    if (JavaVersion.current() == JavaVersion.VERSION_16) {
-        systemProperty('arquillian.launch', 'wildfly-java16')
-    } else if (JavaVersion.current().isJava11Compatible()) {
+    if (JavaVersion.current().isJava11Compatible()) {
         systemProperty('arquillian.launch', 'wildfly-java11')
     }
 
@@ -95,12 +98,7 @@ test {
     dependsOn createModule
     dependsOn unpackWildfly
     dependsOn configurations.jbossmodule
-
-    onlyIf {
-        JavaVersion.current() != JavaVersion.VERSION_16
-    }
 }
-
 
 
 configurations.all {

--- a/asciidoctorj-wildfly-integration-test/src/test/resources/arquillian.xml
+++ b/asciidoctorj-wildfly-integration-test/src/test/resources/arquillian.xml
@@ -29,14 +29,4 @@
     </configuration>
   </container>
 
-  <container qualifier="wildfly-java16">
-    <configuration>
-      <property name="jbossHome">${jboss.home}</property>
-      <!--<property name="javaVmArguments">-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005</property> -->
-      <property name="javaVmArguments">--add-modules java.se,java.security</property>
-      <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
-      <property name="jbossArguments">${jboss.args:}</property>
-    </configuration>
-  </container>
-
 </arquillian>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?
Run `asciidoctorj-wildfly-integration-test` with Java16

How does it achieve that?
The fix only requires upgrading dependencies to latests
```
    arquillianVersion = '1.6.0.Final'
    arquillianWildflyVersion = '3.0.1.Final'
```
And addind the repo `https://maven.repository.redhat.com/ga/`, without it, build fails unable to collect certan specific dependencies.

Are there any alternative ways to implement this?
Tried different version to see if the extra maven repo could be removed without much luck. A part form that, not much alternatives to test.

Are there any implications of this pull request? Anything a user must know?
No

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1000  


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc