### PR TITLE
Add Github Actions workflow for building and publishing releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Release
+
+on: workflow_dispatch
+
+env:
+  ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.GPG_KEY_ID }}
+  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
+  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSS_SONATYPE_USERNAME }}
+  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSS_SONATYPE_PASSWORD }}
+
+jobs:
+  release:
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Build
+        run: |
+          unset GEM_PATH GEM_HOME JRUBY_OPTS
+          ./gradlew --no-daemon clean build
+          ./gradlew --no-daemon publishToSonatype closeSonatypeStagingRepository

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Build Improvement::
 * Upgrade to Wildfly 26.0.1 for integration test (#1085)
 * Upgrade to Spring Boot 2.6.5 for integration test (#1085)
 * Fix gem version check task (#1087)
+* Release from Github Actions (#1090)
 
 Documentation::
 


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Build releases on Github actions.

How does it achieve that?

The PR has a new workflow for building releases.
I configured secrets for the signing key and the access token for Sonatype.
For now the idea for this to work is:
1. We update main so that it has a release version
2. We trigger the action manually on github.com or via CLI
3. GH runs a full build and publishes to a Sonatype staging repository and closes it

Going forward I'd like to switch to the way asciidoctor/asciidoctor does it by simply pushing a tag.

Are there any alternative ways to implement this?

Yes, for example build and publish release on tagging.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc