### PR TITLE
Remove invalid destinationDir option from API for v3.0.x

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,7 @@ Bug Fixes::
 * BREAKING: Fix CLI target file location for source files relative to source dir (#1135) (@AlexCzar)
 * Cell nodes do not inherit from StructuralNode (#1086) (@rahmanusta)
 * Avoid throwing an exception when using AsciidoctorJ CLI and reading input from stdin (#1105) (@AlexCzar)
+* Remove destinationDir Option from API (use toDir instead) (#853, #941) (@abelsromero)
 
 Build Improvement::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -23,7 +23,6 @@ public class Options {
     public static final String ERUBY = "eruby";
     public static final String CATALOG_ASSETS = "catalog_assets";
     public static final String COMPACT = "compact";
-    public static final String DESTINATION_DIR = "destination_dir";
     public static final String SOURCE_DIR = "source_dir";
     public static final String BACKEND = "backend";
     public static final String DOCTYPE = "doctype";
@@ -169,10 +168,6 @@ public class Options {
 
     public void setCompact(boolean compact) {
         this.options.put(COMPACT, compact);
-    }
-
-    public void setDestinationDir(String destinationDir) {
-        this.options.put(DESTINATION_DIR, destinationDir);
     }
 
     public void setSourceDir(String srcDir) {

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
@@ -148,7 +148,7 @@ public class OptionsBuilder {
         this.options.setAttributes(attributes);
         return this;
     }
-    
+
     /**
      * Sets attributes used for rendering input.
      * @deprecated Use {@link #attributes(Attributes)} instead. 
@@ -232,8 +232,9 @@ public class OptionsBuilder {
     }
 
     /**
-     * Keeps track of the file and line number for each parsed block. (Useful for tooling applications where the association between the converted output and the source file is important).
-     * 
+     * Keeps track of the file and line number for each parsed block.
+     * Useful for tooling applications where the association between the converted output and the source file is important.
+     *
      * @param sourcemap
      *            value.
      * @return this instance.
@@ -254,10 +255,13 @@ public class OptionsBuilder {
         this.options.setEruby(eruby);
         return this;
     }
-    
+
     /**
-     * If true, tells the parser to capture images and links in the reference table. (Normally only IDs, footnotes and indexterms are included). The reference table is available via the references property on the document AST object. (Experimental).
-     * 
+     * If true, tells the parser to capture images and links in the reference table.
+     * Normally only IDs, footnotes and indexterms are included.
+     * The reference table is available via the references property on the document AST object.
+     * (Experimental).
+     *
      * @param catalogAssets
      *            value.
      * @return this instance.
@@ -280,8 +284,9 @@ public class OptionsBuilder {
     }
 
     /**
-     * If true, the source is parsed eagerly (i.e., as soon as the source is passed to the load or load_file API). If false, parsing is deferred until the parse method is explicitly invoked.
-     * 
+     * If true, the source is parsed eagerly (i.e., as soon as the source is passed to the load or load_file API).
+     * If false, parsing is deferred until the parse method is explicitly invoked.
+     *
      * @param parse
      *            value.
      * @return this instance.
@@ -304,21 +309,9 @@ public class OptionsBuilder {
     }
 
     /**
-     * Destination output directory.
-     * 
-     * @param destinationDir
-     *            destination directory.
-     * @return this instance.
-     */
-    public OptionsBuilder destinationDir(File destinationDir) {
-        this.options.setDestinationDir(destinationDir.getAbsolutePath());
-        return this;
-    }
-
-    /**
      * Source directory.
      *
-     * This must be used alongside {@link #destinationDir(File)}.
+     * This must be used alongside {@link #toDir(File)}.
      *
      * @param srcDir
      *            source directory.
@@ -342,7 +335,7 @@ public class OptionsBuilder {
         this.options.setOption(option, value);
         return this;
     }
-    
+
     /**
      * Sets base dir for working directory.
      * 
@@ -359,7 +352,7 @@ public class OptionsBuilder {
      * Gets a map with configured options.
      * @deprecated Use {@link #build()} instead.
      * 
-     * @return map with all options. By default an empty map is returned.
+     * @return map with all options. By default, an empty map is returned.
      */
     @Deprecated
     public Map<String, Object> asMap() {
@@ -367,16 +360,16 @@ public class OptionsBuilder {
     }
 
     /**
-     * @deprecated Use {@link #build()} instead. 
+     * @deprecated Use {@link #build()} instead.
      */
     @Deprecated
     public Options get() {
         return this.options;
     }
-    
+
     /**
      * Returns a valid Options instance.
-     * 
+     *
      * @return options instance.
      */
     public Options build() {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/AsciidoctorUtils.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/AsciidoctorUtils.java
@@ -18,6 +18,8 @@ public class AsciidoctorUtils {
      * See class 'org.asciidoctor.jruby.cli.AsciidoctorCliOptions'
      */
     private class CliOptions {
+        private static final String DESTINATION_DIR_LONG = "destination_dir";
+
         private static final String DESTINATION_DIR = "-D";
         private static final String BASE_DIR = "-B";
         private static final String TEMPLATE_DIR = "-T";
@@ -58,9 +60,9 @@ public class AsciidoctorUtils {
 
         List<String> optionsAndAttributes = new ArrayList<>();
 
-        if (options.containsKey(Options.DESTINATION_DIR)) {
+        if (options.containsKey(CliOptions.DESTINATION_DIR_LONG)) {
             optionsAndAttributes.add(CliOptions.DESTINATION_DIR);
-            optionsAndAttributes.add(options.get(Options.DESTINATION_DIR).toString());
+            optionsAndAttributes.add(options.get(CliOptions.DESTINATION_DIR_LONG).toString());
         }
 
         if (options.containsKey(Options.BASEDIR)) {


### PR DESCRIPTION
## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Fix the issue where using the option `destinationDir` from API had no effect.
The option only is used for the CLI, in that case the value is redirected to 'to_dir'.

How does it achieve that?

1. Completely removes the option from `OptionsBuilder` and `Options` class.
2. Moves the constant with the name from `Options` to `AsciidoctorUtils`: this is the second time I struggle with this class. It's out of place because it contains CLI elements to build the asciidoctor command for logging purposes in the core. So to prevent cyclic dependencies some constants are copied both here and in the `asciidoctor-cli` sub-module -> Solution = create new sub-module "shared" or remove the logging. Third time will be the charm :thinking: 

Are there any alternative ways to implement this?

Initial conversations are about deprecations, but I think it's the moment to do some clean up and breaking changes for v3.0.0.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #853
Fixes #941

:two: in :one: :grin: 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc