### PR TITLE
Fix version check

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ Build Improvement::
 * Upgrade to gradle 7.4.2 (#1086)
 * Upgrade to Wildfly 26.0.1 for integration test (#1085)
 * Upgrade to Spring Boot 2.6.5 for integration test (#1085)
+* Fix gem version check task (#1087)
 
 Documentation::
 

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -1,11 +1,16 @@
 apply plugin: 'java-library'
 apply plugin: 'groovy'
 apply plugin: 'biz.aQute.bnd.builder'
+apply plugin: 'com.github.jruby-gradle.base'
 
 project.ext.publicationName = "mavenAsciidoctorJ"
 
 apply from: rootProject.file('gradle/publish.gradle')
 apply from: rootProject.file('gradle/signing.gradle')
+
+repositories {
+  ruby.gems()
+}
 
 dependencies {
   api project(path: ':asciidoctorj-api')
@@ -38,6 +43,8 @@ def gemFiles = fileTree("${project.buildDir}/.gems") {
   include "gems/asciidoctor-*/data/**"
 }
 
+apply from: rootProject.file('gradle/versioncheck.gradle')
+
 jrubyPrepare {
   doLast {
     copy { // bundles the gems inside this artifact
@@ -46,6 +53,32 @@ jrubyPrepare {
     }
   }
 }
+tasks.eclipse.dependsOn jrubyPrepare
+
+
+jruby {
+  defaultRepositories = false
+  defaultVersion = jrubyVersion
+  // TODO I'd like to be able to customize the name of the gemInstallDir
+}
+
+ext {
+  // path to use for the prepared jruby gems
+  preparedGems = new File("$buildDir/preparedGems")
+}
+
+sourceSets {
+  main {
+    //let's register an output folder on the main SourceSet:
+    output.dir(preparedGems, builtBy: 'jrubyPrepare')
+    //it is now a part of the 'main' classpath and will be a part of the jar
+  }
+}
+
+// QUESTION is this the right place to insert this task dependency in the lifecycle?
+// IMPORTANT The TMP or TEMP environment variable must be set for the gem install command to work on Windows
+processResources.dependsOn jrubyPrepare
+
 
 javadoc {
   classpath = sourceSets.main.output + sourceSets.main.compileClasspath + project(':asciidoctorj-test-support').sourceSets.test.output

--- a/build.gradle
+++ b/build.gradle
@@ -185,10 +185,6 @@ subprojects {
 
 }
 
-configure(subprojects.findAll { !it.isDistribution() && it.name != 'asciidoctorj-api' && it.name != 'asciidoctorj-documentation' && it.name != 'asciidoctorj-test-support' && it.name != 'asciidoctorj-arquillian-extension' && !isIntegrationTestProject(it) }) {
-  apply from: rootProject.file('gradle/versioncheck.gradle')
-}
-
 boolean isIntegrationTestProject(def project) {
   project.name in ['asciidoctorj-wildfly-integration-test',
                    'asciidoctorj-springboot-integration-test',
@@ -198,17 +194,9 @@ boolean isIntegrationTestProject(def project) {
 // apply JRuby and sources/javadocs packaging stuff for all subprojects except the distribution
 configure(subprojects.findAll { !it.isDistribution() }) {
 
-  apply plugin: 'com.github.jruby-gradle.base'
   apply from: rootProject.file('gradle/eclipse.gradle')
   apply plugin: 'idea'
 
-  jruby {
-    defaultRepositories false
-  }
-
-  repositories {
-    ruby.gems()
-  }
 
   javadoc {
     // Oracle JDK8 likes to fail the build over spoiled HTML
@@ -224,26 +212,4 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') && ! it.name.
     withSourcesJar()
   }
 
-  jruby {
-    defaultRepositories = false
-    defaultVersion = jrubyVersion
-    // TODO I'd like to be able to customize the name of the gemInstallDir
-  }
-
-  ext {
-    // path to use for the prepared jruby gems
-    preparedGems = new File("$buildDir/preparedGems")
-  }
-
-  sourceSets {
-    main {
-      //let's register an output folder on the main SourceSet:
-      output.dir(preparedGems, builtBy: 'jrubyPrepare')
-      //it is now a part of the 'main' classpath and will be a part of the jar
-    }
-  }
-
-  // QUESTION is this the right place to insert this task dependency in the lifecycle?
-  // IMPORTANT The TMP or TEMP environment variable must be set for the gem install command to work on Windows
-  processResources.dependsOn jrubyPrepare
 }

--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'eclipse'
 
-tasks.eclipse.dependsOn jrubyPrepare
 eclipse {
   classpath {
     defaultOutputDir = file('build/eclipse')

--- a/gradle/versioncheck.gradle
+++ b/gradle/versioncheck.gradle
@@ -22,14 +22,14 @@ task checkVersion() {
 
         String gem_latest_version = getLatestGemVersion(gem_name)
         String javaVersion = latestGemVersionAsJavaVersion(gem_latest_version)
-
         try {
 
-            Version projectVersion = Version.valueOf(version as String)
+            String resolvedVersion = project.configurations.gems.resolvedConfiguration.resolvedArtifacts.find { it.name == gem_name }.moduleVersion.id.version
+            Version projectVersion = Version.valueOf(resolvedVersion as String)
             Version gemJavaVersion = Version.valueOf(javaVersion)
 
             if (projectVersion.lessThan(gemJavaVersion)) {
-                logger.warn "\nWARNING\nVersion mismatch: Current Version: {}, Gem Version: {}\n",version , gem_latest_version
+                logger.warn "\nWARNING\nVersion mismatch: Current Version: {}, Gem Version: {}\n", resolvedVersion , gem_latest_version
             } else {
                 println "up-to-date"
             }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

The versionCheck task does not work properly right now since it compared the version of the last gem to the project version.
Since the versions of AsciidoctorJ no longer align with the version of the Asciidoctor gem and generally have higher numbers now, this task never identifies an outdated version.
This is fixed by looking up the resolved dependency and its version number.

Additionally I made a minor change to the build script to apply the jruby gradle plugin only to the main AsciidoctorJ module and not to all modules anymore.