### PR TITLE
Expose Section's sectnum property

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,7 @@ Improvement::
 * Upgrade to JRuby 9.3.8.0 (#1116)
 * Upgrade to tilt 2.0.11 (#1109)
 * Upgrade to asciimath 2.0.4 (#1109)
+* Expose `sectnum` property in Section interface (#1121)
 
 Bug Fixes::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Section.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Section.java
@@ -74,4 +74,24 @@ public interface Section extends StructuralNode {
      */
     boolean isNumbered();
 
+
+    /**
+     * Get the section number for the current Section.
+     * <p>
+     * The section number is a dot-separated String that uniquely describes the position of this
+     * Section in the document. Each entry represents a level of nesting. The value of each entry is
+     * the 1-based outline number of the Section amongst its numbered sibling Sections.
+     */
+    String getSectnum();
+
+    /**
+     * Get the section number for the current Section.
+     * <p>
+     * The section number is a dot-separated String that uniquely describes the position of this
+     * Section in the document. Each entry represents a level of nesting. The value of each entry is
+     * the 1-based outline number of the Section amongst its numbered sibling Sections.
+     *
+     * @param delimiter the delimiter to separate the number for each level
+     */
+    String getSectnum(String delimiter);
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/SectionImpl.java
@@ -70,4 +70,14 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
         return getBoolean("numbered");
     }
 
+    @Override
+    public String getSectnum() {
+        return getString("sectnum");
+    }
+
+    @Override
+    public String getSectnum(String delimiter) {
+        return getString("sectnum", new Object[]{delimiter});
+    }
+
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/SectionImplTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/SectionImplTest.java
@@ -1,0 +1,97 @@
+package org.asciidoctor.jruby.ast.impl;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.Section;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SectionImplTest {
+
+    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+
+    @Test
+    public void should_return_valid_sectnum_when_sectionNumbers_are_enabled() {
+        final String source = sectionsSample();
+
+        Document document = loadDocument(source, true);
+
+        Section node1 = findSectionNode(document, 1);
+        assertThat(node1.getSectnum()).isEqualTo("1.");
+        assertThat(node1.isNumbered()).isTrue();
+
+        Section node2 = findSectionNode(document, 2);
+        assertThat(node2.getSectnum()).isEqualTo("1.1.");
+        assertThat(node2.isNumbered()).isTrue();
+    }
+
+    @Test
+    public void should_return_invalid_sectnum_when_sectionNumbers_are_not_enabled() {
+        final String source = sectionsSample();
+
+        Document document = loadDocument(source, false);
+
+        Section node1 = findSectionNode(document, 1);
+        assertThat(node1.getSectnum()).isEqualTo(".");
+        assertThat(node1.isNumbered()).isFalse();
+
+        Section node2 = findSectionNode(document, 2);
+        assertThat(node2.getSectnum()).isEqualTo("..");
+        assertThat(node2.isNumbered()).isFalse();
+    }
+
+    @Test
+    public void should_return_sectnum_with_custom_delimiter_when_sectionNumbers_are_enabled() {
+        final String source = sectionsSample();
+
+        Document document = loadDocument(source, true);
+
+        Section node1 = findSectionNode(document, 1);
+        assertThat(node1.getSectnum("_")).isEqualTo("1_");
+
+        Section node2 = findSectionNode(document, 2);
+        assertThat(node2.getSectnum("*")).isEqualTo("1*1*");
+    }
+
+    @Test
+    public void should_return_sectnum_with_custom_delimiter_when_sectionNumbers_are_not_enabled() {
+        final String source = sectionsSample();
+
+        Document document = loadDocument(source, false);
+
+        Section node1 = findSectionNode(document, 1);
+        assertThat(node1.getSectnum("_")).isEqualTo("_");
+
+        Section node2 = findSectionNode(document, 2);
+        assertThat(node2.getSectnum("*")).isEqualTo("**");
+    }
+
+    private Document loadDocument(String source, boolean sectionNumbers) {
+        Attributes attributes = Attributes.builder().sectionNumbers(sectionNumbers).build();
+        Options options = Options.builder().attributes(attributes).build();
+        Document document = asciidoctor.load(source, options);
+        return document;
+    }
+
+    private Section findSectionNode(Document document, int level) {
+        return (Section) document.findBy(Collections.singletonMap("context", ":section"))
+                .stream()
+                .filter(n -> n.getLevel() == level)
+                .findFirst()
+                .get();
+    }
+
+    static String sectionsSample() {
+        return "= Document Title\n\n" +
+                "== Section A\n\n" +
+                "Section A paragraph.\n\n" +
+                "=== Section A Subsection\n\n" +
+                "Section A 'subsection' paragraph.\n\n";
+    }
+}


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Exposes [sectnum](https://github.com/asciidoctor/asciidoctor/blob/4bab183b9f3fad538f86071b2106f3b8185d3832/lib/asciidoctor/section.rb#L119) to users using the API for extensions, converters, etc.

This property is required to easily obtain the section numbering aligned with other Asciidoctor attributes. The alternative is reimplementing all the logic of level counting, secnumlevel, separators formating, etc.

How does it achieve that?

Adds 2 new methods:
* `String getSectnum()`
* `String getSectnum(String delimiter)`

to the Section interface, those simply call the Asciidoctor Ruby property (I assume property is the right name, it's a method).

Are there any alternative ways to implement this?

While working on a converter I could not find it. `index` returns 0, and there's a lot of reimplementation to do to obtain a similar result.

Right now I am using internals `String sectnum = ((SectionImpl) node).getString("sectnum")`, which is not ideal.

Are there any implications of this pull request? Anything a user must know?

1. The property in Asciidoctor is well documented as public, I am assuming this is stable and can be used, but could be wrong. @mojavelinux can you confirm? :bow: 
2. I am keeping the default behauviour when `sectnums` is not set, that is, the delimiters without numbers is returned (see test `should_return_invalid_sectnum_when_sectionNumbers_are_not_enabled`). Is odd and I am tempted to add a check and return empty string, but maybe this should be fixed upstream? //cc @mojavelinux 
3. I am also not adding support to pass the `append` parameter, to keep things simple, and also adding a suffix is something that API users can just do just outside of the method.

## Issue

n/a


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc