### PR TITLE
Upgrade remaining dependency on junit 4.12 to 4.13.2

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Build Improvement::
 
 * Use JavaCompile options.release instead of sourceCompatibility and targetCompatibility to target Java 8 (#1042)
 * Upgrade nexus publishing and staging to new gradle-nexus.publish-plugin (#1043)
+* Upgrade remaining dependency on junit 4.12 to 4.13.2 (#1044)
 
 == 2.5.1 (2021-05-04)
 

--- a/asciidoctorj-test-support/build.gradle
+++ b/asciidoctorj-test-support/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
-    api 'junit:junit:4.12'
+    api "junit:junit:${junitVersion}"
 }
 
 def javaApiUrl = "https://docs.oracle.com/javase/8/docs/api/"


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Sonatype sent a warning that we are still relying on unit 4.12 which has an open CVE.
Indeed asciidoctorj-test-support still has that dependency even though the build itself should already have used the fixed version 4.13.2.
This PR  upgrades this last remaining dependency to 4.13.2 too to avoid that CVE.

How does it achieve that?

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc