### PR TITLE
add explicit dependency after Gradle complained

### DIFF
--- a/asciidoctorj-wildfly-integration-test/build.gradle
+++ b/asciidoctorj-wildfly-integration-test/build.gradle
@@ -45,6 +45,10 @@ task unpackWildfly(type: Copy) {
     into "$buildDir"
 }
 
+compileTestJava {
+    dependsOn unpackWildfly
+}
+
 tasks.create("createModule").doLast {
     copy {
         from "src/test/resources/module.xml"


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?
There is a warning in the build: 

> 2022-01-07T17:47:08.9908240Z > Task :asciidoctorj-wildfly-integration-test:unpackWildfly
2022-01-07T17:47:08.9910154Z Execution optimizations have been disabled for task ':asciidoctorj-wildfly-integration-test:unpackWildfly' to ensure correctness due to the following reasons:
2022-01-07T17:47:08.9914578Z   - Gradle detected a problem with the following location: '/home/runner/work/asciidoctorj/asciidoctorj/asciidoctorj-wildfly-integration-test/build'. Reason: Task ':asciidoctorj-wildfly-integration-test:compileTestJava' uses this output of task ':asciidoctorj-wildfly-integration-test:unpackWildfly' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
2022-01-07T17:47:42.7169565Z 

How does it achieve that?
Adding the dependency explicitly that Gradle complained about.

Are there any alternative ways to implement this?
(?)

Are there any implications of this pull request? Anything a user must know?
no

## Release notes

(not updated as not relevant to release notes IMHO)