### PR TITLE
change default branch name for core in test upstream script

### DIFF
--- a/ci/test-asciidoctor-upstream.sh
+++ b/ci/test-asciidoctor-upstream.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # to build against a tag, set REF to a git tag name (e.g., refs/tags/v1.5.2)
-REF=${1:-refs/heads/master}
+REF=${1:-refs/heads/main}
 if [[ $REF != refs/* ]]; then
   REF=refs/heads/$REF
 fi


### PR DESCRIPTION
## Kind of change

- [x] Build improvement

## Description

The default branch name of Asciidoctor core has been renamed to main. This patch updates the test upstream script to use it as the fallback branch name.