### PR TITLE
Replace use of deprecated 'numbered' attribute by 'sectnums'

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,10 @@ Build Improvement::
 * Upgrade build to Gradle 7.5.1 (#1109)
 * Fix upstream tests forcing SNAPSHOT on Asciidoctor gem installation (#1123) (@abelsromero)
 
+Build / Infrastructure::
+
+* Replace use of deprecated 'numbered' attribute by 'sectnums' (#1123) (@abelsromero)
+
 == 2.5.4 (2022-06-30)
 
 Improvement::

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
@@ -38,7 +38,7 @@ public class Attributes {
     public static final String ICONFONT_NAME = "iconfont-name";
     public static final String ICONS_DIR = "iconsdir";
     public static final String DATA_URI = "data-uri";
-    public static final String SECTION_NUMBERS = "numbered";
+    public static final String SECTION_NUMBERS = "sectnums";
     public static final String IMAGE_ICONS = "";
     public static final String FONT_ICONS = "font";
     public static final String LINK_ATTRS = "linkattrs";
@@ -541,7 +541,7 @@ public class Attributes {
     }
 
     /**
-     * auto-number section titles in the HTML backend
+     * auto-number section titles.
      * 
      * @param sectionNumbers
      */
@@ -596,9 +596,9 @@ public class Attributes {
     /**
      * Sets attributes in string form. An example of a valid string would be:
      * 
-     * 'toc numbered source-highlighter=coderay'
+     * 'toc sectnums source-highlighter=coderay'
      * 
-     * where you are adding three attributes: toc, numbered and source-highlighter with value coderay.
+     * where you are adding three attributes: toc, sectnums and source-highlighter with value coderay.
      * 
      * @param attributes
      *            in string format.
@@ -612,9 +612,9 @@ public class Attributes {
     /**
      * Sets attributes in array form. An example of a valid array would be:
      * 
-     * '['toc', 'numbered']'
+     * '['toc', 'sectnums']'
      * 
-     * where you are adding three attributes: toc and numbered.
+     * where you are adding two attributes: toc and sectnums.
      * 
      * @param attributes
      *            in array format.

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/AttributesBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/AttributesBuilder.java
@@ -435,10 +435,10 @@ public class AttributesBuilder {
 	}
 
 	/**
-	 * Auto-number section titles in the HTML backend.
+	 * Auto-number section titles.
 	 * 
 	 * @param sectionNumbers
-	 *            true if numbers should be autonumbered, false otherwise.
+	 *            true if numbers should be auto-numbered, false otherwise.
 	 * @return this instance.
 	 */
 	public AttributesBuilder sectionNumbers(boolean sectionNumbers) {
@@ -573,9 +573,9 @@ public class AttributesBuilder {
 	/**
 	 * Sets attributes in string form. An example of a valid string would be:
 	 * 
-	 * 'toc numbered source-highlighter=coderay'
+	 * 'toc sectnums source-highlighter=coderay'
 	 * 
-	 * where you are adding three attributes: toc, numbered and
+	 * where you are adding three attributes: toc, sectnums and
 	 * source-highlighter with value coderay.
 	 * 
 	 * @param attributes
@@ -591,9 +591,9 @@ public class AttributesBuilder {
 	/**
 	 * Sets attributes in array form. An example of a valid array would be:
 	 * 
-	 * '['toc', 'numbered']'
+	 * '['toc', 'sectnums']'
 	 * 
-	 * where you are adding three attributes: toc and numbered.
+	 * where you are adding two attributes: toc and sectnums.
 	 * 
 	 * @param attributes
 	 *            in array format.

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorCliOptions.java
@@ -60,7 +60,7 @@ public class AsciidoctorCliOptions {
     @Parameter(names = {NO_HEADER_FOOTER, "--no-header-footer"}, description = "suppress output of header and footer (default: false)")
     private boolean noHeaderFooter = false;
 
-    @Parameter(names = {SECTION_NUMBERS, "--section-numbers"}, description = "auto-number section titles in the HTML backend; disabled by default")
+    @Parameter(names = {SECTION_NUMBERS, "--section-numbers"}, description = "auto-number section titles; disabled by default")
     private boolean sectionNumbers = false;
 
     @Parameter(names = {ERUBY, "--eruby"}, description = "specify eRuby implementation to render built-in templates: [erb, erubis] (default: erb)")

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -513,7 +513,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void setting_toc_attribute_and_numbered_in_string_form_table_of_contents_should_be_generated() throws IOException {
 
-        Attributes attributes = attributes("toc numbered").get();
+        Attributes attributes = attributes("toc sectnums").get();
         Options options = options().inPlace(false).toDir(testFolder.getRoot()).safe(SafeMode.UNSAFE).attributes(attributes).get();
 
         asciidoctor.convertFile(classpath.getResource("tocsample.asciidoc"), options);
@@ -530,8 +530,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void setting_toc_attribute_and_numbered_in_array_form_table_of_contents_should_be_generated() throws IOException {
 
-        Attributes attributes = attributes(new String[] { "toc", "numbered" })
-                .get();
+        Attributes attributes = attributes(new String[] { "toc", "sectnums" }).get();
         Options options = options().inPlace(false).toDir(testFolder.getRoot()).safe(SafeMode.UNSAFE).attributes(attributes).get();
 
        asciidoctor.convertFile(classpath.getResource("tocsample.asciidoc"), options);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorAPICallIsCalled.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorAPICallIsCalled.java
@@ -1,9 +1,7 @@
 package org.asciidoctor.jruby.cli;
 
 import com.beust.jcommander.JCommander;
-import org.asciidoctor.AttributesBuilder;
-import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.SafeMode;
+import org.asciidoctor.*;
 import org.asciidoctor.jruby.internal.AsciidoctorUtils;
 import org.junit.Test;
 
@@ -21,13 +19,17 @@ public class WhenAsciidoctorAPICallIsCalled {
     @Test
     public void api_parameters_should_be_transformed_to_cli_command() {
 
-        AttributesBuilder attributesBuilder = AttributesBuilder.attributes()
-                .attribute("myAtribute", "myValue").sectionNumbers(true)
-                .copyCss(false);
+        Attributes attributes = Attributes.builder()
+                .attribute("myAtribute", "myValue")
+                .sectionNumbers(true)
+                .copyCss(false)
+                .build();
 
-        OptionsBuilder optionsBuilder = OptionsBuilder.options()
-                .backend("docbook").templateDirs(new File("a"), new File("b"))
-                .safe(SafeMode.UNSAFE).attributes(attributesBuilder.get());
+        OptionsBuilder optionsBuilder = Options.builder()
+                .backend("docbook")
+                .templateDirs(new File("a"), new File("b"))
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes);
 
         List<String> command = AsciidoctorUtils.toAsciidoctorCommand(
                 optionsBuilder.asMap(), "file.adoc");
@@ -45,8 +47,8 @@ public class WhenAsciidoctorAPICallIsCalled {
         assertThat(asciidoctorCliOptions.getBackend(), is("docbook"));
         assertThat(asciidoctorCliOptions.getParameters(), containsInAnyOrder("file.adoc"));
 
-        assertThat(asciidoctorCliOptions.getAttributes(), hasEntry("myAtribute", (Object) "myValue"));
-        assertThat(asciidoctorCliOptions.getAttributes(), hasKey("numbered"));
+        assertThat(asciidoctorCliOptions.getAttributes(), hasEntry("myAtribute", "myValue"));
+        assertThat(asciidoctorCliOptions.getAttributes(), hasKey("sectnums"));
         assertThat(asciidoctorCliOptions.getAttributes(), hasKey("copycss!"));
 
     }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement
- [x] Other :point_right: maintenance chore

## Description

What is the goal of this pull request?

Replace use of deprecated attribute `numbered` by recommended value `sectnums`.

How does it achieve that?

* Replaces constant https://github.com/asciidoctor/asciidoctorj/blob/2a57067e4ab64cc149d64d6a0c98913f1eba914f/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java#L41
* Updates tests and JavaDocs when necessary
* No extra tests have been added. There are already valid ones present.

Are there any alternative ways to implement this?

No

Are there any implications of this pull request? Anything a user must know?

Only for users comparing the attibute with the internal value will notice. I personally don't consider that a breaking change since constants should be used to replace manually set values and the internal value should not be checked.
* Theres no impact for users using the constant or AttributesBuilder normally.
* Conversions setting "numbered" manually will still work since is still supported in the Ruby core.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1120


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc