### PR TITLE
Test Section.isNumbered to ensure expected behaviour

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Section.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Section.java
@@ -74,7 +74,6 @@ public interface Section extends StructuralNode {
      */
     boolean isNumbered();
 
-
     /**
      * Get the section number for the current Section.
      * <p>

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/SectionImpl.java
@@ -67,6 +67,8 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
 
     @Override
     public boolean isNumbered() {
+        // Not always an actual boolean, but coercing when object and non-null is enough:
+        // https://github.com/asciidoctor/asciidoctorj/issues/1122
         return getBoolean("numbered");
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyObjectWrapper.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyObjectWrapper.java
@@ -36,11 +36,8 @@ public class RubyObjectWrapper {
 
         if (result instanceof RubyNil) {
             return null;
-        } else if (result instanceof RubySymbol) {
-            return result.asJavaString();
-        } else {
-            return result.asJavaString();
         }
+        return result.asJavaString();
     }
 
     public void setString(String propertyName, String value) {
@@ -120,7 +117,7 @@ public class RubyObjectWrapper {
             }
             result = rubyNode.getInstanceVariables().getInstanceVariable(propertyName);
         } else {
-            if (args == null) {
+            if (args == null || args.length == 0) {
                 result = rubyNode.callMethod(threadContext, propertyName);
             } else {
                 IRubyObject[] rubyArgs = new IRubyObject[args.length];

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/SectionImplTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/SectionImplTest.java
@@ -93,4 +93,43 @@ public class SectionImplTest {
                 "=== Section A Subsection\n\n" +
                 "Section A 'subsection' paragraph.\n\n";
     }
+
+    @Test
+    public void should_return_isNumbered_true_when_doctype_is_article_and_sectnums_is_set() {
+        assertDocTypeAndSectnums("article", true);
+    }
+
+    @Test
+    public void should_return_isNumbered_false_when_doctype_is_article_and_sectnums_is_not_set() {
+        assertDocTypeAndSectnums("article", false);
+    }
+
+    @Test
+    public void should_return_isNumbered_true_when_doctype_is_book_and_sectnums_is_set() {
+        assertDocTypeAndSectnums("book", true);
+    }
+
+    @Test
+    public void should_return_isNumbered_false_when_doctype_is_book_and_sectnums_is_not_set() {
+        assertDocTypeAndSectnums("book", false);
+    }
+
+    private void assertDocTypeAndSectnums(String doctype, boolean sectnums) {
+        String content = buildContent(doctype, sectnums);
+
+        Document document = asciidoctor.load(content, Options.builder().build());
+
+        SectionImpl section = (SectionImpl) document.getBlocks().get(0);
+        assertThat(section.isNumbered()).isEqualTo(sectnums);
+    }
+
+    private static String buildContent(String doctype, boolean sectnums) {
+        return "= Sample Document\n" +
+                ":doctype: " + doctype + "\n" +
+                (sectnums ? ":sectnums:" : "") +
+                "\n\n" +
+                "== Test\n" +
+                "\n" +
+                "Test";
+    }
 }


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Mainly provide some closure to issue #1122.

How does it achieve that?

Test Section.isNumbered to ensure expected behavior
* Core 'numbered' property is not always boolean. In those cases, the boolean can be coerced from non-null value.
See https://github.com/asciidoctor/asciidoctorj/issues/1122
* Minor improvements to RubyObjectWrapper.

Are there any alternative ways to implement this?

We could make further tests and check if the property has the ':chapter' object. But the current implementation already meets the tests, so I see no point in complicating it.
Also, it does not tests doctype `manpage` and `inline` since in those the sections are not taken into consideration or cannot be numbered (manpage).
For reference, I left a comment pointing to the issue in the code.

Are there any implications of this pull request? Anything a user must know?

Includes a couple of minor improvements to `RubyObjectWrapper` but all the tests pass :ok: 

## Issue

If this PR fixes an open issue, please add a line of the form:

Closes #1122


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc
I don't think is worth mentioning.