### PR TITLE
Fixes #1082. Return empty list in DescriptionList.getBlocks() instead…

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DescriptionListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DescriptionListImpl.java
@@ -9,6 +9,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+
 public class DescriptionListImpl extends StructuralNodeImpl implements DescriptionList {
 
     public DescriptionListImpl(IRubyObject delegate) {
@@ -39,7 +41,6 @@ public class DescriptionListImpl extends StructuralNodeImpl implements Descripti
 
     @Override
     public List<StructuralNode> getBlocks() {
-        RubyArray rubyBlocks = (RubyArray) getRubyProperty("blocks");
-        return new RubyBlockListDecorator<>(rubyBlocks);
+        return emptyList();
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheSourceShouldBeAccessed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheSourceShouldBeAccessed.groovy
@@ -103,8 +103,7 @@ That::
 and should continue here'''
         listItem.description.text == '''list item should show bar
 and should continue here'''
-        list.blocks.size() == list.items.size()
-        list.items[0].description.source == list.blocks[0].description.source
+        list.blocks.size() == 0
     }
 
     def 'it should be possible to get the raw text from a table cell'() {


### PR DESCRIPTION
… of return a list of DescriptionListItems, which are not blocks

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

#1082 reports that DescriptionList.getSections() returns a list of objects that are not StructuralNodes but DescriptionListEntries instead. (This only works due to type erasure).

How does it achieve that?

This PR tries to fix the problem by making DescriptionList.getSections() return a new empty list.
That way there will no longer be a ClassCastException when recursively traversing the AST only via getSections().

Are there any alternative ways to implement this?

It could be possible to change the form of the AST by making DescriptionListEntry a StructuralNode that has the terms as properties. 
That might be difficult as the implementation of Asciidoctor Ruby currently treats the terms and its description as a list with 2 items: `[[ListItem Term1, ListItem Term2], ListItem Description]`.
This might be difficult to implement, leaves the question open how to handle description list entries without description and also this would be a breaking change.

Are there any implications of this pull request? Anything a user must know?

Adding any nodes to the result of DescriptionList.getSections() is without any effect.

## Issue

Fixes #1082 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc