### PR TITLE
Remove source- and targetCompatiblity options and use javaCompile.opt…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,10 @@ Bug Fixes::
   Deprecated Attributes.setTableOfContents2().
   Added new constants Placement.PREAMBLE and Placement.MACRO as parameters for Attributes.setTableOfConstants(). (@abelsromero) (#1037)
 
+Build Improvement::
+
+* Use JavaCompile options.release instead of sourceCompatibility and targetCompatibility to target Java 8 (#1042)
+
 == 2.5.1 (2021-05-04)
 
 Improvement::

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,9 @@ subprojects {
 
   plugins.withType(JavaPlugin) {
     project.tasks.withType(JavaCompile) { task ->
-      task.options.release = 8
+      if (JavaVersion.current().isJava11Compatible()) {
+        task.options.release = 8
+      }
       if (project.hasProperty("showDeprecation")) {
         options.compilerArgs << "-Xlint:deprecation"
       }
@@ -115,7 +117,9 @@ subprojects {
       }
     }
     project.tasks.withType(GroovyCompile) { task ->
-      task.options.release = 8
+      if (JavaVersion.current().isJava11Compatible()) {
+        task.options.release = 8
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -103,14 +103,10 @@ subprojects {
 
   status = _status
 
-  // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle
-  // Must redefine here to work around a bug in the Eclipse plugin
-  sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
   plugins.withType(JavaPlugin) {
     project.tasks.withType(JavaCompile) { task ->
-      task.sourceCompatibility = project.sourceCompatibility
-      task.targetCompatibility = project.targetCompatibility
+      task.options.release = 8
       if (project.hasProperty("showDeprecation")) {
         options.compilerArgs << "-Xlint:deprecation"
       }
@@ -119,8 +115,7 @@ subprojects {
       }
     }
     project.tasks.withType(GroovyCompile) { task ->
-      task.sourceCompatibility = project.sourceCompatibility
-      task.targetCompatibility = project.targetCompatibility
+      task.options.release = 8
     }
   }
 
@@ -204,12 +199,10 @@ configure(subprojects.findAll { !it.isDistribution() }) {
     ruby.gems()
   }
 
-  if (JavaVersion.current().isJava8Compatible()) {
-    javadoc {
-      // Oracle JDK8 likes to fail the build over spoiled HTML
-      options.addStringOption('Xdoclint:none', '-quiet')
-      options.source('8')
-    }
+  javadoc {
+    // Oracle JDK8 likes to fail the build over spoiled HTML
+    options.addStringOption('Xdoclint:none', '-quiet')
+    options.source('8')
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,2 @@
 version=2.5.2-SNAPSHOT
-sourceCompatibility=1.8
-targetCompatibility=1.8
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
…ions.release instead

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Make sure that AsciidoctorJ can always be consumed with Java 8.

How does it achieve that?

Use the new Gradle option JavaCompile.options.release instead of source and targetCompatibility (https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation)

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc