### PR TITLE
Rename push_include to pushInclude

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,7 +21,8 @@ Improvement::
 * Add getRevisionInfo method to Document. Make `DocumentHeader` class and `readDocumentHeader` methods as deprecated (@abelsromero) (#1008)
 * Add getAuthors method to Document (@abelsromero) (#1007)
 * Upgrade to asciidoctor 2.0.14 (#1016)
-* Deprecated methods Asciidoctor, Options and Attributes API scheduled for future removal (@abelsromero)(#1015) 
+* Deprecated methods Asciidoctor, Options and Attributes API scheduled for future removal (@abelsromero)(#1015)
+* Add pushInclude to PreprocessorReaderImpl and deprecate push_include (@abelsromero) (#1020)
 
 Build Improvement::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/PreprocessorReader.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/PreprocessorReader.java
@@ -1,19 +1,52 @@
 package org.asciidoctor.extension;
 
-import java.util.Map;
-
 import org.asciidoctor.ast.Document;
+
+import java.util.Map;
 
 public interface PreprocessorReader extends Reader {
 
+    /**
+     * Push source content onto the front of the reader and switch the context
+     * based on the file, document-relative path and line information given.
+     * This method is typically used in an {@link IncludeProcessor} to add content 
+     * read from the target specified.
+     *
+     * @deprecated Use {@link #pushInclude(String, String, String, int, Map)} instead.
+     *
+     * @param data       content to push
+     * @param file       representation of name of the included file. Does not need to exists
+     * @param path       representation of path of the included file. Does not need to exists
+     * @param lineNumber line number of the first line of the included content
+     * @param attributes additional attributes to pass
+     */
+    @Deprecated
     void push_include(String data, String file, String path, int lineNumber, Map<String, Object> attributes);
 
     /**
-     * @return
+     * Push source content onto the front of the reader and switch the context
+     * based on the file, document-relative path and line information given.
+     * This method is typically used in an {@link IncludeProcessor} to add content 
+     * read from the target specified.
+     *
+     * @param data       content to push
+     * @param file       representation of name of the included file. Does not need to exists
+     * @param path       representation of path of the included file. Does not need to exists
+     * @param lineNumber line number of the first line of the included content
+     * @param attributes additional attributes to pass
+     */
+    void pushInclude(String data, String file, String path, int lineNumber, Map<String, Object> attributes);
+
+    /**
      * @deprecated Please use {@link #getDocument()}
+     *
+     * @return Document representation.
      */
     @Deprecated
     Document document();
 
+    /**
+     * @return Document representation.
+     */
     Document getDocument();
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/internal/PreprocessorReaderImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/internal/PreprocessorReaderImpl.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.jruby.extension.internal;
 
 import org.asciidoctor.ast.Document;
-import org.asciidoctor.jruby.ast.impl.NodeConverter;
 import org.asciidoctor.extension.PreprocessorReader;
+import org.asciidoctor.jruby.ast.impl.NodeConverter;
 import org.jruby.RubyHash;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -16,7 +16,11 @@ public class PreprocessorReaderImpl extends ReaderImpl implements PreprocessorRe
 
     @Override
     public void push_include(String data, String file, String path, int lineNumber, Map<String, Object> attributes) {
+        pushInclude(data, file, path, lineNumber, attributes);
+    }
 
+    @Override
+    public void pushInclude(String data, String file, String path, int lineNumber, Map<String, Object> attributes) {
         RubyHash attributeHash = RubyHash.newHash(getRuntime());
         attributeHash.putAll(attributes);
 

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/LsIncludeProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/LsIncludeProcessor.java
@@ -28,7 +28,7 @@ public class LsIncludeProcessor extends IncludeProcessor {    // <1>
             sb.append(f.getName()).append("\n");
         }
 
-        reader.push_include(                                  // <4>
+        reader.pushInclude(                                  // <4>
                 sb.toString(),
                 target,
                 new File(".").getAbsolutePath(),


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Rename `PreprocessorReader::push_include` to `pushInclude` to align with Java conventions.
Also deprecates the old method to keep this change compatible.

How does it achieve that?
-

Are there any alternative ways to implement this?
no

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #980


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc