### PR TITLE
Fix upstream test

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -66,7 +66,7 @@ jobs:
           gradlew.bat -i -S check
   test-asciidoctor-upstream:
     name: Test Asciidoctor Upstream
-    needs: 
+    needs:
       - build
       - build-windows
     strategy:
@@ -80,10 +80,10 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,7 @@ Bug Fixes::
 Build Improvement::
 
 * Upgrade build to Gradle 7.5.1 (#1109)
+* Fix upstream tests forcing SNAPSHOT on Asciidoctor gem installation (#1123) (@abelsromero)
 
 == 2.5.4 (2022-06-30)
 

--- a/ci/test-asciidoctor-upstream.sh
+++ b/ci/test-asciidoctor-upstream.sh
@@ -20,15 +20,16 @@ wget --quiet -O $SRC_DIR.zip https://github.com/asciidoctor/asciidoctor/archive/
 unzip -q $SRC_DIR.zip
 cp ../../ci/asciidoctor-gem-installer.pom $SRC_DIR/pom.xml
 cd $SRC_DIR
-readonly ASCIIDOCTOR_VERSION=`grep 'VERSION' ./lib/asciidoctor/version.rb | sed "s/.*'\(.*\)'.*/\1/" | sed "s/[.]dev$/.dev-SNAPSHOT/"`
+# force SNAPSHOT trailing to keep always consistency, gem-maven-plugin adds it depending on version format, breaking the build
+readonly ASCIIDOCTOR_VERSION="$(grep 'VERSION' ./lib/asciidoctor/version.rb | sed "s/.*'\(.*\)'.*/\1/" | sed "s/[.]dev$/.dev-SNAPSHOT/")-SNAPSHOT"
 # we don't use sed -i here for compatibility with OSX
 sed "s;<version></version>;<version>$ASCIIDOCTOR_VERSION</version>;" pom.xml > pom.xml.sedtmp && \
   mv -f pom.xml.sedtmp pom.xml
 
 # we override the jruby version here with one supported by java9, additionally java9 needs some add-opens arguments that need to be ignored on older jvms
-mvn install -B --no-transfer-progress -Dgemspec=asciidoctor.gemspec -Djruby.version=9.2.17.0 -Djruby.jvmargs="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util.zip=ALL-UNNAMED"
+mvn install -B --no-transfer-progress -Dgemspec="asciidoctor.gemspec" -Djruby.version=9.2.17.0 -Djruby.jvmargs="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util.zip=ALL-UNNAMED"
 popd
 
 ## Test against installed gem
-./gradlew -S -Pskip.signing -PasciidoctorGemVersion=$ASCIIDOCTOR_VERSION -PuseMavenLocal=true check
+./gradlew --no-daemon -S -Pskip.signing -PasciidoctorGemVersion="$ASCIIDOCTOR_VERSION" -PuseMavenLocal=true check
 exit $?


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Fix upstream tests.

How does it achieve that?

Force "-SNAPSHOT" suffix to upstream version
to install gem consistently.
gem-maven-plugin appends it when the gem version
is not strictly semver installing a gem with "-SNAPSHOT"
in the version but not in the maven repo path.

Are there any alternative ways to implement this?

Tried a few things as mentioned here https://github.com/asciidoctor/asciidoctorj/pull/1121#issuecomment-1273907410, option 3 did not work in CI, and this seemed to me the more consistent. We get the sama version format and install path always.

I don't discard spending some extra time with gem-maven-plugin but this depends on time :$

Are there any implications of this pull request? Anything a user must know?

No

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc