### PR TITLE
Fixes #1032. Downgrade concurrent-ruby to 1.1.7

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@ Improvement::
 * Upgrade to asciidoctor 2.0.15 (#1026)
 * Upgrade to asciidoctor-epub 1.5.1 (#1030)
 
+Bug Fixes::
+
+* Fix performance regression in v2.5.0 with asciidoctorj-pdf and concurrent-ruby (@kedar-joshi) (#1032)
+
 Build Improvement::
 
 * Upgrade to sdkman vendor plugin 2.0.0

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ ext {
   hamlGemVersion = '5.0.4'
   openUriCachedGemVersion = '0.0.5'
   slimGemVersion = '4.1.0'
-  concurrentRubyGemVersion = '1.1.8'
+  concurrentRubyGemVersion = '1.1.7'
   spockVersion = '1.3-groovy-2.4'
   threadSafeGemVersion = '0.3.6'
   tiltGemVersion = '2.0.10'


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

The upgrade of concurrent-ruby to 1.1.8 in AsciidoctorJ 2.5.0 resulted in the initialisation of asciidoctor-pdf taking an additional ~10 seconds.
This PR reduces that again to the previous time taken.

How does it achieve that?

Downgrade concurrent-ruby to 1.1.7 which doesn't seem to expose this behavior.

Are there any alternative ways to implement this?

Not from AsciidoctorJ's point of view.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc