### PR TITLE
Add --failure-level command line option to force non-zero exit code (fixes #1113)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ Improvement::
 
 * BREAKING: Fix Macro APIs to take StructuralNodes and return Phrase- or StructuralNodes. (#1084)
 * BREAKING: Allow Preprocessor extensions to create new Readers and replace the original Reader. (#1081)
+* Add command line option --failure-level to force non-zero exit code from AsciidoctorJ CLI if specified logging level is reached. (#1114)
 * Upgrade to asciidoctorj-pdf 2.3.0 (#1109)
 * Upgrade to JRuby 9.3.7.0 (#1109)
 * Upgrade to tilt 2.0.11 (#1109)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorCliOptions.java
@@ -2,6 +2,7 @@ package org.asciidoctor.jruby.cli;
 
 import com.beust.jcommander.Parameter;
 import org.asciidoctor.*;
+import org.asciidoctor.log.Severity;
 
 import java.io.File;
 import java.util.*;
@@ -95,6 +96,9 @@ public class AsciidoctorCliOptions {
     @Parameter(names = {QUIET, "--quiet"}, description = "suppress warnings (default: false)")
     private boolean quiet = false;
 
+    @Parameter(names = {"--failure-level"}, converter = SeverityConverter.class, description = "set minimum log level that yields a non-zero exit code: [info, warning, error, fatal] (default: fatal) ")
+    private Severity failureLevel = Severity.FATAL;
+
     @Parameter(names = {REQUIRE, "--require"}, description = "require the specified library before executing the processor (using require)")
     private List<String> require;
 
@@ -110,6 +114,8 @@ public class AsciidoctorCliOptions {
     public boolean isQuiet() {
         return quiet;
     }
+
+    public Severity getFailureLevel() { return failureLevel; }
 
     public boolean isRequire() {
         return this.require != null && this.require.size() > 0;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -58,6 +58,9 @@ public class AsciidoctorInvoker {
                                 + "' missing or cannot be read");
             }
 
+            MaxSeverityLogHandler maxSeverityLogHandler = new MaxSeverityLogHandler();
+            asciidoctor.registerLogHandler(maxSeverityLogHandler);
+
             Options options = asciidoctorCliOptions.parse();
 
             if (asciidoctorCliOptions.isRequire()) {
@@ -72,7 +75,7 @@ public class AsciidoctorInvoker {
 
             convertInput(asciidoctor, options, inputFiles);
 
-            if (asciidoctorCliOptions.getFailureLevel().compareTo(asciidoctor.getMaxSeverity()) <= 0) {
+            if (asciidoctorCliOptions.getFailureLevel().compareTo(maxSeverityLogHandler.getMaxSeverity()) <= 0) {
                 return 1;
             }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/MaxSeverityLogHandler.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/MaxSeverityLogHandler.java
@@ -1,0 +1,20 @@
+package org.asciidoctor.jruby.cli;
+
+import org.asciidoctor.log.LogHandler;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
+
+public class MaxSeverityLogHandler implements LogHandler {
+    private Severity maxSeverity = Severity.DEBUG;
+
+    @Override
+    public void log(LogRecord logRecord) {
+        if (this.maxSeverity.compareTo(logRecord.getSeverity()) < 0) {
+            this.maxSeverity = logRecord.getSeverity();
+        }
+    }
+
+    public Severity getMaxSeverity() {
+        return this.maxSeverity;
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/SeverityConverter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/SeverityConverter.java
@@ -1,12 +1,17 @@
 package org.asciidoctor.jruby.cli;
 
-import com.beust.jcommander.IStringConverter;
-import org.asciidoctor.SafeMode;
+import com.beust.jcommander.converters.EnumConverter;
 import org.asciidoctor.log.Severity;
 
-public class SeverityConverter implements IStringConverter<Severity> {
+public class SeverityConverter extends EnumConverter<Severity> {
+
+    public SeverityConverter() {
+        super("--failure-level", Severity.class);
+    }
 
     @Override
-    public Severity convert(String argument) { return Severity.valueOf(argument.toUpperCase()); }
+    public Severity convert(String argument) {
+        return super.convert(argument.toUpperCase());
+    }
 
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/SeverityConverter.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/SeverityConverter.java
@@ -1,0 +1,12 @@
+package org.asciidoctor.jruby.cli;
+
+import com.beust.jcommander.IStringConverter;
+import org.asciidoctor.SafeMode;
+import org.asciidoctor.log.Severity;
+
+public class SeverityConverter implements IStringConverter<Severity> {
+
+    @Override
+    public Severity convert(String argument) { return Severity.valueOf(argument.toUpperCase()); }
+
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -22,7 +22,6 @@ import org.asciidoctor.jruby.log.internal.LogHandlerRegistryExecutor;
 import org.asciidoctor.jruby.syntaxhighlighter.internal.SyntaxHighlighterRegistryExecutor;
 import org.asciidoctor.log.LogHandler;
 import org.asciidoctor.log.LogRecord;
-import org.asciidoctor.log.Severity;
 import org.asciidoctor.syntaxhighlighter.SyntaxHighlighterRegistry;
 import org.jruby.*;
 import org.jruby.exceptions.RaiseException;
@@ -46,8 +45,6 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
     private RubyClass extensionGroupClass;
 
     private List<LogHandler> logHandlers = new ArrayList<>();
-
-    private Severity maxSeverity = Severity.DEBUG;
 
     public JRubyAsciidoctor() {
         this(createRubyRuntime(Collections.singletonMap(GEM_PATH, null), new ArrayList<>(), null));
@@ -510,15 +507,8 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     @Override
     public void log(LogRecord logRecord) {
-        if (this.maxSeverity.compareTo(logRecord.getSeverity()) < 0) {
-            this.maxSeverity = logRecord.getSeverity();
-        }
         for (LogHandler logHandler : logHandlers) {
             logHandler.log(logRecord);
         }
-    }
-
-    public Severity getMaxSeverity() {
-        return this.maxSeverity;
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -22,6 +22,7 @@ import org.asciidoctor.jruby.log.internal.LogHandlerRegistryExecutor;
 import org.asciidoctor.jruby.syntaxhighlighter.internal.SyntaxHighlighterRegistryExecutor;
 import org.asciidoctor.log.LogHandler;
 import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
 import org.asciidoctor.syntaxhighlighter.SyntaxHighlighterRegistry;
 import org.jruby.*;
 import org.jruby.exceptions.RaiseException;
@@ -45,6 +46,8 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
     private RubyClass extensionGroupClass;
 
     private List<LogHandler> logHandlers = new ArrayList<>();
+
+    private Severity maxSeverity = Severity.DEBUG;
 
     public JRubyAsciidoctor() {
         this(createRubyRuntime(Collections.singletonMap(GEM_PATH, null), new ArrayList<>(), null));
@@ -507,8 +510,15 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     @Override
     public void log(LogRecord logRecord) {
+        if (this.maxSeverity.compareTo(logRecord.getSeverity()) < 0) {
+            this.maxSeverity = logRecord.getSeverity();
+        }
         for (LogHandler logHandler : logHandlers) {
             logHandler.log(logRecord);
         }
+    }
+
+    public Severity getMaxSeverity() {
+        return this.maxSeverity;
     }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -250,6 +250,22 @@ public class WhenAsciidoctorIsCalledUsingCli {
     }
 
     @Test
+    public void should_exit_with_zero_status_even_if_errors_were_logged() {
+        File inputFile = classpath.getResource("brokeninclude.asciidoc");
+        String inputPath = inputFile.getPath().substring(pwd.length() + 1);
+        int status = new AsciidoctorInvoker().invoke(inputPath);
+        assertThat(status, is(0));
+    }
+
+    @Test
+    public void should_exit_with_nonzero_status_if_logged_severity_was_at_least_failure_level() {
+        File inputFile = classpath.getResource("brokeninclude.asciidoc");
+        String inputPath = inputFile.getPath().substring(pwd.length() + 1);
+        int status = new AsciidoctorInvoker().invoke("--failure-level", "warn", inputPath);
+        assertThat(status, is(1));
+    }
+
+    @Test
     public void with_absolute_path_file_should_be_rendered() {
 
         File inputFile = classpath.getResource("rendersample.asciidoc");


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [X] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

The Ruby asciidoc CLI has option --failure-level which forces the CLI to exit with non-zero status code if the specified logging level (severity) is reached. See: https://github.com/asciidoctor/asciidoctor/pull/2674, https://github.com/asciidoctor/asciidoctor/issues/2003, https://github.com/asciidoctor/asciidoctor/issues/854

This PR implements the same functionality for AsciidoctorJ, pretty much the same way as the Ruby code (keeps track of highest seen log message severity, and checks that the end).

The default value is the same as in Ruby - only "fatal" severity causes non-zero exit code - which probably won't break many things (but someone running AsciidoctorJ as part of a CI build would probably want to fail on "error" severity as well, maybe even "warn"). 

## Issue

Fixes #1113