### PR TITLE
(v2.5.x) Remove open access warnings from cli

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -307,6 +307,7 @@ Improvements::
   * Upgrade to Asciidoctor 2.0.8
   * Upgrade to asciidoctor-pdf 1.5.0-alpha.17 (#809)
   * Add Rouge source highlighter to asciidoctor.jar (#806)
+  * Add required `--add-opens` to cli launch script to remove Jdk warnings when running on Java8 (#1155) (@abelsromero)
 
 Bug Fixes::
 

--- a/asciidoctorj-distribution/src/main/resources/customUnixStartScript.txt
+++ b/asciidoctorj-distribution/src/main/resources/customUnixStartScript.txt
@@ -29,6 +29,10 @@ APP_BASE_NAME=`basename "\$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
 DEFAULT_JVM_OPTS=${defaultJvmOpts}
+readonly java_version=\$(java -version 2>&1 | sed -n ';s/.* version "\\(.*\\)\\.\\(.*\\)\\..*".*/\\1\\.\\2/p;')
+if [ "\$java_version" != "1.8" ]; then
+  DEFAULT_JVM_OPTS="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED \$DEFAULT_JVM_OPTS"
+fi
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"


### PR DESCRIPTION
## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Remove `Native subprocess...` warning when running the CLI in Java > 8.
```
023-04-01T22:03:19.247+02:00 [main] WARN FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem
Pass '--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED' to enable.
```

How does it achieve that?

Modifies CLI script to check the Java version running, in case of Java >8 adds required arguments to remove warning.

Are there any alternative ways to implement this?

Leave the warning and document it. However, given the majority of users should be on Java > 8, leaving the warning because we still support it, seems unfair and lazy.


Are there any implications of this pull request? Anything a user must know?

The script changes will add some delay, but it's not appreciable, especially when one takes into account the startup time for the jvm and Ruby scripts.
This does not fix the other warning that appear in newer versions.
```
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release
```
## Issue

Fixes #1155


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc