### PR TITLE
Expose Document's source and source_lines properties

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,8 @@ Improvement::
 * Upgrade to tilt 2.0.11 (#1109)
 * Upgrade to asciimath 2.0.4 (#1109)
 * Expose `sectnum` property in Section interface (#1121)
+* Replace use of deprecated 'numbered' attribute by 'sectnums' (#1123) (@abelsromero)
+* Expose `source` and `source_lines` use of deprecated 'numbered' in Document interface (#1145) (@abelsromero)
 
 Bug Fixes::
 
@@ -38,10 +40,6 @@ Build Improvement::
 * Run tests on Java 19 (#1563)
 * Fix upstream tests forcing SNAPSHOT on Asciidoctor gem installation (#1123) (@abelsromero)
 * Fix upstream build removing the explicit plugin repository (#1131)
-
-Build / Infrastructure::
-
-* Replace use of deprecated 'numbered' attribute by 'sectnums' (#1123) (@abelsromero)
 
 == 2.5.4 (2022-06-30)
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Document.java
@@ -34,6 +34,21 @@ public interface Document extends StructuralNode {
     List<Author> getAuthors();
 
     /**
+     * Make the raw source for the Document available.
+     * Trailing white characters (spaces, line breaks, etc.) are removed.
+     *
+     * @return raw content as String
+     */
+    String getSource();
+
+    /**
+     * Make the raw source lines for the Document available.
+     *
+     * @return raw content as List<String>
+     */
+    List<String> getSourceLines();
+
+    /**
      * @return basebackend attribute value
      */
     boolean isBasebackend(String backend);

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DocumentImpl.java
@@ -17,6 +17,16 @@ public class DocumentImpl extends StructuralNodeImpl implements Document {
     }
 
     @Override
+    public String getSource() {
+        return getString("source");
+    }
+
+    @Override
+    public List<String> getSourceLines() {
+        return getList("source_lines", String.class);
+    }
+
+    @Override
     public boolean isBasebackend(String backend) {
         return getBoolean("basebackend?", backend);
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -11,7 +11,6 @@ import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.jruby.AsciidoctorJRuby;
 import org.asciidoctor.jruby.DirectoryWalker;
-import org.asciidoctor.jruby.ast.impl.AuthorImpl;
 import org.asciidoctor.jruby.ast.impl.DocumentHeaderImpl;
 import org.asciidoctor.jruby.ast.impl.NodeConverter;
 import org.asciidoctor.jruby.converter.internal.ConverterRegistryExecutor;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyObjectWrapper.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyObjectWrapper.java
@@ -86,7 +86,7 @@ public class RubyObjectWrapper {
         if (result instanceof RubyNil) {
             return 0;
         } else {
-            return (int) ((RubyNumeric) result).getIntValue();
+            return ((RubyNumeric) result).getIntValue();
         }
     }
 
@@ -100,7 +100,7 @@ public class RubyObjectWrapper {
         if (result instanceof RubyNil) {
             return null;
         } else {
-            List<T> ret = new ArrayList<T>();
+            List<T> ret = new ArrayList<>();
             RubyArray array = (RubyArray) result;
             for (int i = 0; i < array.size(); i++) {
                 ret.add(RubyUtils.rubyToJava(runtime, array.at(RubyFixnum.newFixnum(runtime, i)), elementClass));
@@ -160,7 +160,7 @@ public class RubyObjectWrapper {
     }
 
     public <T> T toJava(IRubyObject rubyObject, Class<T> targetClass) {
-        return (T) JavaEmbedUtils.rubyToJava(runtime, rubyObject, targetClass);
+        return JavaEmbedUtils.rubyToJava(runtime, rubyObject, targetClass);
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/SectionImplTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/SectionImplTest.java
@@ -75,8 +75,7 @@ public class SectionImplTest {
     private Document loadDocument(String source, boolean sectionNumbers) {
         Attributes attributes = Attributes.builder().sectionNumbers(sectionNumbers).build();
         Options options = Options.builder().attributes(attributes).build();
-        Document document = asciidoctor.load(source, options);
-        return document;
+        return asciidoctor.load(source, options);
     }
 
     private Section findSectionNode(Document document, int level) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/WhenDocumentIsLoaded.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/WhenDocumentIsLoaded.java
@@ -1,0 +1,119 @@
+package org.asciidoctor.jruby.ast.impl;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
+import org.asciidoctor.ast.Document;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WhenDocumentIsLoaded {
+
+    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+    @Test
+    public void should_return_empty_when_document_is_empty() {
+        assertEmptySources(loadDocument(""));
+    }
+
+    private static void assertEmptySources(Document document) {
+        String source = document.getSource();
+        assertThat(source).isEmpty();
+        List<String> sourceLines = document.getSourceLines();
+        assertThat(sourceLines).isEmpty();
+    }
+
+    @Test
+    public void should_return_source_and_source_lines() {
+        final String asciidoc = asciidocSample();
+
+        Document document = loadDocument(asciidoc);
+
+        String source = document.getSource();
+        assertThat(source).isEqualTo(asciidoc.trim());
+        List<String> sourceLines = document.getSourceLines();
+        assertThat(sourceLines)
+                .containsExactly("= Document Title",
+                        "",
+                        "== Section A",
+                        "",
+                        "Section A paragraph.",
+                        "",
+                        "=== Section A Subsection",
+                        "",
+                        "Section A 'subsection' paragraph.");
+    }
+
+    @Test
+    public void should_return_source_and_source_lines_without_trailing() {
+        final String asciidoc = "= Document Title\n\n" +
+                "== Section\n\n" +
+                "Hello\t  \n";
+
+        Document document = loadDocument(asciidoc);
+
+        String source = document.getSource();
+        assertThat(source).isEqualTo("= Document Title\n\n== Section\n\nHello");
+        List<String> sourceLines = document.getSourceLines();
+        assertThat(sourceLines)
+                .containsExactly("= Document Title",
+                        "",
+                        "== Section",
+                        "",
+                        "Hello");
+    }
+
+    @Test
+    public void should_return_source_and_source_lines_without_resolving_attributes() {
+        final String asciidoc = "= Document Title\n" +
+                ":an-attribute: a-value\n\n" +
+                "This is {an-attribute}";
+
+        Document document = loadDocument(asciidoc);
+
+        String source = document.getSource();
+        assertThat(source).isEqualTo("= Document Title\n:an-attribute: a-value\n\nThis is {an-attribute}");
+        List<String> sourceLines = document.getSourceLines();
+        assertThat(sourceLines)
+                .containsExactly("= Document Title",
+                        ":an-attribute: a-value",
+                        "",
+                        "This is {an-attribute}");
+    }
+
+    @Test
+    public void should_return_source_and_source_lines_without_resolving_includes() {
+        final String asciidoc = "= Document Title\n\n" +
+                "== Section\n\n" +
+                "include::partial.adoc[]";
+
+        Document document = loadDocument(asciidoc);
+
+        String source = document.getSource();
+        assertThat(source).isEqualTo("= Document Title\n\n== Section\n\ninclude::partial.adoc[]");
+        List<String> sourceLines = document.getSourceLines();
+        assertThat(sourceLines)
+                .containsExactly("= Document Title",
+                        "",
+                        "== Section",
+                        "",
+                        "include::partial.adoc[]");
+    }
+
+    private Document loadDocument(String source) {
+        Attributes attributes = Attributes.builder().build();
+        Options options = Options.builder().attributes(attributes).build();
+        return asciidoctor.load(source, options);
+    }
+
+    static String asciidocSample() {
+        return "= Document Title\n\n" +
+                "== Section A\n\n" +
+                "Section A paragraph.\n\n" +
+                "=== Section A Subsection\n\n" +
+                "Section A 'subsection' paragraph.\n\n";
+    }
+}


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Expose Document's `source` and `source_lines` properties.
This is required to be able to use other asciidoctor components like [asciidoctor-reducer](https://github.com/asciidoctor/asciidoctor-reducer).

How does it achieve that?
Using already present AsciidoctorJ APIs and practices, nothing special.

Are there any alternative ways to implement this?
Not that I know.

Are there any implications of this pull request? Anything a user must know?
No

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1143 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc