### PR TITLE
Fix test-asciidoctor-upstream.sh path in 'Build Upstream'

### DIFF
--- a/.github/workflows/upstream-build.yaml
+++ b/.github/workflows/upstream-build.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Build
         run: |
           unset GEM_PATH GEM_HOME JRUBY_OPTS
-          ./test-asciidoctor-upstream.sh ${{ github.event.client_payload.branch }}
+          ./ci/test-asciidoctor-upstream.sh ${{ github.event.client_payload.branch }}


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Fix upstream-build pipeline triggered by Asciidoctor (not step Test Asciidoctor Upstream that runs on PRs) and that has been failing for past 2 weeks :point_right: https://github.com/asciidoctor/asciidoctorj/actions/workflows/upstream-build.yaml. 

How does it achieve that?
Fixes path of script `test-asciidoctor-upstream.sh` which was moved in commit https://github.com/asciidoctor/asciidoctorj/commit/283b10fcf6012f40969c0b0f729b36dcb792ee39.

Are there any alternative ways to implement this?
No.

Are there any implications of this pull request? Anything a user must know?

Don't let me arround pipelines? :roll_eyes: 

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
Don't think it's worth it.