### PR TITLE
Set Java11 as minimal version

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,7 +18,6 @@ jobs:
       max-parallel: 4
       matrix:
         java:
-          - '8'
           - '11'
           - '17'
           - '19'
@@ -26,8 +25,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         exclude:
-        - os: macos-latest
-          java: '8'
         - os: macos-latest
           java: '19'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -24,9 +24,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-        exclude:
-        - os: macos-latest
-          java: '19'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -43,11 +43,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 3
       matrix:
         java:
           - '11'
           - '17'
+          - '19'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Improvement::
 * Replace use of deprecated 'numbered' attribute by 'sectnums' (#1123) (@abelsromero)
 * Expose `source` and `source_lines` use of deprecated 'numbered' in Document interface (#1145) (@abelsromero)
 * Accept 'null' as valid input (same as empty string) for load and convert String methods (#1148) (@abelsromero)
+* Set Java 11 as the minimal version (#1151) (@abelsromero)
 
 Bug Fixes::
 

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -127,12 +127,7 @@ task pollutedTest(type: Test) {
   forkEvery = 10
   minHeapSize = '128m'
   maxHeapSize = '1024m'
-  if (JavaVersion.current().isJava8Compatible()) {
-    jvmArgs '-XX:-UseGCOverheadLimit'
-  }
-  else {
-    jvmArgs '-XX:MaxPermSize=256m', '-XX:-UseGCOverheadLimit'
-  }
+  jvmArgs '-XX:-UseGCOverheadLimit'
 
   environment 'GEM_PATH', '/some/path'
   environment 'GEM_HOME', '/some/other/path'

--- a/asciidoctorj-springboot-integration-test/build.gradle
+++ b/asciidoctorj-springboot-integration-test/build.gradle
@@ -11,8 +11,3 @@ dependencies {
 }
 
 test.dependsOn(':asciidoctorj-springboot-integration-test:springboot-app:assemble')
-
-tasks.withType(JavaCompile).configureEach { task ->
-    task.options.release = 17
-}
-

--- a/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
+++ b/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
@@ -1,3 +1,4 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
@@ -20,6 +21,20 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+java {
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of(getToolchainVersion()))
+	}
+}
+
+def getToolchainVersion() {
+	if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows()) {
+		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_19))
+			return 19
+	}
+	return 17
 }
 
 bootJar {

--- a/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
+++ b/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
@@ -1,6 +1,7 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
-	id 'org.springframework.boot' version '3.0.0'
-	id 'io.spring.dependency-management' version '1.1.0'
+	id 'org.springframework.boot' version '3.0.4'
 	id 'java'
 }
 
@@ -13,14 +14,12 @@ repositories {
 
 dependencies {
 	implementation project(':asciidoctorj')
+
+	implementation platform(SpringBootPlugin.BOM_COORDINATES)
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-}
-
-tasks.withType(JavaCompile).configureEach { task ->
-	task.options.release = 17
 }
 
 bootJar {

--- a/build.gradle
+++ b/build.gradle
@@ -113,19 +113,11 @@ subprojects {
 
   plugins.withType(JavaPlugin) {
     project.tasks.withType(JavaCompile) { task ->
-      if (JavaVersion.current().isJava11Compatible()) {
-        task.options.release = 8
-      }
       if (project.hasProperty("showDeprecation")) {
         options.compilerArgs << "-Xlint:deprecation"
       }
       if (project.hasProperty("showUnchecked")) {
         options.compilerArgs << "-Xlint:unchecked"
-      }
-    }
-    project.tasks.withType(GroovyCompile) { task ->
-      if (JavaVersion.current().isJava11Compatible()) {
-        task.options.release = 8
       }
     }
   }
@@ -168,9 +160,6 @@ subprojects {
     forkEvery = 10
     minHeapSize = '128m'
     maxHeapSize = '1024m'
-    if (JavaVersion.current().isJava8Compatible()) {
-      jvmArgs '-XX:-UseGCOverheadLimit'
-    }
 
     testLogging {
       // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
@@ -199,9 +188,8 @@ configure(subprojects.findAll { !it.isDistribution() }) {
 
 
   javadoc {
-    // Oracle JDK8 likes to fail the build over spoiled HTML
+    // Oracle JDK11+ likes to fail the build over spoiled HTML
     options.addStringOption('Xdoclint:none', '-quiet')
-    options.source('8')
   }
 }
 
@@ -210,6 +198,9 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') && ! it.name.
   java {
     withJavadocJar()
     withSourcesJar()
+    toolchain {
+      languageVersion.set(JavaLanguageVersion.of(11))
+    }
   }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 import java.time.Duration
 
 /*
@@ -199,8 +201,19 @@ configure(subprojects.findAll { !it.name.endsWith('-distribution') && ! it.name.
     withJavadocJar()
     withSourcesJar()
     toolchain {
-      languageVersion.set(JavaLanguageVersion.of(11))
+      languageVersion.set(JavaLanguageVersion.of(getToolchainVersion()))
     }
   }
 
+}
+
+// Windows workaround to fix invalid toolchain detection
+def getToolchainVersion() {
+  if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows()) {
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_19))
+      return 19
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17))
+      return 17
+  }
+  return 11
 }

--- a/docs/modules/ROOT/pages/logs-handling.adoc
+++ b/docs/modules/ROOT/pages/logs-handling.adoc
@@ -1,5 +1,5 @@
 = Logs Handling API
-:uri-javadocs-logmanager: https://docs.oracle.com/javase/8/docs/api/java/util/logging/LogManager.html
+:uri-javadocs-logmanager: https://docs.oracle.com/en/java/javase/11/docs/api/java.logging/java/util/logging/LogManager.html
 
 [NOTE]
 This API is inspired by Java Logging API (JUL).

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

*What is the goal of this pull request?*

Remove support for Java 8 and set 11 as de minimal version.
Java8 is EOL and I don't think we should promote using it.

*How does it achieve that?*

* Remove use of 'task.options.release' for Java version configuration in favour of Gradle's preferrs 'toolchain'.
* Removed Java 8 from pipelines.
Also:
* Bump Gradle to latest v8.0.2
* Remove use of 'io.spring.dependency-management' Gradle plugin in 'spring-boot' app in favor of Gradle's BOM support. This reduces maintenance since only Boot version needs to be updated.
* Enables CI pipelines for Java 19 on macos and Windows.

*Are there any alternative ways to implement this?*

`task.options.release` still works, but Gradle docs suggest using the new toolchain configuration as this is the ["preferred"](https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation).

*Are there any implications of this pull request? Anything a user must know?*

Users using Java 8 should stay in 2.5.x until they upgrade their apps.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1150 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc