### PR TITLE
Fix example on Logs Handling API documentation

### DIFF
--- a/docs/modules/ROOT/pages/logs-handling.adoc
+++ b/docs/modules/ROOT/pages/logs-handling.adoc
@@ -76,7 +76,7 @@ import org.asciidoctor.log.LogRecord;
 /**
  * Stores LogRecords in memory for later analysis.
  */
-public class MemoryLogHandler extends LogHandler {
+public class MemoryLogHandler implements LogHandler {
 
   private List<LogRecord> logRecords = new ArrayList<>();
 


### PR DESCRIPTION
The custom LogHandle given as an example in the Logs Handling API sections didn't work, as it used 'extends' rather than 'implements' to the LogHandler interface.

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

   Fix an error on the code given in the Logs Handling API documentation section

How does it achieve that?

   Code snippet updated (extends replaced with 'implements')

Are there any alternative ways to implement this?
   N/A 

Are there any implications of this pull request? Anything a user must know?
   N/A
## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc