### PR TITLE
Fixes #1037. Avoid usage of deprecated attributes toc2 and toc-placem…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,9 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 Bug Fixes::
 
-* Avoid using of deprecated attributes toc2 and toc-placement. Deprecated (@abelsromero) (#1037)
+* Avoid using of deprecated attributes toc2 and toc-placement.
+  Deprecated Attributes.setTableOfContents2().
+  Added new constants Placement.PREAMBLE and Placement.MACRO as parameters for Attributes.setTableOfConstants(). (@abelsromero) (#1037)
 
 == 2.5.1 (2021-05-04)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Avoid using of deprecated attributes toc2 and toc-placement. Deprecated (@abelsromero) (#1037)
+
 == 2.5.1 (2021-05-04)
 
 Improvement::

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
@@ -333,7 +333,9 @@ public class Attributes {
      * 
      * @param placement
      *            where toc is rendered.
+     * @deprecated Use {@link #setTableOfContents(Placement)}
      */
+    @Deprecated
     public void setTableOfContents2(Placement placement) {
         this.attributes.put(TOC_2, toAsciidoctorFlag(true));
         this.attributes.put(TOC_POSITION, placement.getPosition());
@@ -346,8 +348,7 @@ public class Attributes {
      *            position of toc.
      */
     public void setTableOfContents(Placement placement) {
-        this.attributes.put(TOC, toAsciidoctorFlag(true));
-        this.attributes.put(TOC_POSITION, placement.getPosition());
+        this.attributes.put(TOC, placement.getPosition());
     }
 
     /**
@@ -383,7 +384,11 @@ public class Attributes {
      *            value.
      */
     public void setTableOfContents(boolean toc) {
-        this.attributes.put(TOC, toAsciidoctorFlag(toc));
+        if (toc) {
+            this.attributes.put(TOC, "");
+        } else {
+            this.attributes.remove(TOC);
+        }
     }
 
     /**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/AttributesBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/AttributesBuilder.java
@@ -153,7 +153,9 @@ public class AttributesBuilder {
      * Sets table of contents 2 attribute.
      * @param placement where toc is rendered.
      * @return this instance.
+	 * @deprecated Use {@link #tableOfContents(Placement)}
      */
+    @Deprecated
     public AttributesBuilder tableOfContents2(Placement placement) {
         this.attributes.setTableOfContents2(placement);
         return this;

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Placement.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Placement.java
@@ -2,12 +2,13 @@ package org.asciidoctor;
 
 public enum Placement {
 
-    
-    TOP("top"), BOTTOM("bottom"), LEFT("left"), RIGHT("right");
-    
+
+    TOP("top"), BOTTOM("bottom"), LEFT("left"), RIGHT("right"),
+    PREAMBLE("preamble"), MACRO("macro");
+
     private String position;
     
-    private Placement(String position) {
+    Placement(String position) {
         this.position = position;
     }
     

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -1,35 +1,6 @@
 package org.asciidoctor;
 
-import static org.asciidoctor.AttributesBuilder.attributes;
-import static org.asciidoctor.OptionsBuilder.options;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.xmlmatchers.xpath.HasXPath.hasXPath;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Map;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Source;
-import javax.xml.transform.dom.DOMSource;
-
+import com.google.common.io.CharStreams;
 import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
@@ -43,7 +14,28 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.xml.sax.SAXException;
 
-import com.google.common.io.CharStreams;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.asciidoctor.AttributesBuilder.attributes;
+import static org.asciidoctor.OptionsBuilder.options;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
+import static org.junit.Assert.assertEquals;
+import static org.xmlmatchers.xpath.HasXPath.hasXPath;
 
 @RunWith(Arquillian.class)
 public class WhenAttributesAreUsedInAsciidoctor {
@@ -364,8 +356,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void setting_toc_attribute_table_of_contents_should_be_generated() throws IOException {
 
-        Attributes attributes = attributes().tableOfContents(true).get();
-        Options options = options().inPlace(false).toDir(testFolder.getRoot()).safe(SafeMode.UNSAFE).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().tableOfContents(true).build();
+        Options options = Options.builder().inPlace(false).toDir(testFolder.getRoot()).safe(SafeMode.UNSAFE).attributes(attributes).build();
 
         asciidoctor.convertFile(classpath.getResource("tocsample.asciidoc"), options);
 
@@ -374,6 +366,58 @@ public class WhenAttributesAreUsedInAsciidoctor {
         Elements tocElement = doc.select("div.toc");
         assertThat(tocElement.hasClass("toc"), is(true));
 
+    }
+
+    @Test
+    public void setting_toc_attribute_left_should_work() throws IOException {
+        Attributes attributes = Attributes.builder().tableOfContents(Placement.LEFT).build();
+        Options options = Options.builder().inPlace(false).toDir(testFolder.getRoot()).safe(SafeMode.UNSAFE).attributes(attributes).build();
+
+        asciidoctor.convertFile(classpath.getResource("tocsample.asciidoc"), options);
+
+        Document doc = Jsoup.parse(new File(testFolder.getRoot(),
+                "tocsample.html"), "UTF-8");
+        Elements tocElement = doc.select("body.toc-left > div#header > div#toc");
+        assertThat(tocElement.size(), is(1));
+    }
+
+    @Test
+    public void setting_toc_attribute_right_should_work() throws IOException {
+        Attributes attributes = Attributes.builder().tableOfContents(Placement.RIGHT).build();
+        Options options = Options.builder().inPlace(false).toDir(testFolder.getRoot()).safe(SafeMode.UNSAFE).attributes(attributes).build();
+
+        asciidoctor.convertFile(classpath.getResource("tocsample.asciidoc"), options);
+
+        Document doc = Jsoup.parse(new File(testFolder.getRoot(),
+                "tocsample.html"), "UTF-8");
+        Elements tocElement = doc.select("body.toc-right > div#header > div#toc");
+        assertThat(tocElement.size(), is(1));
+    }
+
+    @Test
+    public void setting_toc_attribute_preamble_should_work() throws IOException {
+        Attributes attributes = Attributes.builder().tableOfContents(Placement.PREAMBLE).build();
+        Options options = Options.builder().inPlace(false).toDir(testFolder.getRoot()).safe(SafeMode.UNSAFE).attributes(attributes).build();
+
+        asciidoctor.convertFile(classpath.getResource("tocsample.asciidoc"), options);
+
+        Document doc = Jsoup.parse(new File(testFolder.getRoot(),
+                "tocsample.html"), "UTF-8");
+        Elements tocElement = doc.select("body.article > div#content > div#preamble > div#toc");
+        assertThat(tocElement.size(), is(1));
+    }
+
+    @Test
+    public void setting_toc_attribute_macro_should_work() throws IOException {
+        Attributes attributes = Attributes.builder().tableOfContents(Placement.MACRO).build();
+        Options options = Options.builder().inPlace(false).toDir(testFolder.getRoot()).safe(SafeMode.UNSAFE).attributes(attributes).build();
+
+        asciidoctor.convertFile(classpath.getResource("tocsamplemacro.asciidoc"), options);
+
+        Document doc = Jsoup.parse(new File(testFolder.getRoot(),
+                "tocsamplemacro.html"), "UTF-8");
+        Elements tocElement = doc.select("body.article > div#content > div.sect1 > div.sectionbody > div#toc");
+        assertThat(tocElement.size(), is(1));
     }
 
     @Test

--- a/asciidoctorj-core/src/test/resources/tocsamplemacro.asciidoc
+++ b/asciidoctorj-core/src/test/resources/tocsamplemacro.asciidoc
@@ -5,5 +5,7 @@ The preamble.
 == First chapter
 first chapter
 
+toc::[]
+
 == Second chapter
 second chapter


### PR DESCRIPTION
…ent.

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

This PR fixes #1037.
It avoids using the attributes toc2 and too-placement for Attributes.setTableOfContents().
The method Attributes.setTableOfContents2() has been deprecated as the attribute toc2 is also deprecated in Asciidoctor.

How does it achieve that?

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc