### PR TITLE
Deprecate destinationDir option for v2.5.x

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,9 @@ Improvement::
 * Upgrade to asciidoctorj-diagram 2.2.4 (#1140)
 * Upgrade to jruby 9.3.10.0 (#1138) (@alexlevinfr)
 
+Bug Fixes::
+* Fix destinationDir not having effect. Deprecate destinationDir in favour of toDir (@abelsromero) (#853, #941)
+
 Build / Infrastructure::
 
 * Replace use of deprecated 'numbered' attribute by 'sectnums' (#1127) (@abelsromero)

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -1,5 +1,6 @@
 package org.asciidoctor;
 
+import java.io.File;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -171,6 +172,14 @@ public class Options {
         this.options.put(COMPACT, compact);
     }
 
+    /**
+     * Destination output directory.
+     *
+     * @param destinationDir
+     *            destination directory.
+     * @deprecated Use {@link #setToDir(String)} instead.
+     */
+    @Deprecated
     public void setDestinationDir(String destinationDir) {
         this.options.put(DESTINATION_DIR, destinationDir);
     }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
@@ -305,13 +305,15 @@ public class OptionsBuilder {
 
     /**
      * Destination output directory.
-     * 
+     *
      * @param destinationDir
-     *            destination directory.
+     *             destination directory.
      * @return this instance.
+     * @deprecated Use {@link #toDir(File)} instead.
      */
+    @Deprecated
     public OptionsBuilder destinationDir(File destinationDir) {
-        this.options.setDestinationDir(destinationDir.getAbsolutePath());
+        this.options.setToDir(destinationDir.getAbsolutePath());
         return this;
     }
 


### PR DESCRIPTION
## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Fix the option to set toDir internally.
Deprecate the option to warn users it is being [removed in v3.0.x](https://github.com/asciidoctor/asciidoctorj/pull/1153).

How does it achieve that?
Set toDir and add deprecation documentation.

Are there any alternative ways to implement this?
No

Are there any implications of this pull request? Anything a user must know?
No

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #853
Fixes #941

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc