### PR TITLE
v2.5.x: Fixes #1096. Make Cell extend StructuralNode instead of ContentNode.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Cell nodes do not inherit from StructuralNode (#1086) (@rahmanusta)
+
 == 2.5.4 (2022-06-30)
 
 Improvement::

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Cell.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Cell.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.ast;
 
-public interface Cell extends ContentNode {
+public interface Cell extends StructuralNode {
 
     Column getColumn();
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/CellImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/CellImpl.java
@@ -6,7 +6,7 @@ import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Table;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class CellImpl extends ContentNodeImpl implements Cell {
+public class CellImpl extends StructuralNodeImpl implements Cell {
 
     public CellImpl(IRubyObject rubyNode) {
         super(rubyNode);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
@@ -2,6 +2,7 @@ package org.asciidoctor;
 
 import org.asciidoctor.arquillian.api.Unshared;
 import org.asciidoctor.ast.Author;
+import org.asciidoctor.ast.Cell;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.RevisionInfo;
 import org.asciidoctor.ast.Section;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -51,7 +53,12 @@ public class WhenAsciiDocIsLoadedToDocument {
             "\n" +
             "== Section B\n" +
             "\n" +
-            "paragraph";
+            "paragraph\n" +
+            "\n" +
+            "|===\n" +
+            "|A\n" +
+            "|B\n" +
+            "|===";
 
     private static final String ROLE = "[\"quote\", \"author\", \"source\", role=\"famous\"]\n" +
             "____\n" +
@@ -91,6 +98,20 @@ public class WhenAsciiDocIsLoadedToDocument {
 
         Document document = asciidoctor.load(DOCUMENT, new HashMap<>());
         assertThat(document.getDoctitle(), is("Document Title"));
+    }
+
+    @Test
+    public void should_find_all_nodes() {
+        Document document = asciidoctor.load(DOCUMENT, Options.builder().sourcemap(true).build());
+        List<StructuralNode> findBy = document.findBy(new HashMap<>());
+        assertThat(findBy, hasSize(17));
+        List<Cell> tableCells = findBy.stream()
+                .filter(Cell.class::isInstance)
+                .map(Cell.class::cast)
+                .collect(toList());
+        assertThat(tableCells, hasSize(2));
+        assertThat(tableCells.get(0).getSourceLocation().getLineNumber(), is(23));
+        assertThat(tableCells.get(1).getSourceLocation().getLineNumber(), is(24));
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2.5.4
+version=2.5.5-SNAPSHOT
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Similar to #1099 this PR makes org.asciidoctor.ast.Cell extend StructuralNode instead of ContentNode.
This matches also the class hierarchy in Asciidoctor Ruby.
That way, if Document.findBy() returns a Cell in the result list there will no longer be a ClassCastException.

How does it achieve that?



Are there any alternative ways to implement this?

Probably.

Are there any implications of this pull request? Anything a user must know?

I'd like to argue that this is an almost fully compatible change that doesn't even break binary compatibility: https://docs.oracle.com/javase/specs/jls/se7/html/jls-13.html
Someone might have been able to write code that would now break (`assert !StructuralNode.class.isInstance(cell)`), but that can be said for any bugfix.

Please note that this PR is for the v2.5.x maintenance branch!!!

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1096  


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc