### PR TITLE
Bump SpringBoot version to latest 2.5.2 in it test

### DIFF
--- a/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
+++ b/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.4.2'
+	id 'org.springframework.boot' version '2.5.2'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 }
@@ -10,10 +10,6 @@ sourceCompatibility = '1.8'
 
 repositories {
 	mavenCentral()
-}
-
-ext {
-	asciidoctorjVersion = '2.4.2'
 }
 
 dependencies {


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Upgrade version of Spring Boot version used in the Spring Boot integration test.

How does it achieve that?

Simply upgrade the configuration of the submodule `springboot-app`.
It also removes an unnecessary asciidoctorj version property.

Are there any alternative ways to implement this?

If necessary we could consider parameterizing the version in a way that allowed to run the same test against several version, por example the 2 most recent minnors. But that can be tricky when we fund breaking changes between minors.

Are there any implications of this pull request? Anything a user must know?
No.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc