### PR TITLE
Expose author as class from Document

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@ Improvement::
 * Allow defining `@Name` as a meta annotation on Block and Inline Macros (@uniqueck) (#898)
 * Upgrade to jruby 9.2.17.0 (#1004)
 * Upgrade to asciidoctorj-diagram 2.1.2 (#1004)
+* Add getAuthors method to Document (#1007)
 
 Build Improvement::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.ast;
 
+import java.util.List;
 import java.util.Map;
 
 public interface Document extends StructuralNode {
@@ -23,6 +24,14 @@ public interface Document extends StructuralNode {
      */
     @Deprecated
     String doctitle();
+
+    /**
+     * Gets the author(s) information as defined in the author line
+     * in the document header, or in author & email attributes.
+     *
+     * @return authors information
+     */
+    List<Author> getAuthors();
 
     /**
      * @return basebackend attribute value

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/AuthorImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/AuthorImpl.java
@@ -1,19 +1,17 @@
 package org.asciidoctor.jruby.ast.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.asciidoctor.ast.Author;
+import org.jruby.RubyStruct;
+import org.jruby.javasupport.JavaEmbedUtils;
 
 public class AuthorImpl implements Author {
 
-    private static final String AUTHOR_ATTRIBUTE_NAME = "author";
-    private static final String LASTNAME_ATTRIBUTE_NAME = "lastname";
-    private static final String FIRST_NAME_ATTRIBUTE_NAME = "firstname";
-    private static final String EMAIL_ATTRIBUTE_NAME = "email";
-    private static final String INITIALS_ATTRIBUTE_NAME = "authorinitials";
-    private static final String MIDDLE_NAME_ATTRIBUTE_NAME = "middlename";
+    private static final String AUTHOR_KEY_NAME = "name";
+    private static final String LASTNAME_KEY_NAME = "lastname";
+    private static final String FIRST_NAME_KEY_NAME = "firstname";
+    private static final String EMAIL_KEY_NAME = "email";
+    private static final String INITIALS_KEY_NAME = "initials";
+    private static final String MIDDLE_NAME_KEY_NAME = "middlename";
 
     private String fullName;
     private String lastName;
@@ -22,61 +20,19 @@ public class AuthorImpl implements Author {
     private String email;
     private String initials;
 
-    public static Author getInstance(Map<String, Object> attributes) {
-        return getAuthor(attributes, "");
-    }
-
-    public static List<Author> getAuthors(Map<String, Object> attributes) {
-
-        List<Author> authors = new ArrayList<Author>();
-
-        boolean noMoreAuthors = false;
-
-        int suffix = 1;
-
-        while (!noMoreAuthors) {
-
-            if (attributes.containsKey(AUTHOR_ATTRIBUTE_NAME + "_" + suffix)) {
-                authors.add(getAuthor(attributes, "_" + suffix));
-                suffix++;
-            } else {
-                noMoreAuthors = true;
-            }
-
-        }
-
-        return authors;
-
-    }
-
-    private static Author getAuthor(Map<String, Object> attributes, String suffix) {
-        AuthorImpl author = new AuthorImpl();
-
-        if (attributes.containsKey(AUTHOR_ATTRIBUTE_NAME + suffix)) {
-            author.setFullName((String) attributes.get(AUTHOR_ATTRIBUTE_NAME + suffix));
-        }
-
-        if (attributes.containsKey(LASTNAME_ATTRIBUTE_NAME + suffix)) {
-            author.setLastName((String) attributes.get(LASTNAME_ATTRIBUTE_NAME + suffix));
-        }
-
-        if (attributes.containsKey(FIRST_NAME_ATTRIBUTE_NAME + suffix)) {
-            author.setFirstName((String) attributes.get(FIRST_NAME_ATTRIBUTE_NAME + suffix));
-        }
-
-        if (attributes.containsKey(MIDDLE_NAME_ATTRIBUTE_NAME + suffix)) {
-            author.setMiddleName((String) attributes.get(MIDDLE_NAME_ATTRIBUTE_NAME) + suffix);
-        }
-
-        if (attributes.containsKey(EMAIL_ATTRIBUTE_NAME + suffix)) {
-            author.setEmail((String) attributes.get(EMAIL_ATTRIBUTE_NAME + suffix));
-        }
-
-        if (attributes.containsKey(INITIALS_ATTRIBUTE_NAME + suffix)) {
-            author.setInitials((String) attributes.get(INITIALS_ATTRIBUTE_NAME + suffix));
-        }
-
+    public static Author getInstance(RubyStruct authorStruct) {
+        final AuthorImpl author = new AuthorImpl();
+        author.setFullName(aref(authorStruct, AUTHOR_KEY_NAME));
+        author.setFirstName(aref(authorStruct, FIRST_NAME_KEY_NAME));
+        author.setMiddleName(aref(authorStruct, MIDDLE_NAME_KEY_NAME));
+        author.setLastName(aref(authorStruct, LASTNAME_KEY_NAME));
+        author.setInitials(aref(authorStruct, INITIALS_KEY_NAME));
+        author.setEmail(aref(authorStruct, EMAIL_KEY_NAME));
         return author;
+    }
+
+    private static String aref(RubyStruct s, String key) {
+        return (String) JavaEmbedUtils.rubyToJava(s.aref(s.getRuntime().newString(key)));
     }
 
     public String getFullName() {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentHeaderImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentHeaderImpl.java
@@ -1,21 +1,19 @@
 package org.asciidoctor.jruby.ast.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.asciidoctor.ast.Author;
 import org.asciidoctor.ast.DocumentHeader;
 import org.asciidoctor.ast.RevisionInfo;
 import org.asciidoctor.ast.Title;
 import org.asciidoctor.jruby.internal.CaseInsensitiveMap;
 
+import java.util.List;
+import java.util.Map;
+
 public class DocumentHeaderImpl implements DocumentHeader {
 
     private Title documentTitle;
     private String pageTitle;
-    private Author author;
-    private List<Author> authors = new ArrayList<Author>();
+    private List<Author> authors;
     private RevisionInfo revisionInfo;
 
     private Map<String, Object> attributes;
@@ -37,7 +35,7 @@ public class DocumentHeaderImpl implements DocumentHeader {
     }
 
     public Author getAuthor() {
-        return author;
+        return authors == null || authors.size() == 0 ? null : authors.get(0);
     }
 
     public RevisionInfo getRevisionInfo() {
@@ -49,27 +47,17 @@ public class DocumentHeaderImpl implements DocumentHeader {
     }
 
     public static DocumentHeaderImpl createDocumentHeader(Title documentTitle, String pageTitle,
-            Map<String, Object> attributes) {
+                                                          List<Author> authors, Map<String, Object> attributes) {
 
         DocumentHeaderImpl documentHeader = new DocumentHeaderImpl();
 
         documentHeader.documentTitle = documentTitle;
         documentHeader.pageTitle = pageTitle;
-        documentHeader.attributes = new CaseInsensitiveMap<String, Object>(attributes);
-
-        documentHeader.author = getAuthor(attributes);
+        documentHeader.attributes = new CaseInsensitiveMap<>(attributes);
+        documentHeader.authors = authors;
         documentHeader.revisionInfo = getRevisionInfo(attributes);
-        documentHeader.authors.addAll(getAuthors(attributes));
 
         return documentHeader;
-    }
-
-    private static List<Author> getAuthors(Map<String, Object> attributes) {
-        return AuthorImpl.getAuthors(attributes);
-    }
-
-    private static Author getAuthor(Map<String, Object> attributes) {
-        return AuthorImpl.getInstance(attributes);
     }
 
     private static RevisionInfo getRevisionInfo(Map<String, Object> attributes) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentImpl.java
@@ -1,17 +1,17 @@
 package org.asciidoctor.jruby.ast.impl;
 
-import java.util.Map;
-
+import org.asciidoctor.ast.Author;
 import org.asciidoctor.ast.Catalog;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Title;
 import org.asciidoctor.jruby.internal.RubyHashMapDecorator;
 import org.asciidoctor.jruby.internal.RubyHashUtil;
-import org.jruby.Ruby;
-import org.jruby.RubyBoolean;
-import org.jruby.RubyHash;
-import org.jruby.RubySymbol;
+import org.jruby.*;
 import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class DocumentImpl extends StructuralNodeImpl implements Document {
 
@@ -57,6 +57,14 @@ public class DocumentImpl extends StructuralNodeImpl implements Document {
     @Deprecated
     public String doctitle() {
         return getDoctitle();
+    }
+
+    @Override
+    public List<Author> getAuthors() {
+        return getList("authors", RubyStruct.class)
+                .stream()
+                .map(AuthorImpl::getInstance)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -11,6 +11,7 @@ import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.jruby.AsciidoctorJRuby;
 import org.asciidoctor.jruby.DirectoryWalker;
+import org.asciidoctor.jruby.ast.impl.AuthorImpl;
 import org.asciidoctor.jruby.ast.impl.DocumentHeaderImpl;
 import org.asciidoctor.jruby.ast.impl.NodeConverter;
 import org.asciidoctor.jruby.converter.internal.ConverterRegistryExecutor;
@@ -168,7 +169,8 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
         return DocumentHeaderImpl.createDocumentHeader(
                 documentImpl.getStructuredDoctitle(),
                 documentImpl.getDoctitle(),
-                documentImpl.getAttributes());
+                documentImpl.getAuthors(),
+                document.getAttributes());
     }
 
     @SuppressWarnings("unchecked")

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
@@ -1,6 +1,7 @@
 package org.asciidoctor;
 
 import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.ast.Author;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Section;
 import org.asciidoctor.ast.StructuralNode;
@@ -18,18 +19,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.either;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+
 
 @RunWith(Arquillian.class)
-public class WhenAsciiDocIsRenderedToDocument {
+public class WhenAsciiDocIsLoadedToDocument {
 
     private static final String DOCUMENT = "= Document Title\n" +
             "\n" +
@@ -70,7 +70,7 @@ public class WhenAsciiDocIsRenderedToDocument {
 
     @Test
     public void should_return_section_blocks() {
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         Section section = (Section) document.getBlocks().get(1);
         assertThat(section.getIndex(), is(0));
         assertThat(section.getSectionName(), either(is("sect1")).or(is("section")));
@@ -80,7 +80,7 @@ public class WhenAsciiDocIsRenderedToDocument {
     @Test
     public void should_return_blocks_from_a_document() {
 
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.getDoctitle(), is("Document Title"));
 
     }
@@ -88,20 +88,20 @@ public class WhenAsciiDocIsRenderedToDocument {
     @Test
     public void should_return_a_document_object_from_string() {
 
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.getDoctitle(), is("Document Title"));
     }
 
     @Test
     public void should_find_elements_from_document() {
 
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         Map<Object, Object> selector = new HashMap<Object, Object>();
         selector.put("context", ":image");
         List<StructuralNode> findBy = document.findBy(selector);
         assertThat(findBy, hasSize(2));
 
-        assertThat((String)findBy.get(0).getAttributes().get("target"), is("tiger.png"));
+        assertThat((String) findBy.get(0).getAttributes().get("target"), is("tiger.png"));
         assertThat(findBy.get(0).getLevel(), greaterThan(0));
 
     }
@@ -118,27 +118,27 @@ public class WhenAsciiDocIsRenderedToDocument {
 
     @Test
     public void should_return_node_name() {
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.getNodeName(), is("document"));
     }
 
     @Test
     public void should_return_if_it_is_inline() {
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.isInline(), is(false));
     }
 
     @Test
     public void should_return_if_it_is_block() {
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.isBlock(), is(true));
     }
 
     @Test
     public void should_be_able_to_manipulate_attributes() {
         Map<String, Object> options = OptionsBuilder.options()
-                                                    .attributes(AttributesBuilder.attributes().dataUri(true))
-                                                    .compact(true).asMap();
+                .attributes(AttributesBuilder.attributes().dataUri(true))
+                .compact(true).asMap();
         Document document = asciidoctor.load(DOCUMENT, options);
         assertThat(document.getAttributes(), hasKey("toc-placement"));
         assertThat(document.hasAttribute("toc-placement"), is(true));
@@ -148,7 +148,7 @@ public class WhenAsciiDocIsRenderedToDocument {
 
     @Test
     public void should_be_able_to_get_roles() {
-        Document document = asciidoctor.load(ROLE, new HashMap<String, Object>());
+        Document document = asciidoctor.load(ROLE, new HashMap<>());
         StructuralNode abstractBlock = document.getBlocks().get(0);
         assertThat(abstractBlock.getRole(), is("famous"));
         assertThat(abstractBlock.hasRole("famous"), is(true));
@@ -159,7 +159,7 @@ public class WhenAsciiDocIsRenderedToDocument {
     @Test
     public void should_be_able_to_add_role() {
         final String tmpRole = "tmpRole";
-        Document document = asciidoctor.load(ROLE, new HashMap<String, Object>());
+        Document document = asciidoctor.load(ROLE, new HashMap<>());
         StructuralNode abstractBlock = document.getBlocks().get(0);
         assertThat(abstractBlock.hasRole(tmpRole), is(false));
         abstractBlock.addRole(tmpRole);
@@ -169,7 +169,7 @@ public class WhenAsciiDocIsRenderedToDocument {
     @Test
     public void should_be_able_to_remove_role() {
         final String famousRole = "famous";
-        Document document = asciidoctor.load(ROLE, new HashMap<String, Object>());
+        Document document = asciidoctor.load(ROLE, new HashMap<>());
         StructuralNode abstractBlock = document.getBlocks().get(0);
         assertThat(abstractBlock.hasRole(famousRole), is(true));
         abstractBlock.removeRole(famousRole);
@@ -178,7 +178,7 @@ public class WhenAsciiDocIsRenderedToDocument {
 
     @Test
     public void should_be_able_to_get_reftext() {
-        Document document = asciidoctor.load(REFTEXT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(REFTEXT, new HashMap<>());
         StructuralNode abstractBlock = document.getBlocks().get(0);
         assertThat(abstractBlock.getReftext(), is("the first section"));
         assertThat(abstractBlock.isReftext(), is(true));
@@ -200,15 +200,15 @@ public class WhenAsciiDocIsRenderedToDocument {
                 .compact(true).asMap();
         Document document = asciidoctor.load(DOCUMENT, options);
         assertThat(document.iconUri("note"),
-            either(
-                is("data:image/png:base64,") // <= Asciidoctor 1.5.5
-            )
-                .or(is("data:image/png;base64,"))); // >= Asciidoctor 1.5.6
+                either(
+                        is("data:image/png:base64,") // <= Asciidoctor 1.5.5
+                )
+                        .or(is("data:image/png;base64,"))); // >= Asciidoctor 1.5.6
     }
 
     @Test
     public void should_be_able_to_get_media_uri() {
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.mediaUri("target"), is("target"));
     }
 
@@ -224,7 +224,7 @@ public class WhenAsciiDocIsRenderedToDocument {
 
     @Test
     public void should_be_able_to_normalize_web_path() {
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.normalizeWebPath("target", null, true), is("target"));
     }
 
@@ -243,7 +243,7 @@ public class WhenAsciiDocIsRenderedToDocument {
     public void should_be_able_to_set_attribute() {
         final Object attributeName = "testattribute";
         final Object attributeValue = "testvalue";
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.setAttribute(attributeName, attributeValue, true), is(true));
         assertThat(document.getAttribute(attributeName), is(attributeValue));
         assertThat(document.getAttributes().get(attributeName), is(attributeValue));
@@ -253,7 +253,7 @@ public class WhenAsciiDocIsRenderedToDocument {
     public void should_be_able_to_set_attribute_on_attributes_map() {
         final String attributeName = "testattribute";
         final Object attributeValue = "testvalue";
-        Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
+        Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         document.getAttributes().put(attributeName, attributeValue);
         assertThat(document.getAttribute(attributeName), is(attributeValue));
         assertThat(document.getAttributes().get(attributeName), is(attributeValue));
@@ -288,16 +288,16 @@ public class WhenAsciiDocIsRenderedToDocument {
     public void should_get_attributes() {
 
         final String documentWithAttributes = "= Document Title\n" +
-            ":docattr: docvalue\n" +
-            "\n" +
-            "preamble\n" +
-            "\n" +
-            "== Section A\n" +
-            "\n" +
-            "paragraph\n" +
-            "\n";
+                ":docattr: docvalue\n" +
+                "\n" +
+                "preamble\n" +
+                "\n" +
+                "== Section A\n" +
+                "\n" +
+                "paragraph\n" +
+                "\n";
 
-        Document document = asciidoctor.load(documentWithAttributes, new HashMap<String, Object>());
+        Document document = asciidoctor.load(documentWithAttributes, new HashMap<>());
         List<StructuralNode> blocks = document.getBlocks();
 
         Section section = (Section) blocks.get(1);
@@ -316,19 +316,19 @@ public class WhenAsciiDocIsRenderedToDocument {
 
     @Test
     public void should_get_content_model() {
-    	final String documentWithPreambleAndSection = ""
-    			+ "= Document Title\n"
-    			+ "\n"
-    			+ "A test document with a preamble and a section.\n"
-    			+ "\n"
-    			+ "The preamble contains multiple paragraphs to force the outer block to be compound.\n"
-    			+ "\n"
-    			+ "== First Section\n"
-    			+ "\n"
-    			+ "And herein lies the problem.\n"
-    			+ "\n";
+        final String documentWithPreambleAndSection = ""
+                + "= Document Title\n"
+                + "\n"
+                + "A test document with a preamble and a section.\n"
+                + "\n"
+                + "The preamble contains multiple paragraphs to force the outer block to be compound.\n"
+                + "\n"
+                + "== First Section\n"
+                + "\n"
+                + "And herein lies the problem.\n"
+                + "\n";
 
-        Document document = asciidoctor.load(documentWithPreambleAndSection, new HashMap<String, Object>());
+        Document document = asciidoctor.load(documentWithPreambleAndSection, new HashMap<>());
         List<StructuralNode> blocks = document.getBlocks();
 
         StructuralNode preambleContainer = blocks.get(0);
@@ -345,26 +345,109 @@ public class WhenAsciiDocIsRenderedToDocument {
     @Test
     public void should_be_able_to_get_parent_from_document() {
         String s = "== A small Example\n" +
-            "\n" +
-            "Lorem ipsum dolor sit amet:\n";
+                "\n" +
+                "Lorem ipsum dolor sit amet:\n";
 
-        Document document = asciidoctor.load(s, new HashMap<String, Object>());
-        assertNull(document.getParent());
+        Document document = asciidoctor.load(s, new HashMap<>());
+        assertThat(document.getParent(), nullValue());
     }
 
     @Test
     public void should_read_caption() {
-        String s = "[caption=\"Table A. \"]\n" + 
-                ".A formal table\n" + 
-                "|===\n" + 
-                "|Cell in column 1, row 1\n" + 
-                "|Cell in column 2, row 1\n" + 
+        String s = "[caption=\"Table A. \"]\n" +
+                ".A formal table\n" +
+                "|===\n" +
+                "|Cell in column 1, row 1\n" +
+                "|Cell in column 2, row 1\n" +
                 "|===";
 
-        Document document = asciidoctor.load(s, new HashMap<String, Object>());
-        assertNotNull(document.getBlocks());
+        Document document = asciidoctor.load(s, new HashMap<>());
+        assertThat(document.getBlocks(), notNullValue());
         assertThat(document.getBlocks().size(), is(1));
         assertThat(document.getBlocks().get(0).getCaption(), is("Table A. "));
     }
 
+    @Test
+    public void should_get_empty_collection_when_no_author_is_set() {
+        String content = "= Sample Document\n" +
+                "\n" +
+                "Preamble...";
+
+        Document document = asciidoctor.load(content, emptyMap());
+
+        List<Author> authors = document.getAuthors();
+        assertThat(authors, hasSize(0));
+    }
+
+    @Test
+    public void should_get_single_author_when_only_one_is_set_in_author_line() {
+        String content = "= Sample Document\n" +
+                "Doc Writer <doc.writer@asciidoc.org>" +
+                "\n" +
+                "Preamble...";
+
+        Document document = asciidoctor.load(content, emptyMap());
+
+        List<Author> authors = document.getAuthors();
+        assertThat(authors, hasSize(1));
+
+        Author author = authors.get(0);
+        assertThat(author.getEmail(), is("doc.writer@asciidoc.org"));
+        assertThat(author.getFullName(), is("Doc Writer"));
+        assertThat(author.getFirstName(), is("Doc"));
+        assertThat(author.getMiddleName(), nullValue());
+        assertThat(author.getLastName(), is("Writer"));
+        assertThat(author.getInitials(), is("DW"));
+    }
+
+    @Test
+    public void should_get_single_author_when_only_one_is_set_in_attribute() {
+        String content = "= Sample Document\n" +
+                ":author: Doc Writer\n" +
+                ":email: doc.writer@asciidoc.org\n" +
+                "\n" +
+                "Preamble...";
+
+        Document document = asciidoctor.load(content, emptyMap());
+
+        List<Author> authors = document.getAuthors();
+        assertThat(authors, hasSize(1));
+
+        Author author = authors.get(0);
+        assertThat(author.getEmail(), is("doc.writer@asciidoc.org"));
+        assertThat(author.getFullName(), is("Doc Writer"));
+        assertThat(author.getFirstName(), is("Doc"));
+        assertThat(author.getMiddleName(), nullValue());
+        assertThat(author.getLastName(), is("Writer"));
+        assertThat(author.getInitials(), is("DW"));
+    }
+
+    @Test
+    public void should_get_multiple_authors_when_they_arez_set_in_author_line() {
+        String content = "= Sample Document\n" +
+                "Doc Writer <doc.writer@asciidoc.org>; John A. Smith <john.smith@asciidoc.org>\n" +
+                "\n" +
+                "Preamble...";
+
+        Document document = asciidoctor.load(content, emptyMap());
+
+        List<Author> authors = document.getAuthors();
+        assertThat(authors, hasSize(2));
+
+        Author firstAuthor = authors.get(0);
+        assertThat(firstAuthor.getEmail(), is("doc.writer@asciidoc.org"));
+        assertThat(firstAuthor.getFullName(), is("Doc Writer"));
+        assertThat(firstAuthor.getFirstName(), is("Doc"));
+        assertThat(firstAuthor.getMiddleName(), nullValue());
+        assertThat(firstAuthor.getLastName(), is("Writer"));
+        assertThat(firstAuthor.getInitials(), is("DW"));
+
+        Author secondAuthor = authors.get(1);
+        assertThat(secondAuthor.getEmail(), is("john.smith@asciidoc.org"));
+        assertThat(secondAuthor.getFullName(), is("John A. Smith"));
+        assertThat(secondAuthor.getFirstName(), is("John"));
+        assertThat(secondAuthor.getMiddleName(), is("A."));
+        assertThat(secondAuthor.getLastName(), is("Smith"));
+        assertThat(secondAuthor.getInitials(), is("JAS"));
+    }
 }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Expose authors information through `Author` class from Document instance.
This allows to easily obtain such information without having to parse author, and email attributes.
Full discussion https://github.com/asciidoctor/asciidoctorj/issues/970.

How does it achieve that?

Adds `List<Author> getAuthors()` to Document interface and DocumentImpl implementation.
In order to avoid internals, this implementation does not use attributes but uses the `authors` property and `Author` struct of the Ruby implementation. This allows for simple code since it's not necessary to reimplement the attributes parsing logic in Ruby.
Additionally it helped to spot a couple of issues in the current code.

Are there any alternative ways to implement this?

The information could be achieved using attrributes. To show this, the PR contains intermediate commits with that approach, later refactored. It shows the code is larger, duplicates Ruby code and requires access to an undocumented attribute `authorcount` (or higher complexity parsing author and email attributes).

Are there any implications of this pull request? Anything a user must know?

No, code keeps compatibility with current `DocumentHeader` usage.
I decided not to deprecate because it contains revision information with is currently not available in Document. I'll open an issue to discuss.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 
Fixes #970

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc