### PR TITLE
Upgrade test dependencies on Arquillian and Spock

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,10 @@ Build Improvement::
 * Upgrade to sdkman vendor plugin 2.0.0
 * Remove builds on appveyor (#1027)
 
+Build / Infrastructure::
+
+* Upgrade test dependencies on Arquillian and Spock (#1031)
+
 == 2.5.0 (2021-02-27)
 
 Improvement::

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -60,8 +60,7 @@ jar {
   bnd(
     ('Bundle-Name'): 'asciidoctorj',
     ('Bundle-SymbolicName'): 'org.asciidoctor.asciidoctorj',
-    ('Import-Package'):
-      'com.beust.jcommander;resolution:=optional, *'
+    ('Import-Package'): 'com.beust.jcommander;resolution:=optional, *'
   )
   metaInf { from "$buildDir/version-info/" }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentContainsADefinitionList.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentContainsADefinitionList.groovy
@@ -161,7 +161,7 @@ Item A::
             Document process(Document doc) {
                 DescriptionList dl = doc.getBlocks().get(0)
                 DescriptionListEntry dlEntry = dl.items[0]
-                dlEntry.setDescription(createListItem(dl, newDescription))
+                dlEntry.description = createListItem(dl, newDescription)
                 doc
             }
         })

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenSubstitutionsAreUsed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenSubstitutionsAreUsed.groovy
@@ -39,8 +39,8 @@ System.out.println("Hello World");
 
         when:
         Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
-        Block paragraph = doc.blocks()[0].blocks[0]
-        Block source = doc.blocks()[0].blocks[1]
+        Block paragraph = doc.blocks[0].blocks[0]
+        Block source = doc.blocks[0].blocks[1]
 
         then:
         paragraph.substitutions == [SUBSTITUTION_SPECIAL_CHARACTERS, SUBSTITUTION_QUOTES, SUBSTITUTION_ATTRIBUTES, SUBSTITUTION_REPLACEMENTS, SUBSTITUTION_MACROS, SUBSTITUTION_POST_REPLACEMENTS]
@@ -64,8 +64,8 @@ Second test paragraph {foo}
         when:
         asciidoctor.javaExtensionRegistry().treeprocessor(TestTreeprocessor)
         Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
-        Block firstparagraph = doc.blocks()[0].blocks[0]
-        Block secondparagraph = doc.blocks()[0].blocks[1]
+        Block firstparagraph = doc.blocks[0].blocks[0]
+        Block secondparagraph = doc.blocks[0].blocks[1]
 
         String html = asciidoctor.convert(document, OptionsBuilder.options().asMap())
 
@@ -99,8 +99,8 @@ System.out.println("{foo}");
         when:
         asciidoctor.javaExtensionRegistry().treeprocessor(TestTreeprocessor)
         Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
-        Block firstparagraph = doc.blocks()[0].blocks[0]
-        Block secondparagraph = doc.blocks()[0].blocks[1]
+        Block firstparagraph = doc.blocks[0].blocks[0]
+        Block secondparagraph = doc.blocks[0].blocks[1]
 
         String html = asciidoctor.convert(document, OptionsBuilder.options().asMap())
 
@@ -182,10 +182,10 @@ First test paragraph *{foo}
 
         when:
         asciidoctor.javaExtensionRegistry().treeprocessor(SetSubstitutionTestTreeprocessor)
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
-        Block firstparagraph = doc.blocks()[0].blocks[0]
+        Document doc = asciidoctor.load(document, Options.builder().build())
+        Block firstparagraph = doc.blocks[0].blocks[0]
 
-        String html = asciidoctor.convert(document, OptionsBuilder.options().asMap())
+        String html = asciidoctor.convert(document, Options.builder().build())
 
         then:
         firstparagraph.substitutions == [SUBSTITUTION_ATTRIBUTES]
@@ -197,7 +197,7 @@ First test paragraph *{foo}
     static class SetSubstitutionTestTreeprocessor extends Treeprocessor {
         @Override
         Document process(Document document) {
-            document.blocks()[0].blocks[0].setSubstitutions(SUBSTITUTION_ATTRIBUTES)
+            document.blocks[0].blocks[0].substitutions = [SUBSTITUTION_ATTRIBUTES]
             document
         }
     }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/ConfigModifyingBlockProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/ConfigModifyingBlockProcessor.groovy
@@ -20,6 +20,6 @@ class ConfigModifyingBlockProcessor extends BlockProcessor {
 
     @Override
     Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
-        setConfig([:])
+        config = [:]
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
@@ -33,7 +33,7 @@ class GithubContributorsBlockMacro extends BlockMacroProcessor {
         Column avatarColumn = createTableColumn(table, 0)
         Column loginColumn = createTableColumn(table, 1)
         Column contributionsColumn = createTableColumn(table, 2)
-        contributionsColumn.setHorizontalAlignment(Table.HorizontalAlignment.CENTER)
+        contributionsColumn.horizontalAlignment = Table.HorizontalAlignment.CENTER
 
         // Create the single header row with the column titles
         Row headerRow = createTableRow(table)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/TableCreatorTreeProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/TableCreatorTreeProcessor.groovy
@@ -19,8 +19,8 @@ class TableCreatorTreeProcessor extends Treeprocessor {
 
         // Create and add a column
         Column column = createTableColumn(table, 0, [:])
-        column.setHorizontalAlignment(Table.HorizontalAlignment.CENTER)
-        column.setVerticalAlignment(Table.VerticalAlignment.BOTTOM)
+        column.horizontalAlignment = Table.HorizontalAlignment.CENTER
+        column.verticalAlignment = Table.VerticalAlignment.BOTTOM
         table.columns.add(column)
 
         // Create and add a row to the table

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorSetsTheSourceMapOption.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorSetsTheSourceMapOption.groovy
@@ -19,7 +19,7 @@ class WhenAPreprocessorSetsTheSourceMapOption extends Specification {
     static class SourceMapOptionPreprocessor extends Preprocessor {
         @Override
         void process(Document document, PreprocessorReader reader) {
-            document.setSourcemap(true)
+            document.sourcemap = true
         }
     }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenExtensionsAreRegisteredAsService.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenExtensionsAreRegisteredAsService.groovy
@@ -35,11 +35,11 @@ class WhenExtensionsAreRegisteredAsService extends Specification {
     ClassLoader originalTCCL
 
     def setup() {
-        originalTCCL = Thread.currentThread().getContextClassLoader()
+        originalTCCL = Thread.currentThread().contextClassLoader
     }
 
     def cleanup() {
-        Thread.currentThread().setContextClassLoader(originalTCCL)
+        Thread.currentThread().contextClassLoader = originalTCCL
     }
 
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenASyntaxHighlighterIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenASyntaxHighlighterIsRegistered.groovy
@@ -1,24 +1,20 @@
 package org.asciidoctor.syntaxhighlighter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.AttributesBuilder
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Attributes
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.Document
 import org.asciidoctor.extension.LocationType
-import org.jboss.arquillian.spock.ArquillianSputnik
-import org.jboss.arquillian.test.api.ArquillianResource
 import org.jsoup.Jsoup
-import org.junit.runner.RunWith
 import spock.lang.Specification
 import spock.lang.Unroll
 
-@RunWith(ArquillianSputnik)
 class WhenASyntaxHighlighterIsRegistered extends Specification {
 
   public static final String NAME_SYNTAXHIGHLIGHTER = 'test'
-  @ArquillianResource
-  private Asciidoctor asciidoctor
+
+  private Asciidoctor asciidoctor = Asciidoctor.Factory.create()
 
   static class TestHighlighter implements SyntaxHighlighterAdapter {
 
@@ -101,15 +97,16 @@ System.out.println("Hello World");
 ----'''
 
   @Unroll
-  def '#highlighter.simpleName should create header docinfo #expectHeader and footer docinfo #expectFooter'(Class highlighter, boolean expectHeader, boolean expectFooter) {
+  def '#highlighter.simpleName should create header docinfo #expectHeader and footer docinfo #expectFooter'() {
 
     expect:
     asciidoctor.syntaxHighlighterRegistry().register(highlighter, NAME_SYNTAXHIGHLIGHTER)
-    String html = asciidoctor.convert(DOC, OptionsBuilder.options()
+    String html = asciidoctor.convert(DOC, Options.builder()
             .safe(SafeMode.UNSAFE)
             .headerFooter(true)
             .attributes(
-            AttributesBuilder.attributes().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)))
+                    Attributes.builder().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER).build())
+            .build())
 
     org.jsoup.nodes.Document doc = Jsoup.parse(html)
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenASyntaxHighlighterThatWritesStylesheetsIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenASyntaxHighlighterThatWritesStylesheetsIsRegistered.groovy
@@ -1,19 +1,16 @@
 package org.asciidoctor.syntaxhighlighter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.AttributesBuilder
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Attributes
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.Document
 import org.asciidoctor.extension.LocationType
-import org.jboss.arquillian.spock.ArquillianSputnik
-import org.jboss.arquillian.test.api.ArquillianResource
+import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
 import spock.lang.Specification
 import spock.lang.Unroll
 
-@RunWith(ArquillianSputnik)
 class WhenASyntaxHighlighterThatWritesStylesheetsIsRegistered extends Specification {
 
   public static final String NAME_SYNTAXHIGHLIGHTER = 'test'
@@ -21,12 +18,10 @@ class WhenASyntaxHighlighterThatWritesStylesheetsIsRegistered extends Specificat
   public static final String CONTENT_CSS = 'FOOBAR'
   public static final String FILENAME_CSS = 'highlighter.css'
 
-  @ArquillianResource
-  private Asciidoctor asciidoctor
+  private Asciidoctor asciidoctor = Asciidoctor.Factory.create()
 
-  @ArquillianResource
-  private TemporaryFolder tmp
-
+  @Rule
+  public TemporaryFolder tmp = new TemporaryFolder()
 
   static class TestHighlighter implements SyntaxHighlighterAdapter, StylesheetWriter {
 
@@ -81,15 +76,15 @@ System.out.println("Hello World");
     asciidoctor.syntaxHighlighterRegistry().register(TestHighlighter, NAME_SYNTAXHIGHLIGHTER)
 
     when:
-    asciidoctor.convert(doc, OptionsBuilder.options()
+    asciidoctor.convert(doc, Options.builder()
             .safe(SafeMode.UNSAFE)
             .headerFooter(true)
             .toFile(new File(toDir,'syntaxhighlighterwithwritestylesheet.html'))
             .attributes(
-            AttributesBuilder.attributes().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)
-                    .copyCss(true)
-                    .linkCss(true))
-    )
+                    Attributes.builder().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)
+                            .copyCss(true)
+                            .linkCss(true).build())
+            .build())
 
     then:
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
@@ -1,12 +1,15 @@
 package org.asciidoctor;
 
 import org.asciidoctor.arquillian.api.Unshared;
-import org.asciidoctor.ast.*;
+import org.asciidoctor.ast.Author;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.RevisionInfo;
+import org.asciidoctor.ast.Section;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.jruby.internal.IOUtils;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/HighlightJsHighlighterTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/HighlightJsHighlighterTest.java
@@ -29,8 +29,8 @@ public class HighlightJsHighlighterTest {
     @ArquillianResource
     private ClasspathResources classpathResources;
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @ArquillianResource
+    public TemporaryFolder tempDir;
 
     @Test
     public void should_invoke_syntax_highlighter() throws Exception {

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/OrderTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/OrderTest.java
@@ -1,13 +1,12 @@
 package org.asciidoctor.integrationguide.syntaxhighlighter;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.AttributesBuilder;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -27,8 +26,8 @@ public class OrderTest {
     @ArquillianResource
     private ClasspathResources classpathResources;
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @ArquillianResource
+    public TemporaryFolder tempDir;
 
     @Test
     public void should_invoke_syntax_highlighter() throws Exception {
@@ -45,14 +44,16 @@ public class OrderTest {
             .register(OrderDocumentingHighlighter.class, "order");
 
         asciidoctor.convertFile(sources_adoc,
-            OptionsBuilder.options()
+            Options.builder()
                 .headerFooter(true)
                 .toDir(toDir)
                 .safe(SafeMode.UNSAFE)
-                .attributes(AttributesBuilder.attributes()
+                .attributes(Attributes.builder()
                     .sourceHighlighter("order")
                     .copyCss(true)
-                    .linkCss(true)));
+                    .linkCss(true)
+                    .build())
+                .build());
 
         String actual = OrderDocumentingHighlighter.messages.stream()
                 .map(msg -> ". " + msg + "\n")

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/PrismJsHighlighterTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/PrismJsHighlighterTest.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.integrationguide.syntaxhighlighter;
 
-import org.apache.commons.io.IOUtils;
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
@@ -11,21 +10,14 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.io.FileReader;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 public class PrismJsHighlighterTest {
@@ -36,8 +28,8 @@ public class PrismJsHighlighterTest {
     @ArquillianResource
     private ClasspathResources classpathResources;
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @ArquillianResource
+    public TemporaryFolder tempDir;
 
     @Test
     public void should_invoke_syntax_highlighter() throws Exception {

--- a/asciidoctorj-wildfly-integration-test/build.gradle
+++ b/asciidoctorj-wildfly-integration-test/build.gradle
@@ -1,7 +1,6 @@
 jar.enabled = false
 
 ext {
-    arquillianVersion = '1.6.0.Final'
     arquillianWildflyVersion = '3.0.1.Final'
 
     wildflyVersion = '23.0.0.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ plugins {
   id "io.codearte.nexus-staging" version "0.22.0"
   id "de.marcphilipp.nexus-publish" version "0.4.0"
   id 'com.github.jruby-gradle.base' version '2.0.0'
+  id 'codenarc'
 }
 
 apply plugin: 'io.codearte.nexus-staging'
@@ -52,8 +53,8 @@ ext {
   statusIsRelease = (status == 'release')
 
   // jar versions
-  arquillianVersion = '1.1.10.Final'
-  arquillianSpockVersion = '1.0.0.Beta3'
+  arquillianVersion = '1.6.0.Final'
+  arquillianSpockVersion = '1.0.0.CR1'
   asciidoctorjPdfVersion = '1.5.4'
   asciidoctorjEpub3Version = '1.5.1'
   asciidoctorjDiagramVersion = '2.1.2'
@@ -76,14 +77,14 @@ ext {
   coderayGemVersion = '1.1.3'
   rougeGemVersion = '3.26.0'
 
-  codenarcVersion = '0.24.1'
-  groovyVersion = '2.4.13'
+  codenarcVersion = '2.1.0'
+  groovyVersion = '2.4.21'
   erubisGemVersion = '2.7.0'
   hamlGemVersion = '5.0.4'
   openUriCachedGemVersion = '0.0.5'
   slimGemVersion = '4.1.0'
   concurrentRubyGemVersion = '1.1.8'
-  spockVersion = '0.7-groovy-2.0'
+  spockVersion = '1.3-groovy-2.4'
   threadSafeGemVersion = '0.3.6'
   tiltGemVersion = '2.0.10'
   osgiVersion = '7.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
   jcommanderVersion = '1.72'
   jrubyVersion = '9.2.17.0'
   jsoupVersion = '1.12.1'
-  junitVersion = '4.13.1'
+  junitVersion = '4.13.2'
   assertjVersion = '3.19.0'
   nettyVersion = '4.1.58.Final'
   saxonVersion = '9.9.0-2'

--- a/docs/modules/ROOT/examples/org/asciidoctor/integrationguide/OptionsTest.java
+++ b/docs/modules/ROOT/examples/org/asciidoctor/integrationguide/OptionsTest.java
@@ -50,7 +50,7 @@ public class OptionsTest {
 //tag::optionsPDFBackend[]
         File targetFile = // ...
 //end::optionsPDFBackend[]
-                temporaryFolder.newFile("test.pdf");
+        temporaryFolder.newFile("test.pdf");
         assertTrue(targetFile.exists());
 //tag::optionsPDFBackend[]
         asciidoctor.convert(
@@ -95,7 +95,7 @@ public class OptionsTest {
 //tag::optionToFile[]
         File targetFile = //...
 //end::optionToFile[]
-                temporaryFolder.newFile("toFileExample.html");
+        temporaryFolder.newFile("toFileExample.html");
 
 //tag::optionToFile[]
         asciidoctor.convert(
@@ -116,19 +116,19 @@ public class OptionsTest {
     public void use_font_awesome_icons() throws Exception {
 //tag::attributeFontIcons[]
         String result =
-                asciidoctor.convert(
-                        "NOTE: Asciidoctor supports font-based admonition icons!\n" +
-                                "\n" +
-                                "{foo}",
-                        Options.builder()
-                                .toFile(false)
-                                .headerFooter(false)
-                                .attributes(
-                                        Attributes.builder()                                          // <1>        
-                                                .icons(Attributes.FONT_ICONS)                         // <2>
-                                                .attribute("foo", "bar") // <3>
-                                                .build())
-                                .build());
+            asciidoctor.convert(
+                "NOTE: Asciidoctor supports font-based admonition icons!\n" +
+                    "\n" +
+                    "{foo}",
+                    Options.builder()
+                            .toFile(false)
+                            .headerFooter(false)
+                            .attributes(
+                                    Attributes.builder()                                          // <1>        
+                                            .icons(Attributes.FONT_ICONS)                         // <2>
+                                            .attribute("foo", "bar") // <3>
+                                            .build())
+                            .build());
         assertThat(result, containsString("<i class=\"fa icon-note\" title=\"Note\"></i>"));
         assertThat(result, containsString("<p>bar</p>"));
 //end::attributeFontIcons[]

--- a/docs/modules/syntax-highlighting/examples/org/asciidoctor/integrationguide/syntaxhighlighter/HighlightJsHighlighterTest.java
+++ b/docs/modules/syntax-highlighting/examples/org/asciidoctor/integrationguide/syntaxhighlighter/HighlightJsHighlighterTest.java
@@ -8,7 +8,6 @@ import org.asciidoctor.SafeMode;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -29,8 +28,8 @@ public class HighlightJsHighlighterTest {
     @ArquillianResource
     private ClasspathResources classpathResources;
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @ArquillianResource
+    public TemporaryFolder tempDir;
 
     @Test
     public void should_invoke_syntax_highlighter() throws Exception {

--- a/docs/modules/syntax-highlighting/examples/org/asciidoctor/integrationguide/syntaxhighlighter/PrismJsHighlighterTest.java
+++ b/docs/modules/syntax-highlighting/examples/org/asciidoctor/integrationguide/syntaxhighlighter/PrismJsHighlighterTest.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.integrationguide.syntaxhighlighter;
 
-import org.apache.commons.io.IOUtils;
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
@@ -11,21 +10,14 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.io.FileReader;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 public class PrismJsHighlighterTest {
@@ -36,8 +28,8 @@ public class PrismJsHighlighterTest {
     @ArquillianResource
     private ClasspathResources classpathResources;
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @ArquillianResource
+    public TemporaryFolder tempDir;
 
     @Test
     public void should_invoke_syntax_highlighter() throws Exception {


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

This PR upgrades the test dependencies on Spock and Arquillian, so that the wildfly test no longer uses a different version of Arquillian than the rest of the project.
I had to disable Arquillian for 2 of the Spock tests that use Data Tables. If I haven't done any mistake I assume that there is some bug in there and I'll open a ticket for arquillian-spock at the next occasion.

The upgrade of the codenarc plugin also required some changes in some test.