### PR TITLE
Add required '--add-opens' to cli script

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,7 @@ Improvement::
 * Accept 'null' as valid input (same as empty string) for load and convert String methods (#1148) (@abelsromero)
 * Set Java 11 as the minimal version (#1151) (@abelsromero)
 * Create `asciidoctorj-cli` module to prevent unnecessary dependencies to asciidoctorj jar consumers (#1149)
+* Add required `--add-opens` to cli launch script to remove Jdk warnings (#1155) (@abelsromero)
 
 Bug Fixes::
 

--- a/asciidoctorj-distribution/build.gradle
+++ b/asciidoctorj-distribution/build.gradle
@@ -53,6 +53,8 @@ startScripts {
   applicationName = rootProject.name
   mainClass.set('org.asciidoctor.cli.jruby.AsciidoctorInvoker')
   defaultJvmOpts = [
+    '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.io=ALL-UNNAMED',
     '-client', '-Xmn128m', '-Xms256m', '-Xmx256m', '-Djava.awt.headless=true',
     '-Xverify:none', '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1', '-XX:+DisableExplicitGC', '-Djruby.compile.mode=OFF'
   ]


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Remove `WARN FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem` message at least when running the CLI.


How does it achieve that?

Simply adds required `--add-open`  options.

Are there any alternative ways to implement this?
No.

Are there any implications of this pull request? Anything a user must know?
This is not related to  https://github.com/asciidoctor/asciidoctorj/issues/1034, and does not fix it.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1155

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc