### PR TITLE
Fix doc filename instead of title shown in nav menu

### DIFF
--- a/docs/modules/guides/pages/use-prerelease-version.adoc
+++ b/docs/modules/guides/pages/use-prerelease-version.adoc
@@ -1,4 +1,4 @@
-== Using a pre-release version
+= Using a pre-release version
 
 Pre-release versions of `AsciidoctorJ` are published to oss.sonatype.org.
 The exact location of the repository will be announced.


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Fix an invalid title that causes the filename to appear in the menu

![image](https://user-images.githubusercontent.com/5781153/115621046-477d9880-a2f6-11eb-98a7-74ae852e2add.png)


How does it achieve that?
Fix title level from 2 to 1.

Are there any alternative ways to implement this?
:thinking: 

Are there any implications of this pull request? Anything a user must know?
No, that I know of.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc