### PR TITLE
Fix upstream build.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,6 +34,7 @@ Build Improvement::
 
 * Upgrade build to Gradle 7.5.1 (#1109)
 * Fix upstream tests forcing SNAPSHOT on Asciidoctor gem installation (#1123) (@abelsromero)
+* Fix upstream build removing the explicit plugin repository (#1131)
 
 Build / Infrastructure::
 

--- a/ci/asciidoctor-gem-installer.pom
+++ b/ci/asciidoctor-gem-installer.pom
@@ -15,12 +15,6 @@
             <url>http://rubygems-proxy.torquebox.org/releases</url>
         </repository>
     </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>rubygems-releases</id>
-            <url>https://rubygems-proxy.torquebox.org/releases</url>
-        </pluginRepository>
-    </pluginRepositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
The upstream build is currently broken.
This PR tries to fix it again.

How does it achieve that?

The current configuration tries to fetch the jruby maven plugin from https://rubygems-proxy.torquebox.org/releases. This seems to be hosting some Russian gambling site now 🤪
However, it should be possible to download this plugin simply from Maven central.
Therefore, this PR removes the configuration of the plugin repository.

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc