### PR TITLE
Expose RevisionInfo from Document interface

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@ Improvement::
 * Upgrade to jruby 9.2.17.0 (#1004)
 * Upgrade to asciidoctorj-diagram 2.1.2 (#1004)
 * Add getAuthors method to Document (#1007)
+* Add getRevisionInfo method to Document. Make `DocumentHeader` class and `readDocumentHeader` methods as deprecated (#1008)
 
 Build Improvement::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Asciidoctor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Asciidoctor.java
@@ -13,12 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -376,26 +371,35 @@ public interface Asciidoctor extends AutoCloseable {
     /**
      * Reads only header parameters instead of all document.
      *
+     * @deprecated Use {@link #loadFile(File, Map)} instead.
+     *
      * @param file to read the attributes.
      * @return header.
      */
+    @Deprecated
     DocumentHeader readDocumentHeader(File file);
 
     /**
      * Reads only header parameters instead of all document.
      *
+     * @deprecated Use {@link #load(String, Map)} instead.
+     *
      * @param content where rendered content is written. Writer is flushed, but not
      *                closed.
      * @return header.
      */
+    @Deprecated
     DocumentHeader readDocumentHeader(String content);
 
     /**
      * Reads only header parameters instead of all document.
      *
+     * @deprecated Use {@link #loadFile(File, Map)} instead.
+     *
      * @param contentReader where asciidoc content is read.
      * @return header.
      */
+    @Deprecated
     DocumentHeader readDocumentHeader(Reader contentReader);
 
     /**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
@@ -94,4 +94,12 @@ public interface Document extends StructuralNode {
      * @return catalog
      */
     Catalog getCatalog();
+
+
+    /**
+     * The revision information with: date, number and remark.
+     *
+     * @return revisionInfo
+     */
+    RevisionInfo getRevisionInfo();
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/DocumentHeader.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/DocumentHeader.java
@@ -3,17 +3,46 @@ package org.asciidoctor.ast;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Document header information holder.
+ *
+ */
+@Deprecated
 public interface DocumentHeader {
 
+    /**
+     * @deprecated Use {@link Document#getAuthors()} instead.
+     */
+    @Deprecated
     List<Author> getAuthors();
 
+    /**
+     * @deprecated Use {@link Document#getStructuredDoctitle()} instead.
+     */
+    @Deprecated
     Title getDocumentTitle();
 
+    /**
+     * @deprecated Use {@link Document#getDoctitle()} instead.
+     */
+    @Deprecated
     String getPageTitle();
 
+    /**
+     * @deprecated Use {@link Document#getAuthors()} instead.
+     */
+    @Deprecated
     Author getAuthor();
 
+    /**
+     * @deprecated Use {@link Document#getRevisionInfo()} instead.
+     */
+    @Deprecated
     RevisionInfo getRevisionInfo();
 
+    /**
+     * @deprecated Use {@link Document#getAttributes()} instead.
+     */
+    @Deprecated
     Map<String, Object> getAttributes();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentImpl.java
@@ -1,9 +1,6 @@
 package org.asciidoctor.jruby.ast.impl;
 
-import org.asciidoctor.ast.Author;
-import org.asciidoctor.ast.Catalog;
-import org.asciidoctor.ast.Document;
-import org.asciidoctor.ast.Title;
+import org.asciidoctor.ast.*;
 import org.asciidoctor.jruby.internal.RubyHashMapDecorator;
 import org.asciidoctor.jruby.internal.RubyHashUtil;
 import org.jruby.*;
@@ -90,5 +87,10 @@ public class DocumentImpl extends StructuralNodeImpl implements Document {
     @Override
     public Catalog getCatalog() {
         return new CatalogImpl(new RubyHashMapDecorator((RubyHash) getProperty("catalog")));
+    }
+
+    @Override
+    public RevisionInfo getRevisionInfo() {
+        return RevisionInfoImpl.getInstance(getAttributes());
     }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
@@ -1,14 +1,12 @@
 package org.asciidoctor;
 
 import org.asciidoctor.arquillian.api.Unshared;
-import org.asciidoctor.ast.Author;
-import org.asciidoctor.ast.Document;
-import org.asciidoctor.ast.Section;
-import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.ast.*;
 import org.asciidoctor.jruby.internal.IOUtils;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -449,5 +447,22 @@ public class WhenAsciiDocIsLoadedToDocument {
         assertThat(secondAuthor.getMiddleName(), is("A."));
         assertThat(secondAuthor.getLastName(), is("Smith"));
         assertThat(secondAuthor.getInitials(), is("JAS"));
+    }
+
+    @Test
+    public void should_get_revision_info() {
+        String content = "= Sample Document\n" +
+                "Doc Writer <doc.writer@asciidoc.org>\n" +
+                "v1.0, 2013-05-20: First draft\n" +
+                "\n" +
+                "Preamble...";
+
+        Document document = asciidoctor.load(content, emptyMap());
+
+        RevisionInfo revisionInfo = document.getRevisionInfo();
+
+        assertThat(revisionInfo.getDate(), is("2013-05-20"));
+        assertThat(revisionInfo.getNumber(), is("1.0"));
+        assertThat(revisionInfo.getRemark(), is("First draft"));
     }
 }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Expose RevisionInfo from Document to be accessible from extensions.
Note this is different from how the info is exposed in Asciidoctor Ruby, but aligned with Asciidoctor.js.

How does it achieve that?

Adds `RevisionInfo getRevisionInfo()` to `Document` interface.
Uses same implementation found in `DocumentHeaderImpl`.

Are there any alternative ways to implement this?

:point_right: Only thing to discuss is we want to deprecate the Header methods in this same PR or do it separatedly. :point_left: 
Other than that, the PR is harmless.

Are there any implications of this pull request? Anything a user must know?

No.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 

Fixes #1008 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc