### PR TITLE
Fixes #1105. Avoid throwing exception in CLI when reading input from …

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ Improvement::
 Bug Fixes::
 
 * Cell nodes do not inherit from StructuralNode (#1086) (@rahmanusta)
+* Avoid throwing an exception when using AsciidoctorJ CLI and reading input from stdin (#1105) (@AlexCzar)
 
 Build Improvement::
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -149,6 +149,7 @@ public class AsciidoctorInvoker {
 
         if (inputFiles.size() == 1 && "-".equals(inputFiles.get(0).getName())) {
             asciidoctor.convert(readInputFromStdIn(), options);
+            return;
         }
 
         findInvalidInputFile(inputFiles)


### PR DESCRIPTION
…stdin

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Avoid that the AsciidoctorJ cli throws an exception when reading input from stdin:
```
# echo Test|asciidoctorj - -o /dev/null
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
2022-08-20T16:55:03.084+02:00 [main] WARN FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem
Pass '--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED' to enable.
asciidoctor: FAILED: input file(s) '/Users/robertpanzer/dev/asciidoctorj/-' missing or cannot be read
Exception in thread "main" java.lang.IllegalArgumentException: asciidoctor: FAILED: input file(s) '/Users/robertpanzer/dev/asciidoctorj/-' missing or cannot be read
	at org.asciidoctor.jruby.cli.AsciidoctorInvoker.lambda$convertInput$0(AsciidoctorInvoker.java:161)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at org.asciidoctor.jruby.cli.AsciidoctorInvoker.convertInput(AsciidoctorInvoker.java:155)
	at org.asciidoctor.jruby.cli.AsciidoctorInvoker.invoke(AsciidoctorInvoker.java:73)
	at org.asciidoctor.jruby.cli.AsciidoctorInvoker.main(AsciidoctorInvoker.java:198)
# echo $?
1
```

How does it achieve that?

Change the implementation to return early after converting the input instead of trying interpret the command line arguments as file names.

Are there any alternative ways to implement this?

I can't think of any.

Are there any implications of this pull request? Anything a user must know?

No.

## Issue

Fixes #1106
