### PR TITLE
Fix Macro APIs to return Structural or Phrase Nodes instead of java.l…

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/BlockMacroProcessor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/BlockMacroProcessor.java
@@ -5,7 +5,7 @@ import org.asciidoctor.ast.StructuralNode;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class BlockMacroProcessor extends MacroProcessor<StructuralNode, StructuralNode> {
+public abstract class BlockMacroProcessor extends MacroProcessor<StructuralNode> {
 
     public BlockMacroProcessor() {
         this(null, new HashMap<>());

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/BlockMacroProcessor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/BlockMacroProcessor.java
@@ -5,7 +5,7 @@ import org.asciidoctor.ast.StructuralNode;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class BlockMacroProcessor extends MacroProcessor<StructuralNode> {
+public abstract class BlockMacroProcessor extends MacroProcessor<StructuralNode, StructuralNode> {
 
     public BlockMacroProcessor() {
         this(null, new HashMap<>());

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
@@ -1,11 +1,12 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class InlineMacroProcessor extends MacroProcessor<ContentNode> {
+public abstract class InlineMacroProcessor extends MacroProcessor<ContentNode, PhraseNode> {
 
     /**
      * This value is used as the config option key when defining a regular expression that should be

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/InlineMacroProcessor.java
@@ -1,12 +1,11 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class InlineMacroProcessor extends MacroProcessor<ContentNode, PhraseNode> {
+public abstract class InlineMacroProcessor extends MacroProcessor<PhraseNode> {
 
     /**
      * This value is used as the config option key when defining a regular expression that should be

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/MacroProcessor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/MacroProcessor.java
@@ -1,11 +1,12 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.StructuralNode;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class MacroProcessor<T extends ContentNode, R extends ContentNode> extends BaseProcessor {
+public abstract class MacroProcessor<R extends ContentNode> extends BaseProcessor {
 
     protected String name;
 
@@ -30,6 +31,6 @@ public abstract class MacroProcessor<T extends ContentNode, R extends ContentNod
         return new HashMap<>();
     }
     
-    public abstract R process(T parent, String target, Map<String, Object> attributes);
+    public abstract R process(StructuralNode parent, String target, Map<String, Object> attributes);
     
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/MacroProcessor.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/MacroProcessor.java
@@ -5,7 +5,7 @@ import org.asciidoctor.ast.ContentNode;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class MacroProcessor<T extends ContentNode> extends BaseProcessor {
+public abstract class MacroProcessor<T extends ContentNode, R extends ContentNode> extends BaseProcessor {
 
     protected String name;
 
@@ -30,6 +30,6 @@ public abstract class MacroProcessor<T extends ContentNode> extends BaseProcesso
         return new HashMap<>();
     }
     
-    public abstract Object process(T parent, String target, Map<String, Object> attributes);
+    public abstract R process(T parent, String target, Map<String, Object> attributes);
     
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/processorproxies/InlineMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/processorproxies/InlineMacroProcessorProxy.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.jruby.extension.processorproxies;
 
+import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.jruby.ast.impl.NodeConverter;
 import org.asciidoctor.jruby.internal.*;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/processorproxies/InlineMacroProcessorProxy.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/processorproxies/InlineMacroProcessorProxy.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.jruby.extension.processorproxies;
 
-import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.jruby.ast.impl.NodeConverter;
 import org.asciidoctor.jruby.internal.*;
@@ -68,7 +68,7 @@ public class InlineMacroProcessorProxy extends AbstractMacroProcessorProxy<Inlin
             // If options contains a String with a Regexp create the RubyRegexp from it
             RubyHash rubyConfig = RubyHashUtil.convertMapToRubyHashWithSymbols(getRuntime(), getProcessor().getConfig());
             Object regexp = getProcessor().getConfig().get("regexp");
-            if (regexp != null && regexp instanceof CharSequence) {
+            if (regexp instanceof CharSequence) {
                 RubySymbol regexpSymbol = RubySymbol.newSymbol(getRuntime(), "regexp");
                 rubyConfig.put(regexpSymbol, convertRegexp(getRuntime(), (CharSequence) regexp));
             }
@@ -122,7 +122,7 @@ public class InlineMacroProcessorProxy extends AbstractMacroProcessorProxy<Inlin
     @JRubyMethod(name = "process", required = 3)
     public IRubyObject process(ThreadContext context, IRubyObject parent, IRubyObject target, IRubyObject attributes) {
         Object o = getProcessor().process(
-                NodeConverter.createASTNode(parent),
+                (StructuralNode) NodeConverter.createASTNode(parent),
                 RubyUtils.rubyToJava(getRuntime(), target, String.class),
                 new RubyAttributesMapDecorator((RubyHash) attributes));
         return convertProcessorResult(o);

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedBlockMacroProcessor.groovy
@@ -10,7 +10,7 @@ class AnnotatedBlockMacroProcessor extends BlockMacroProcessor {
     public static final String RESULT = 'This content is added by this macro!'
 
     @Override
-    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+    StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         createBlock(parent, 'paragraph', RESULT)
     }
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
@@ -1,8 +1,8 @@
 package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
-import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.PhraseNode
+import org.asciidoctor.ast.StructuralNode
 
 @CompileStatic
 @Name('man')
@@ -14,7 +14,7 @@ class AnnotatedLongInlineMacroProcessor extends InlineMacroProcessor {
     public static final String SECTION = 'section'
 
     @Override
-    PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+    PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         assert attributes[SECTION] == '7' || ( attributes[SECTION] == '8' || attributes[SUBSECTION] == '1')
 
         Map<String, Object> options = new HashMap<String, Object>()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedLongInlineMacroProcessor.groovy
@@ -2,6 +2,7 @@ package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
 import org.asciidoctor.ast.ContentNode
+import org.asciidoctor.ast.PhraseNode
 
 @CompileStatic
 @Name('man')
@@ -13,7 +14,7 @@ class AnnotatedLongInlineMacroProcessor extends InlineMacroProcessor {
     public static final String SECTION = 'section'
 
     @Override
-    Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
         assert attributes[SECTION] == '7' || ( attributes[SECTION] == '8' || attributes[SUBSECTION] == '1')
 
         Map<String, Object> options = new HashMap<String, Object>()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
@@ -1,8 +1,8 @@
 package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
-import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.PhraseNode
+import org.asciidoctor.ast.StructuralNode
 
 @CompileStatic
 @Name('man')
@@ -14,7 +14,7 @@ class AnnotatedRegexpInlineMacroProcessor extends InlineMacroProcessor {
     }
 
     @Override
-    PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+    PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         Map<String, Object> options = new HashMap<String, Object>()
         options['type'] = ':link'
         options['target'] = "${target}.html"

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/AnnotatedRegexpInlineMacroProcessor.groovy
@@ -2,6 +2,7 @@ package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
 import org.asciidoctor.ast.ContentNode
+import org.asciidoctor.ast.PhraseNode
 
 @CompileStatic
 @Name('man')
@@ -13,7 +14,7 @@ class AnnotatedRegexpInlineMacroProcessor extends InlineMacroProcessor {
     }
 
     @Override
-    Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
         Map<String, Object> options = new HashMap<String, Object>()
         options['type'] = ':link'
         options['target'] = "${target}.html"

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
@@ -18,7 +18,7 @@ class GithubContributorsBlockMacro extends BlockMacroProcessor {
     }
 
     @Override
-    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+    StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         URL url = new URL("http://api.github.com/repos/${target}/contributors")
         URLConnection connection = url.openConnection(new Proxy(Proxy.Type.HTTP, new InetSocketAddress('localhost', TestHttpServer.instance.localPort)))
         String content = connection.inputStream.text

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/ListCreatorBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/ListCreatorBlockMacro.groovy
@@ -13,7 +13,7 @@ class ListCreatorBlockMacro extends BlockMacroProcessor {
     }
 
     @Override
-    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+    StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
 
         def attrs = new HashMap<String, Object>()
         attrs['start'] = '42'

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/SectionCreatorBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/SectionCreatorBlockMacro.groovy
@@ -9,7 +9,7 @@ class SectionCreatorBlockMacro extends BlockMacroProcessor {
     public static final String CONTENT = 'This is just some text'
 
     @Override
-    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+    StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         Section section = createSection(parent)
         section.title = target
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionUsesCounters.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionUsesCounters.groovy
@@ -126,7 +126,7 @@ testmacro::countera[]
     static class TestBlockMacroProcessor extends BlockMacroProcessor {
 
         @Override
-        Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
 
             String text = "This is macro call ${parent.document.getAndIncrementCounter(target)} for ${target}"
             // Have to do this to interact successfully with counters also used in the document
@@ -143,7 +143,7 @@ testmacro::countera[]
     static class TestBlockMacroWithInitialCounterProcessor extends BlockMacroProcessor {
 
         @Override
-        Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
 
             String text = "This is macro call ${parent.document.getAndIncrementCounter(target, 42)} for ${target}"
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnExtensionAppendsChildBlocks.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnExtensionAppendsChildBlocks.groovy
@@ -123,7 +123,7 @@ testmacro::target[]
 
         asciidoctor.javaExtensionRegistry().blockMacro(new BlockMacroProcessor('testmacro'){
             @Override
-            Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+            StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
                 createBlock(parent, 'paragraph', expectedContent, [:])
             }
         })

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockMacroRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockMacroRegistrationTest.java
@@ -34,7 +34,7 @@ public class BlockMacroRegistrationTest {
 
     public static class AbstractTestProcessor extends BlockMacroProcessor {
         @Override
-        public Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        public StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
             return createBlock(parent, "paragraph", target.toUpperCase());
         }
     }
@@ -48,7 +48,7 @@ public class BlockMacroRegistrationTest {
         }
 
         @Override
-        public Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        public StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
             return createBlock(parent, "paragraph", target.toUpperCase());
         }
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/InlineMacroRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/InlineMacroRegistrationTest.java
@@ -2,8 +2,8 @@ package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.jruby.internal.AsciidoctorCoreException;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -32,7 +32,7 @@ public class InlineMacroRegistrationTest {
 
     public static class AbstractTestProcessor extends InlineMacroProcessor {
         @Override
-        public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+        public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
             String transformed = target.chars()
                 .mapToObj(c -> Character.isUpperCase(c) ? " " + (char) c : Character.toString((char) c))
                 .collect(joining())
@@ -50,7 +50,7 @@ public class InlineMacroRegistrationTest {
         }
 
         @Override
-        public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+        public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
             String transformed = target.chars()
                 .mapToObj(c -> Character.isUpperCase(c) ? " " + (char) c : Character.toString((char) c))
                 .collect(joining())

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/InlineMacroRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/InlineMacroRegistrationTest.java
@@ -3,6 +3,7 @@ package org.asciidoctor.extension;
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.jruby.internal.AsciidoctorCoreException;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -31,7 +32,7 @@ public class InlineMacroRegistrationTest {
 
     public static class AbstractTestProcessor extends InlineMacroProcessor {
         @Override
-        public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+        public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
             String transformed = target.chars()
                 .mapToObj(c -> Character.isUpperCase(c) ? " " + (char) c : Character.toString((char) c))
                 .collect(joining())
@@ -49,7 +50,7 @@ public class InlineMacroRegistrationTest {
         }
 
         @Override
-        public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+        public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
             String transformed = target.chars()
                 .mapToObj(c -> Character.isUpperCase(c) ? " " + (char) c : Character.toString((char) c))
                 .collect(joining())

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.ast.ContentNode;
-import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.ast.PhraseNode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,8 +17,8 @@ public class ManpageMacro extends InlineMacroProcessor {
     }
 
     @Override
-    public Object process(ContentNode parent, String target,
-            Map<String, Object> attributes) {
+    public PhraseNode process(ContentNode parent, String target,
+                              Map<String, Object> attributes) {
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("type", ":link");
         options.put("target", target + ".html");

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +17,7 @@ public class ManpageMacro extends InlineMacroProcessor {
     }
 
     @Override
-    public PhraseNode process(ContentNode parent, String target,
+    public PhraseNode process(StructuralNode parent, String target,
                               Map<String, Object> attributes) {
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("type", ":link");

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/SayMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/SayMacro.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension;
 
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +17,7 @@ public class SayMacro extends InlineMacroProcessor {
     }
 
     @Override
-    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         String text = "*" + target + "*";
         Map<String, Object> phraseNodeAttributes = new HashMap<>();
         phraseNodeAttributes.put("subs", ":normal");

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/SayMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/SayMacro.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.ast.ContentNode;
-import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.ast.PhraseNode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +17,7 @@ public class SayMacro extends InlineMacroProcessor {
     }
 
     @Override
-    public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
         String text = "*" + target + "*";
         Map<String, Object> phraseNodeAttributes = new HashMap<>();
         phraseNodeAttributes.put("subs", ":normal");

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenTheInlineMacroProcessorRunsTwice.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenTheInlineMacroProcessorRunsTwice.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -21,7 +21,7 @@ public class WhenTheInlineMacroProcessorRunsTwice {
         asciidoctor.javaExtensionRegistry().inlineMacro(new InlineMacroProcessor("example") {
 
             @Override
-            public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+            public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
                 return createPhraseNode(parent, "quoted", attributes.toString(), attributes, new HashMap<>());
             }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenTheInlineMacroProcessorRunsTwice.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenTheInlineMacroProcessorRunsTwice.java
@@ -2,6 +2,7 @@ package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -20,7 +21,7 @@ public class WhenTheInlineMacroProcessorRunsTwice {
         asciidoctor.javaExtensionRegistry().inlineMacro(new InlineMacroProcessor("example") {
 
             @Override
-            public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+            public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
                 return createPhraseNode(parent, "quoted", attributes.toString(), attributes, new HashMap<>());
             }
 

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/CommentPreprocessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/CommentPreprocessorTest.java
@@ -1,9 +1,8 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.util.ClasspathResources;
-import org.hamcrest.Matcher;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
@@ -39,8 +38,8 @@ public class CommentPreprocessorTest {
 //tag::include[]
         asciidoctor.javaExtensionRegistry().preprocessor(CommentPreprocessor.class);      // <1>
 
-        String result1 = asciidoctor.convertFile(comment_adoc, OptionsBuilder.options().toFile(false));
-        String result2 = asciidoctor.convertFile(comment_with_note_adoc, OptionsBuilder.options().toFile(false));
+        String result1 = asciidoctor.convertFile(comment_adoc, Options.builder().toFile(false).build());
+        String result2 = asciidoctor.convertFile(comment_with_note_adoc, Options.builder().toFile(false).build());
 
         assertThat(result1, is(result2)); // <2>
 //end::include[]

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ContextMenuInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ContextMenuInlineMacroProcessor.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
@@ -14,7 +15,7 @@ import java.util.Map;
 public class ContextMenuInlineMacroProcessor extends InlineMacroProcessor {
 
     @Override
-    public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
         String[] items = target.split("\\|");
         Map<String, Object> attrs = new HashMap<String, Object>();
         attrs.put("menu", "Right click");                              // <1>

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ContextMenuInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ContextMenuInlineMacroProcessor.java
@@ -1,11 +1,12 @@
 package org.asciidoctor.integrationguide.extension;
 
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,14 +16,11 @@ import java.util.Map;
 public class ContextMenuInlineMacroProcessor extends InlineMacroProcessor {
 
     @Override
-    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         String[] items = target.split("\\|");
-        Map<String, Object> attrs = new HashMap<String, Object>();
+        Map<String, Object> attrs = new HashMap<>();
         attrs.put("menu", "Right click");                              // <1>
-        List<String> submenus = new ArrayList<String>();
-        for (int i = 0; i < items.length - 1; i++) {
-            submenus.add(items[i]);
-        }
+        List<String> submenus = Arrays.asList(items).subList(0, items.length - 1);
         attrs.put("submenus", submenus);
         attrs.put("menuitem", items[items.length - 1]);
 

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ContextMenuInlineMacroProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ContextMenuInlineMacroProcessorTest.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -22,7 +22,7 @@ public class ContextMenuInlineMacroProcessorTest {
 
         asciidoctor.javaExtensionRegistry().inlineMacro(ContextMenuInlineMacroProcessor.class);
 
-        String result = asciidoctor.convert("rightclick:New|Class[]", OptionsBuilder.options().toFile(false).safe(SafeMode.UNSAFE));
+        String result = asciidoctor.convert("rightclick:New|Class[]", Options.builder().toFile(false).safe(SafeMode.UNSAFE).build());
 
 
         assertThat(

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/CopyrightFooterPostprocessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/CopyrightFooterPostprocessorTest.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -35,9 +35,10 @@ public class CopyrightFooterPostprocessorTest {
 
         String result =
                 asciidoctor.convertFile(doc,
-                        OptionsBuilder.options()
+                        Options.builder()
                                 .headerFooter(true)                                            // <2>
-                                .toFile(false));
+                                .toFile(false)
+                                .build());
 
         assertThat(result, containsString(CopyrightFooterPostprocessor.COPYRIGHT_NOTICE));
 //end::include[]

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/GistBlockMacroPositionalAttributesProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/GistBlockMacroPositionalAttributesProcessor.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class GistBlockMacroPositionalAttributesProcessor extends BlockMacroProcessor {
 
     @Override
-    public Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+    public StructuralNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
 
         String script;
         String provider = (String) attributes.get("provider");

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/GistBlockMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/GistBlockMacroProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class GistBlockMacroProcessor extends BlockMacroProcessor {     // <2>
 
     @Override
-    public Object process(                                             // <3>
+    public StructuralNode process(                                     // <3>
             StructuralNode parent, String target, Map<String, Object> attributes) {
 
         String content = new StringBuilder()
@@ -23,7 +23,7 @@ public class GistBlockMacroProcessor extends BlockMacroProcessor {     // <2>
             .append("</div>")
             .append("</div>").toString();
 
-        return createBlock(parent, "pass", content);                   // <5>
+        return createBlock(parent, "pass", content);           // <5>
     }
 
 }

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ImageInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ImageInlineMacroProcessor.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
@@ -12,7 +13,7 @@ import java.util.Map;
 public class ImageInlineMacroProcessor extends InlineMacroProcessor {
 
     @Override
-    public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
 
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("type", "image");                                            // <1>

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ImageInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ImageInlineMacroProcessor.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
@@ -13,7 +13,7 @@ import java.util.Map;
 public class ImageInlineMacroProcessor extends InlineMacroProcessor {
 
     @Override
-    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
 
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("type", "image");                                            // <1>

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ImageInlineMacroProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ImageInlineMacroProcessorTest.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -22,7 +22,7 @@ public class ImageInlineMacroProcessorTest {
 
         asciidoctor.javaExtensionRegistry().inlineMacro(ImageInlineMacroProcessor.class);
 
-        String result = asciidoctor.convert("foo:1234[]", OptionsBuilder.options().toFile(false).safe(SafeMode.UNSAFE));
+        String result = asciidoctor.convert("foo:1234[]", Options.builder().toFile(false).safe(SafeMode.UNSAFE).build());
 
         assertThat(
                 result,

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroPositionalAttributesProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroPositionalAttributesProcessor.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.integrationguide.extension;
 
 //tag::include[]
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 import org.asciidoctor.extension.PositionalAttributes;
@@ -17,7 +17,7 @@ import java.util.Map;
 public class IssueInlineMacroPositionalAttributesProcessor extends InlineMacroProcessor {
 
     @Override
-    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
 
         String href =
                 new StringBuilder()

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroPositionalAttributesProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroPositionalAttributesProcessor.java
@@ -2,6 +2,7 @@ package org.asciidoctor.integrationguide.extension;
 
 //tag::include[]
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 import org.asciidoctor.extension.PositionalAttributes;
@@ -16,7 +17,7 @@ import java.util.Map;
 public class IssueInlineMacroPositionalAttributesProcessor extends InlineMacroProcessor {
 
     @Override
-    public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
 
         String href =
                 new StringBuilder()

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroProcessor.java
@@ -3,6 +3,7 @@ package org.asciidoctor.integrationguide.extension;
 //tag::include[]
 
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
@@ -13,8 +14,8 @@ import java.util.Map;
 public class IssueInlineMacroProcessor extends InlineMacroProcessor {    // <2>
 
     @Override
-    public Object process(                                               // <3>
-            ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(                                           // <3>
+        ContentNode parent, String target, Map<String, Object> attributes) {
 
         String href =
                 new StringBuilder()

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroProcessor.java
@@ -2,8 +2,8 @@ package org.asciidoctor.integrationguide.extension;
 
 //tag::include[]
 
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
@@ -15,7 +15,7 @@ public class IssueInlineMacroProcessor extends InlineMacroProcessor {    // <2>
 
     @Override
     public PhraseNode process(                                           // <3>
-        ContentNode parent, String target, Map<String, Object> attributes) {
+        StructuralNode parent, String target, Map<String, Object> attributes) {
 
         String href =
                 new StringBuilder()

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/IssueInlineMacroProcessorTest.java
@@ -2,7 +2,6 @@ package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
-import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -33,7 +32,7 @@ public class IssueInlineMacroProcessorTest {
 //tag::include[]
         asciidoctor.javaExtensionRegistry().inlineMacro(IssueInlineMacroProcessor.class);       // <1>
 
-        String result = asciidoctor.convertFile(issueinlinemacro_adoc, OptionsBuilder.options().toFile(false));
+        String result = asciidoctor.convertFile(issueinlinemacro_adoc, Options.builder().toFile(false).build());
 
         assertThat(
                 result,

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/KeyboardInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/KeyboardInlineMacroProcessor.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
@@ -14,8 +14,8 @@ import java.util.Map;
 public class KeyboardInlineMacroProcessor extends InlineMacroProcessor {
 
     @Override
-    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
-        Map<String, Object> attrs = new HashMap<String, Object>();
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        Map<String, Object> attrs = new HashMap<>();
         attrs.put("keys", Arrays.asList("Ctrl", target));             // <1>
         return createPhraseNode(parent, "kbd", (String) null, attrs); // <2>
     }

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/KeyboardInlineMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/KeyboardInlineMacroProcessor.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 import org.asciidoctor.extension.Name;
 
@@ -13,7 +14,7 @@ import java.util.Map;
 public class KeyboardInlineMacroProcessor extends InlineMacroProcessor {
 
     @Override
-    public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
         Map<String, Object> attrs = new HashMap<String, Object>();
         attrs.put("keys", Arrays.asList("Ctrl", target));             // <1>
         return createPhraseNode(parent, "kbd", (String) null, attrs); // <2>

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/KeyboardInlineMacroProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/KeyboardInlineMacroProcessorTest.java
@@ -1,9 +1,8 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
-import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
@@ -25,7 +24,7 @@ public class KeyboardInlineMacroProcessorTest {
 
         asciidoctor.javaExtensionRegistry().inlineMacro(KeyboardInlineMacroProcessor.class);       // <1>
 
-        String result = asciidoctor.convert("ctrl:S[]", OptionsBuilder.options().toFile(false).safe(SafeMode.UNSAFE));
+        String result = asciidoctor.convert("ctrl:S[]", Options.builder().toFile(false).safe(SafeMode.UNSAFE).build());
 
         assertThat(
                 result,

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/LoggingBlockMacroProcessor.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/LoggingBlockMacroProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class LoggingBlockMacroProcessor extends BlockMacroProcessor {
 
     @Override
-    public Object process(
+    public StructuralNode process(
             StructuralNode parent, String target, Map<String, Object> attributes) {
 
         String message = target;

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/LsIncludeProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/LsIncludeProcessorTest.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -35,7 +35,7 @@ public class LsIncludeProcessorTest {
 
         asciidoctor.javaExtensionRegistry().includeProcessor(LsIncludeProcessor.class);       // <1>
 
-        String result = asciidoctor.convertFile(lsinclude_adoc, OptionsBuilder.options().toFile(false));
+        String result = asciidoctor.convertFile(lsinclude_adoc, Options.builder().toFile(false).build());
 
         assertThat(
                 result,

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/RobotsDocinfoProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/RobotsDocinfoProcessorTest.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
@@ -37,10 +37,11 @@ public class RobotsDocinfoProcessorTest {
 
         String result = asciidoctor.convert(
                 src,
-                OptionsBuilder.options()
+                Options.builder()
                         .headerFooter(true)                      // <2>
                         .safe(SafeMode.SERVER)                   // <3>
-                        .toFile(false));
+                        .toFile(false)
+                        .build());
 
         org.jsoup.nodes.Document document = Jsoup.parse(result); // <4>
         Element metaElement = document.head().children().last();

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessorTest.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
@@ -81,9 +82,10 @@ public class TerminalCommandTreeprocessorTest {
 //tag::include-extension-registry[]
         String result = asciidoctor.convertFile(
             src,
-            OptionsBuilder.options()
+            Options.builder()
                 .headerFooter(false)
-                .toFile(false));
+                .toFile(false)
+                .build());
 //end::include-extension-registry[]
             assertThat(result, is(referenceResult));
         } finally {

--- a/docs/modules/guides/pages/extension-migration-guide-2x-to-30.adoc
+++ b/docs/modules/guides/pages/extension-migration-guide-2x-to-30.adoc
@@ -1,11 +1,9 @@
-= Extension Migration: 1.6.x to 2.0.x
-:url-base-1-5: https://github.com/asciidoctor/asciidoctorj/blob/v1.5.8.1
-:url-base-1-6: https://github.com/asciidoctor/asciidoctorj/blob/v1.6.0
+= Extension Migration: 2.0.x to 3.0.x
 
 Between 2.x and 3.0.x there are some changes that may affect existing extensions.
 This guide will illustrate the changes.
 
-== Preprocessor API
+== Preprocessor Extensions
 
 In AsciidoctorJ 1.x and 2.x a Preprocessor could not return anything from its process() method.
 This deviated from the API offered by Asciidoctor itself which allows to replace the original Reader.
@@ -51,3 +49,40 @@ public class ChangeAttributeValuePreprocessor extends Preprocessor {
 ----
 <1> Change the method signature to return a `Reader` instead of `void`.
 <2> Directly return the passed Reader.
+
+== Inline Macro Extensions
+
+The API that inline macro extensions had the return type `java.lang.Object`, while `org.asciidoctor.ast.PhraseNode` is actually expected.
+Additionally, the parent node passed to the process method is guaranteed to be a `org.asciidoctor.ast.StructuralNode`, while the previous API offered the supertype `org.asciidoctor.ast.ContentNode`.
+This is corrected in AsciidoctorJ 3.x making it clearer for extension implementors what types to expect and what types to return.
+
+Let's assume that an InlineMacro originally looks like this for AsciidoctorJ 2.x:
+
+[source,java]
+----
+public class KeyboardInlineMacroProcessor extends InlineMacroProcessor {
+     @Override
+     public Object process(ContentNode parent, String target, Map<String, Object> attributes) {
+         Map<String, Object> attrs = new HashMap<>();
+         attrs.put("keys", Arrays.asList("Ctrl", target));
+         return createPhraseNode(parent, "kbd", (String) null, attrs);
+    }
+}
+----
+
+The only change that is necessary is to change the method declaration of the process method:
+Change the return type to `org.asciidoctor.ast.PhraseNode` and the type of the first parameter to `org.asciidoctor.ast.StructuralNode`.
+
+[source,java]
+----
+public class KeyboardInlineMacroProcessor extends InlineMacroProcessor {
+     @Override
+     public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
+         Map<String, Object> attrs = new HashMap<>();
+         attrs.put("keys", Arrays.asList("Ctrl", target));
+         return createPhraseNode(parent, "kbd", (String) null, attrs);
+    }
+}
+----
+
+This change mostly makes it clearer for new extensions what they have to return and what they can expect.


### PR DESCRIPTION
…ang.Object.

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

As @melix had to experience painfully this week the macro APIs are not really showing what type of node an extension has to return. Currently both InlineMacroProcessors and BlockMacroProcessors define java.lang.Object as the return type.
Instead of parameterizing the return type of the method I parameterized the parameter for the parent node 🤦 
I don't know what I had drunk when looking over that.

This PR tries to update the signatures so that it's clearer for the user what type of nodes they have to return.

How does it achieve that?

It updates the InlineMacroProcessor.process() to return a PhraseNode instead of java.lang.Object and BlockMacroProcessor.process() to return StructuralNode.

@mojavelinux Is it even possible that anything else than a StructuralNode/AbstractBlock is passed as a parent to an Inline- or BlockMacroProcessor?
We currently have the topmost base class ContentNode as the type of the parent parameter.
If not I could remove that type parameter.

Are there any alternative ways to implement this?

I don't think so.

Are there any implications of this pull request? Anything a user must know?

This is a breaking change. The source code of existing extensions must be updated.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc