### PR TITLE
Replace deprecated 'headerFooter' by 'standalone'

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches:
       - main
-      - v2.5.x
   schedule:
     - cron: '0 0 * * *'
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,7 @@ Improvement::
 * Set Java 11 as the minimal version (#1151) (@abelsromero)
 * Create `asciidoctorj-cli` module to prevent unnecessary dependencies to asciidoctorj jar consumers (#1149)
 * Add required `--add-opens` to cli launch script to remove Jdk warnings (#1155) (@abelsromero)
+* Rename deprecated `headerFooter` option to the new `standalone` with same functionality (#1155) (@abelsromero)
 
 Bug Fixes::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -7,11 +7,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * AsciidoctorJ conversion options. Each one maps to an option in Asciidoctor.
+ * See https://docs.asciidoctor.org/asciidoctor/latest/api/options/ for further
+ * details.
+ */
 public class Options {
 
     public static final String IN_PLACE = "in_place";
     public static final String ATTRIBUTES = "attributes";
-    public static final String HEADER_FOOTER = "header_footer";
     public static final String TEMPLATE_DIRS = "template_dirs";
     public static final String TEMPLATE_ENGINE = "template_engine";
     public static final String TO_FILE = "to_file";
@@ -72,18 +76,20 @@ public class Options {
     /**
      * Toggle including header and footer into the output.
      *
-     * @param headerFooter If <code>true</true>, include header and footer into the output,
-     *                     otherwise exclude them. This overrides any output-specific defaults.
-     *
+     * @param standalone <code>true</code> to generate a standalone output document
+     *                   (which includes the shell around the body content, such
+     *                   as the header and footer).
+     *                   Defaults to <code>true</code> when converting a file only,
+     *                   otherwise is <code>false</code>.
      */
-    public void setHeaderFooter(boolean headerFooter) {
-        this.options.put(HEADER_FOOTER, headerFooter);
+    public void setStandalone(boolean standalone) {
+        this.options.put(STANDALONE, standalone);
     }
 
     public void setTemplateDirs(String... templateDirs) {
 
         if (!this.options.containsKey(TEMPLATE_DIRS)) {
-            this.options.put(TEMPLATE_DIRS, new ArrayList<Object>());
+            this.options.put(TEMPLATE_DIRS, new ArrayList<>());
         }
 
         List<Object> allTemplateDirs = (List<Object>) this.options.get(TEMPLATE_DIRS);
@@ -117,7 +123,7 @@ public class Options {
      *               as the input file, including header and footer into the output. If
      *               <code>false</code>, return output as a string without any header or
      *               footer. The default header and footer visibility can be overridden
-     *               using {@link #setHeaderFooter(boolean)}.
+     *               using {@link #setStandalone(boolean)}.
      *
      */
     public void setToFile(boolean toFile) {

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
@@ -4,6 +4,11 @@ import java.io.File;
 import java.io.OutputStream;
 import java.util.Map;
 
+/**
+ * Fluent Options API for AsciidoctorJ.
+ *
+ * @see org.asciidoctor.Options
+ */
 public class OptionsBuilder {
 
     private final Options options = new Options();
@@ -37,9 +42,11 @@ public class OptionsBuilder {
 
     /**
      * Sets doctype option.
-     * 
-     * @param docType
-     *            value.
+     * Valid options are <code>article</code>, <code>book</code>,
+     * <code>manpage</code> and <code>inline</code>.
+     * Default <code>article</code>.
+     *
+     * @param docType value.
      * @return this instance.
      */
     public OptionsBuilder docType(String docType) {
@@ -60,14 +67,17 @@ public class OptionsBuilder {
     }
 
     /**
-     * Sets header footer attribute.
-     * 
-     * @param headerFooter
-     *            value.
+     * Sets standalone option.
+     *
+     * @param standalone <code>true</code> to generate a standalone output document
+     *                   (which includes the shell around the body content, such
+     *                   as the header and footer).
+     *                   Defaults to <code>true</code> when converting a file only,
+     *                   otherwise is <code>false</code>.
      * @return this instance.
      */
-    public OptionsBuilder headerFooter(boolean headerFooter) {
-        this.options.setHeaderFooter(headerFooter);
+    public OptionsBuilder standalone(boolean standalone) {
+        this.options.setStandalone(standalone);
         return this;
     }
 
@@ -79,7 +89,9 @@ public class OptionsBuilder {
      * @param templateDir
      *            directory where templates are stored.
      * @return this instance.
+     * @deprecated Use {@link #templateDirs(File...)} instead.
      */
+    @Deprecated
     public OptionsBuilder templateDir(File templateDir) {
         this.options.setTemplateDirs(templateDir.getAbsolutePath());
         return this;

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/AsciidoctorUtils.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/AsciidoctorUtils.java
@@ -34,7 +34,6 @@ public class AsciidoctorUtils {
     }
 
     private AsciidoctorUtils() {
-        super();
     }
 
     public static boolean isOptionWithAttribute(Map<String, Object> options, String attributeName, String attributeValue) {
@@ -93,7 +92,7 @@ public class AsciidoctorUtils {
             optionsAndAttributes.add(options.get(Options.ERUBY).toString());
         }
 
-        if (options.containsKey(Options.HEADER_FOOTER)) {
+        if (options.containsKey(Options.STANDALONE)) {
             optionsAndAttributes.add(CliOptions.NO_HEADER_FOOTER);
         }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentContainsADefinitionList.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentContainsADefinitionList.groovy
@@ -33,7 +33,7 @@ Item C:: Another description
 '''
 
         when:
-        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().headerFooter(false).asMap())
+        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().standalone(false).asMap())
 
         then:
         DescriptionList list = documentNode.blocks[0]
@@ -112,7 +112,7 @@ Item A::
 
         when:
         asciidoctor.javaConverterRegistry().register(TestConverter, TestConverter.NAME)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().backend(TestConverter.NAME).headerFooter(false).asMap())
+        String result = asciidoctor.convert(document, OptionsBuilder.options().backend(TestConverter.NAME).standalone(false).asMap())
 
         then:
         result == '''TEST DOCUMENT
@@ -134,7 +134,7 @@ Item B::
 
         when:
         asciidoctor.javaConverterRegistry().register(TestConverter, TestConverter.NAME)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().backend(TestConverter.NAME).headerFooter(false).asMap())
+        String result = asciidoctor.convert(document, OptionsBuilder.options().backend(TestConverter.NAME).standalone(false).asMap())
 
         then:
         result == '''TEST DOCUMENT
@@ -165,7 +165,7 @@ Item A::
                 doc
             }
         })
-        String result = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false).asMap())
+        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).asMap())
 
         then:
         org.jsoup.nodes.Document htmlDoc = Jsoup.parse(result)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenATableIsLoaded.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenATableIsLoaded.groovy
@@ -29,7 +29,7 @@ class WhenATableIsLoaded extends Specification {
 '''
 
         when:
-        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().headerFooter(false).asMap())
+        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().standalone(false).asMap())
         Table tableNode = documentNode.blocks[0]
 
         then:
@@ -50,7 +50,7 @@ class WhenATableIsLoaded extends Specification {
 '''
 
         when:
-        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().headerFooter(false).asMap())
+        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().standalone(false).asMap())
         Table tableNode = documentNode.blocks[0]
 
         then:
@@ -78,7 +78,7 @@ The second content cell
 '''
 
 		when:
-		Document documentNode = asciidoctor.load(document, OptionsBuilder.options().headerFooter(false).asMap())
+		Document documentNode = asciidoctor.load(document, OptionsBuilder.options().standalone(false).asMap())
 		Table tableNode = documentNode.blocks[0]
 
 		then:

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenSlimTemplatesAreUsed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenSlimTemplatesAreUsed.groovy
@@ -19,7 +19,7 @@ class WhenSlimTemplatesAreUsed extends Specification {
 
     def 'the slim paragraph template should be used when rendering a document inline'() {
         given:
-        Options options = options().templateDir(classpath.getResource('src/custom-backends/slim')).toFile(false).headerFooter(false).get()
+        Options options = options().templateDir(classpath.getResource('src/custom-backends/slim')).toFile(false).standalone(false).get()
 
         String sourceDocument = '''
 = Hello World

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheSourceShouldBeAccessed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheSourceShouldBeAccessed.groovy
@@ -151,7 +151,7 @@ xxx
                 doc
             }
         })
-        String html = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false).asMap())
+        String html = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).asMap())
         org.jsoup.nodes.Document doc = Jsoup.parse(html)
 
         then:
@@ -179,7 +179,7 @@ xxx
                 doc
             }
         })
-        String html = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false).asMap())
+        String html = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).asMap())
         org.jsoup.nodes.Document doc = Jsoup.parse(html)
 
         then:
@@ -211,7 +211,7 @@ xxx
                 doc
             }
         })
-        String html = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false).asMap())
+        String html = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).asMap())
         org.jsoup.nodes.Document doc = Jsoup.parse(html)
 
         then:

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableConverterTest.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableConverterTest.groovy
@@ -36,7 +36,7 @@ class TableConverterTest extends Specification {
         asciidoctor.javaConverterRegistry().register(TableTestConverter, 'tabletestconverter')
 
         when:
-        String content = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false).backend('tabletestconverter'))
+        String content = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).backend('tabletestconverter'))
 
         then:
         content.readLines().collect {it - ~/\s+$/ } == '''HELLO TABLE
@@ -68,7 +68,7 @@ a|
         asciidoctor.javaConverterRegistry().register(TableTestConverter, 'tabletestconverter')
 
         when:
-        String content = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false).backend('tabletestconverter'))
+        String content = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).backend('tabletestconverter'))
 
         then:
         content.readLines().collect {it - ~/\s+$/ } == '''HELLO ASCIIDOCTOR TABLE

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesAList.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesAList.groovy
@@ -36,7 +36,7 @@ list::HelloWorld[]
         asciidoctor.javaExtensionRegistry().blockMacro(LISTMACRO_NAME, new ListCreatorBlockMacro('olist'))
 
         when:
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).headerFooter(false))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(false))
 
         then:
         noExceptionThrown()
@@ -57,7 +57,7 @@ list::HelloWorld[]
         asciidoctor.javaExtensionRegistry().blockMacro(LISTMACRO_NAME, new ListCreatorBlockMacro('ulist'))
 
         when:
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).headerFooter(false))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(false))
 
         then:
         noExceptionThrown()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesASection.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesASection.groovy
@@ -35,7 +35,7 @@ section::HelloWorld[]
         asciidoctor.javaExtensionRegistry().blockMacro(BLOCKMACRO_NAME, SectionCreatorBlockMacro)
 
         when:
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).headerFooter(true))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(true))
 
         then:
         noExceptionThrown()
@@ -52,7 +52,7 @@ section::HelloWorld[]
         asciidoctor.createGroup().blockMacro(BLOCKMACRO_NAME, SectionCreatorBlockMacro).register()
 
         when:
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).headerFooter(true))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(true))
 
         then:
         noExceptionThrown()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockProcessorCreatesABlockThatATreeProcessorVisits.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockProcessorCreatesABlockThatATreeProcessorVisits.groovy
@@ -77,7 +77,7 @@ This will be ignored
 		asciidoctor.javaExtensionRegistry().treeprocessor(BlockVisitor)
 
         when:
-        asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).headerFooter(true))
+        asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(true))
 
         then:
         notThrown(ClassCastException)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockShouldBeDuplicated.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockShouldBeDuplicated.groovy
@@ -58,7 +58,7 @@ This will be ignored
     '''
 
         when:
-        org.jsoup.nodes.Document html = Jsoup.parse(asciidoctor.convert(asciidoctorSource, OptionsBuilder.options().safe(SafeMode.SAFE).headerFooter(false).asMap()))
+        org.jsoup.nodes.Document html = Jsoup.parse(asciidoctor.convert(asciidoctorSource, OptionsBuilder.options().safe(SafeMode.SAFE).standalone(false).asMap()))
 
         then:
         html.select(CLASS_LISTINGBLOCK).get(0).text() == 'This will be ignored'

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionChecksAttributes.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionChecksAttributes.groovy
@@ -27,7 +27,7 @@ Check me
     def "a BlockProcessor should only get String attribute keys"() {
         when:
         asciidoctor.javaExtensionRegistry().block(AttributeCheckingBlockProcessor)
-        asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         noExceptionThrown()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionGroupIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionGroupIsRegisteredWithAnnotations.groovy
@@ -91,7 +91,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor should be configurable via the Location annotation"() {
         when:
         asciidoctor.createGroup().docinfoProcessor(AnnotatedDocinfoProcessor).register()
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -102,7 +102,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance should be configurable via the Location annotation"() {
         when:
         asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor()).register()
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -114,7 +114,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance can override the annotation from footer to header"() {
         when:
         asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.HEADER)).register()
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -124,7 +124,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance can override the annotation from footer to footer"() {
         when:
         asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.FOOTER)).register()
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -136,7 +136,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.createGroup().blockMacro(AnnotatedBlockMacroProcessor).register()
-        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         result.contains(AnnotatedBlockMacroProcessor.RESULT)
@@ -148,7 +148,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.createGroup().block(AnnotatedBlockProcessor).register()
-        String result = asciidoctor.convert(BLOCK_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         result.contains(DO_NOT_TOUCH_THIS)
@@ -162,7 +162,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.createGroup().block(new AnnotatedBlockProcessor('dummy', 'yell2')).register()
-        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().standalone(false))
 
         then:
         result.contains(DO_NOT_TOUCH_THIS)
@@ -173,7 +173,7 @@ And even more infos on manpage:git[7].
     def "when registering an InlineMacroProcessor class with long format it should be configurable via annotations"() {
         when:
         asciidoctor.createGroup().inlineMacro(AnnotatedLongInlineMacroProcessor).register()
-        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -184,7 +184,7 @@ And even more infos on manpage:git[7].
     def "when registering an InlineMacroProcessor class with regexp it should be configurable via annotations"() {
         when:
         asciidoctor.createGroup().inlineMacro(AnnotatedRegexpInlineMacroProcessor).register()
-        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
@@ -91,7 +91,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor should be configurable via the Location annotation"() {
         when:
         asciidoctor.javaExtensionRegistry().docinfoProcessor(AnnotatedDocinfoProcessor)
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -102,7 +102,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance should be configurable via the Location annotation"() {
         when:
         asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor())
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -114,7 +114,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance can override the annotation from footer to header"() {
         when:
         asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.HEADER))
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -124,7 +124,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance can override the annotation from footer to footer"() {
         when:
         asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.FOOTER))
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -136,7 +136,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.javaExtensionRegistry().blockMacro(AnnotatedBlockMacroProcessor)
-        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         result.contains(AnnotatedBlockMacroProcessor.RESULT)
@@ -148,7 +148,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.javaExtensionRegistry().block(AnnotatedBlockProcessor)
-        String result = asciidoctor.convert(BLOCK_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         result.contains(DO_NOT_TOUCH_THIS)
@@ -162,7 +162,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.javaExtensionRegistry().block(new AnnotatedBlockProcessor('dummy', 'yell2'))
-        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().standalone(false))
 
         then:
         result.contains(DO_NOT_TOUCH_THIS)
@@ -173,7 +173,7 @@ And even more infos on manpage:git[7].
     def "when registering an InlineMacroProcessor class with long format it should be configurable via annotations"() {
         when:
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedLongInlineMacroProcessor)
-        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -184,7 +184,7 @@ And even more infos on manpage:git[7].
     def "when registering an InlineMacroProcessor class with regexp it should be configurable via annotations"() {
         when:
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedRegexpInlineMacroProcessor)
-        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionUsesCounters.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionUsesCounters.groovy
@@ -51,7 +51,7 @@ The attribute for counterb: {counter:counterb}
 '''
         when:
         asciidoctor.javaExtensionRegistry().blockMacro(TestBlockMacroProcessor)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -83,7 +83,7 @@ The attribute for counterb: {counter:counterb}
 '''
         when:
         asciidoctor.javaExtensionRegistry().treeprocessor(TestTreeProcessor)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -109,7 +109,7 @@ testmacro::countera[]
 '''
         when:
         asciidoctor.javaExtensionRegistry().blockMacro(TestBlockMacroWithInitialCounterProcessor)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorCreatesNodes.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorCreatesNodes.groovy
@@ -51,7 +51,7 @@ puts "Hello"
         asciidoctor.javaExtensionRegistry().treeprocessor(tp)
 
         when: 'The document is converted'
-        String html = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(true))
+        String html = asciidoctor.convert(document, OptionsBuilder.options().standalone(true))
 
         then: 'The second source block uses the same value of the language attribute and highlight as Ruby'
         org.jsoup.nodes.Document htmlDocument = Jsoup.parse(html)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorWorksOnTables.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorWorksOnTables.groovy
@@ -32,7 +32,7 @@ class WhenATreeProcessorWorksOnTables extends Specification {
         asciidoctor.javaExtensionRegistry().treeprocessor(TableCreatorTreeProcessor)
 
         when: 'the document is rendered'
-        String content = asciidoctor.convert(EMPTY_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String content = asciidoctor.convert(EMPTY_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then: 'the resulting document has a table'
         org.jsoup.nodes.Document document = Jsoup.parse(content)
@@ -72,7 +72,7 @@ class WhenATreeProcessorWorksOnTables extends Specification {
 | World | Hello 
 |===
 
-''', OptionsBuilder.options().headerFooter(false))
+''', OptionsBuilder.options().standalone(false))
 
         def htmlDocument = Jsoup.parse(content)
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnExtensionAppendsChildBlocks.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnExtensionAppendsChildBlocks.groovy
@@ -52,7 +52,7 @@ more text
         })
 
         when:
-        String result = asciidoctor.convert(this.document, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(this.document, OptionsBuilder.options().standalone(false))
 
         then:
         org.jsoup.nodes.Document htmlDocument = Jsoup.parse(result)
@@ -86,7 +86,7 @@ And this as well
         })
 
         when:
-        String result = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(false))
 
         then:
         org.jsoup.nodes.Document htmlDocument = Jsoup.parse(result)
@@ -129,7 +129,7 @@ testmacro::target[]
         })
 
         when:
-        String result = asciidoctor.convert(document, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(false))
 
         then:
         result.contains(expectedContent)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnInlineMacroProcessorProcessesATable.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnInlineMacroProcessorProcessesATable.groovy
@@ -43,7 +43,7 @@ a| You can find infos on man:gittutorial[7] or man:git[8, 1].
     def "a InlineMacroProcessor should be able to process table cells"() {
         when:
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedLongInlineMacroProcessor)
-        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -54,7 +54,7 @@ a| You can find infos on man:gittutorial[7] or man:git[8, 1].
     def "a InlineMacroProcessor should be able to process table cells with asciidoc style"() {
         when:
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedLongInlineMacroProcessor)
-        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT_ASCIIDOC_STYLE, OptionsBuilder.options().headerFooter(false))
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT_ASCIIDOC_STYLE, OptionsBuilder.options().standalone(false))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenACoderayAdapterIsImplementedInGroovy.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenACoderayAdapterIsImplementedInGroovy.groovy
@@ -45,14 +45,14 @@ func main() {
     when:
     String htmlJava = asciidoctor.convert(doc, OptionsBuilder.options()
             .safe(SafeMode.UNSAFE)
-            .headerFooter(true)
+            .standalone(true)
             .attributes(AttributesBuilder.attributes()
                 .sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)
                 .linkCss(true)))
 
     String htmlRuby = asciidoctor.convert(doc, OptionsBuilder.options()
             .safe(SafeMode.UNSAFE)
-            .headerFooter(true)
+            .standalone(true)
             .attributes(AttributesBuilder.attributes()
                 .sourceHighlighter('coderay')
                 .linkCss(true)))

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAHighlightjsAdapterIsImplementedInGroovy.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAHighlightjsAdapterIsImplementedInGroovy.groovy
@@ -50,7 +50,7 @@ func main() {
         when:
         String html = asciidoctor.convert(doc, OptionsBuilder.options()
                 .safe(SafeMode.UNSAFE)
-                .headerFooter(true)
+                .standalone(true)
                 .attributes(AttributesBuilder.attributes().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)))
 
         then:
@@ -69,7 +69,7 @@ func main() {
         when:
         asciidoctor.convert(doc, OptionsBuilder.options()
                 .safe(SafeMode.UNSAFE)
-                .headerFooter(true)
+                .standalone(true)
                 .attributes(AttributesBuilder.attributes().sourceHighlighter(HighlightJsExtension.NAME_HIGHLIGHTER)))
 
         then:

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenALayoutingSyntaxHighlighterIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenALayoutingSyntaxHighlighterIsRegistered.groovy
@@ -57,7 +57,7 @@ System.out.println("Hello World");
     when:
     String html = asciidoctor.convert(doc, OptionsBuilder.options()
             .safe(SafeMode.UNSAFE)
-            .headerFooter(false)
+            .standalone(false)
             .attributes(AttributesBuilder.attributes().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)))
 
     org.jsoup.nodes.Document document = Jsoup.parse(html)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAServerSideSyntaxHighlighterIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAServerSideSyntaxHighlighterIsRegistered.groovy
@@ -61,7 +61,7 @@ System.out.println("Hello World");
     when:
     String html = asciidoctor.convert(doc, OptionsBuilder.options()
             .safe(SafeMode.UNSAFE)
-            .headerFooter(false)
+            .standalone(false)
             .attributes(AttributesBuilder.attributes().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)))
 
     org.jsoup.nodes.Document document = Jsoup.parse(html)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenASyntaxHighlighterIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenASyntaxHighlighterIsRegistered.groovy
@@ -103,7 +103,7 @@ System.out.println("Hello World");
     asciidoctor.syntaxHighlighterRegistry().register(highlighter, NAME_SYNTAXHIGHLIGHTER)
     String html = asciidoctor.convert(DOC, Options.builder()
             .safe(SafeMode.UNSAFE)
-            .headerFooter(true)
+            .standalone(true)
             .attributes(
                     Attributes.builder().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER).build())
             .build())

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenASyntaxHighlighterThatWritesStylesheetsIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenASyntaxHighlighterThatWritesStylesheetsIsRegistered.groovy
@@ -78,7 +78,7 @@ System.out.println("Hello World");
     when:
     asciidoctor.convert(doc, Options.builder()
             .safe(SafeMode.UNSAFE)
-            .headerFooter(true)
+            .standalone(true)
             .toFile(new File(toDir,'syntaxhighlighterwithwritestylesheet.html'))
             .attributes(
                     Attributes.builder().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorJInstanceIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorJInstanceIsRequired.java
@@ -11,11 +11,11 @@ public class WhenAnAsciidoctorJInstanceIsRequired {
   private static final String DOC = "[yell]\nHello World";
 
   @Test
-  public void shouldUnwrapAsciidoctorInstanceAndRegisterRubyExtension() throws Exception {
+  public void shouldUnwrapAsciidoctorInstanceAndRegisterRubyExtension() {
     AsciidoctorJRuby asciidoctorj = Asciidoctor.Factory.create().unwrap(AsciidoctorJRuby.class);
     asciidoctorj.rubyExtensionRegistry().loadClass(getClass().getResourceAsStream("/ruby-extensions/YellRubyBlock.rb")).block("yell", "YellRubyBlock");
 
-    String html = asciidoctorj.convert(DOC, OptionsBuilder.options().headerFooter(false));
+    String html = asciidoctorj.convert(DOC, OptionsBuilder.options().standalone(false));
 
     assertThat(html, containsString("HELLO WORLD"));
   }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -58,7 +58,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    public void shouldRedirectToJUL() throws Exception {
+    public void shouldRedirectToJUL() {
         final MemoryLogHandler memoryLogHandler = registerMemoryLogHandler();
 
         File inputFile = classpath.getResource("documentwithnotexistingfile.adoc");
@@ -87,7 +87,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    public void shouldNotifyLogHandler() throws Exception {
+    public void shouldNotifyLogHandler() {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 
@@ -121,7 +121,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    public void shouldLogInvalidRefs() throws Exception {
+    public void shouldLogInvalidRefs() {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 
@@ -144,7 +144,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    public void shouldOnlyNotifyFromRegisteredAsciidoctor() throws Exception {
+    public void shouldOnlyNotifyFromRegisteredAsciidoctor() {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 
@@ -188,7 +188,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    public void shouldNoLongerNotifyAfterUnregisterOnlyNotifyFromRegisteredAsciidoctor() throws Exception {
+    public void shouldNoLongerNotifyAfterUnregisterOnlyNotifyFromRegisteredAsciidoctor() {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 
@@ -227,7 +227,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    public void shouldNotifyLogHandlerService() throws Exception {
+    public void shouldNotifyLogHandlerService() {
 
         File inputFile = classpath.getResource("documentwithnotexistingfile.adoc");
         String renderContent = asciidoctor.convertFile(inputFile,
@@ -274,7 +274,7 @@ public class WhenAsciidoctorLogsToConsole {
     }
 
     @Test
-    public void a_extension_should_be_able_to_log() throws Exception {
+    public void a_extension_should_be_able_to_log() {
 
         final List<LogRecord> logRecords = new ArrayList<>();
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -50,7 +50,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
     private Asciidoctor asciidoctor;
 
     @Test
-    public void qualified_http_url_inline_with_hide_uri_scheme_set() throws IOException {
+    public void qualified_http_url_inline_with_hide_uri_scheme_set() {
         
         Attributes attributes = attributes().hiddenUriScheme(true).get();
         
@@ -89,7 +89,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
     }
 
     @Test
-    public void should_preload_open_cache_uri_gem() throws IOException {
+    public void should_preload_open_cache_uri_gem() {
         
         Attributes attributes = attributes().cacheUri(true).get();
         
@@ -132,7 +132,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
     }
 
     @Test
-    public void should_add_a_hardbreak_at_end_of_each_line_when_hardbreaks_option_is_set() throws IOException {
+    public void should_add_a_hardbreak_at_end_of_each_line_when_hardbreaks_option_is_set() {
         
         Attributes attributes = attributes().hardbreaks(true).get();
         
@@ -184,7 +184,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
         final Options options = options()
             .attributes(attributes().showTitle(true).get())
             .toFile(false)
-            .headerFooter(false)
+            .standalone(false)
             .get();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options));
@@ -198,7 +198,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
         final Options options = options()
             .attributes(attributes().showTitle(false).showTitle(true).get())
             .toFile(false)
-            .headerFooter(false)
+            .standalone(false)
             .get();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options));
@@ -212,7 +212,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
         final Options options = options()
             .attributes(attributes().showTitle(false).get())
             .toFile(false)
-            .headerFooter(false)
+            .standalone(false)
             .get();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options));
@@ -225,7 +225,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
         final Options options = options()
             .attributes(attributes().showTitle(true).showTitle(false).get())
             .toFile(false)
-            .headerFooter(false)
+            .standalone(false)
             .get();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options));
@@ -238,7 +238,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
         final Options options = options()
             .attributes(attributes().showTitle(true).get())
             .toFile(false)
-            .headerFooter(true)
+            .standalone(true)
             .get();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options));
@@ -253,7 +253,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
         final Options options = options()
             .attributes(attributes().showTitle(false).get())
             .toFile(false)
-            .headerFooter(true)
+            .standalone(true)
             .get();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options));
@@ -267,7 +267,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
         final Options options = options()
             .attributes(attributes().showTitle(false).get())
             .toFile(false)
-            .headerFooter(true)
+            .standalone(true)
             .get();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(classpath.getResource("rendersample.asciidoc"), options));
@@ -312,8 +312,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
     }
     
     @Test
-    public void should_skip_front_matter_if_specified_by_skip_front_matter_attribute()
-            throws IOException {
+    public void should_skip_front_matter_if_specified_by_skip_front_matter_attribute() {
 
         Attributes attributes = attributes().skipFrontMatter(true).get();
         Options options = options().toFile(false).inPlace(false).attributes(attributes).get();
@@ -801,7 +800,7 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
     @Test
     public void string_content_with_icons_enabled_and_iconsdir_set_should_be_rendered_with_iconsdir()
-            throws IOException, SAXException, ParserConfigurationException {
+            throws IOException {
 
         InputStream content = new FileInputStream(
                 classpath.getResource("documentwithnote.asciidoc"));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenSourceHighlightingIsUsed.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenSourceHighlightingIsUsed.java
@@ -27,10 +27,10 @@ public class WhenSourceHighlightingIsUsed {
     private Asciidoctor asciidoctor;
 
     @Test
-    public void should_render_with_rouge() throws Exception {
+    public void should_render_with_rouge() {
         String html = asciidoctor.convert(DOCUMENT,
             OptionsBuilder.options()
-                .headerFooter(true)
+                .standalone(true)
                 .safe(SafeMode.UNSAFE)
                 .attributes(
                     AttributesBuilder.attributes()
@@ -43,10 +43,10 @@ public class WhenSourceHighlightingIsUsed {
     }
 
     @Test
-    public void should_render_with_coderay() throws Exception {
+    public void should_render_with_coderay() {
         String html = asciidoctor.convert(DOCUMENT,
             OptionsBuilder.options()
-                .headerFooter(true)
+                .standalone(true)
                 .safe(SafeMode.UNSAFE)
                 .attributes(
                     AttributesBuilder.attributes()

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenTwoAsciidoctorInstancesAreCreated.groovy
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenTwoAsciidoctorInstancesAreCreated.groovy
@@ -1,5 +1,7 @@
 package org.asciidoctor
 
+import org.asciidoctor.ast.Block
+import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.extension.BlockMacroProcessor
 import spock.lang.Specification
@@ -25,8 +27,8 @@ testmacro::Test[]
         asciidoctor1.javaExtensionRegistry().blockMacro('testmacro', TestBlockMacroProcessor)
 
         then:
-        asciidoctor1.convert(document, OptionsBuilder.options().headerFooter(false)).contains(TEST_STRING)
-        !asciidoctor2.convert(document, OptionsBuilder.options().headerFooter(false)).contains(TEST_STRING)
+        asciidoctor1.convert(document, OptionsBuilder.options().standalone(false)).contains(TEST_STRING)
+        !asciidoctor2.convert(document, OptionsBuilder.options().standalone(false)).contains(TEST_STRING)
     }
 
 
@@ -36,7 +38,7 @@ testmacro::Test[]
         }
 
         @Override
-        Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
+        Block process(StructuralNode parent, String target, Map<String, Object> attributes) {
             createBlock(parent, PARAGRAPH, TEST_STRING)
         }
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
@@ -143,7 +143,7 @@ public class WhenConverterIsRegistered {
                 "\n" +
                 "== Test" +
                 "\n" +
-                "== Test2\n", OptionsBuilder.options().backend("test3").headerFooter(false));
+                "== Test2\n", OptionsBuilder.options().backend("test3").standalone(false));
 
         assertEquals("== 1 Test ==\n" +
                 "== 42 Test2 ==", result);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/PreprocessorTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/PreprocessorTest.java
@@ -41,7 +41,7 @@ public class PreprocessorTest {
 
         // If I parse the document
         Document ast = asciidoctor.load(document, Options.builder()
-                .headerFooter(true)
+                .standalone(true)
                 .toFile(false)
                 .build());
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
@@ -212,7 +211,7 @@ public class WhenJavaExtensionGroupIsRegistered {
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("simple.adoc"),
-                Options.builder().headerFooter(true).safe(SafeMode.SERVER).toFile(false).build());
+                Options.builder().standalone(true).safe(SafeMode.SERVER).toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -233,7 +232,7 @@ public class WhenJavaExtensionGroupIsRegistered {
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("simple.adoc"),
-                Options.builder().headerFooter(true).safe(SafeMode.SERVER).toFile(false).build());
+                Options.builder().standalone(true).safe(SafeMode.SERVER).toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -801,7 +800,7 @@ public class WhenJavaExtensionGroupIsRegistered {
     }
 
     @Test
-    public void a_block_processor_should_be_executed_when_registered_block_is_found_in_document() throws IOException {
+    public void a_block_processor_should_be_executed_when_registered_block_is_found_in_document() {
 
         this.asciidoctor.createGroup()
             .block("yell", YellStaticBlock.class)
@@ -818,8 +817,7 @@ public class WhenJavaExtensionGroupIsRegistered {
     }
 
     @Test
-    public void a_block_processor_instance_should_be_executed_when_registered_block_is_found_in_document()
-            throws IOException {
+    public void a_block_processor_instance_should_be_executed_when_registered_block_is_found_in_document() {
 
         Map<String, Object> config = new HashMap<String, Object>();
         config.put(Contexts.KEY, Arrays.asList(Contexts.PARAGRAPH));
@@ -839,7 +837,7 @@ public class WhenJavaExtensionGroupIsRegistered {
     }
 
     @Test
-    public void a_block_processor_should_be_executed_when_registered_listing_block_is_found_in_document() throws IOException {
+    public void a_block_processor_should_be_executed_when_registered_listing_block_is_found_in_document() {
 
         this.asciidoctor.createGroup()
             .block("yell", YellStaticListingBlock.class)
@@ -856,8 +854,7 @@ public class WhenJavaExtensionGroupIsRegistered {
     }
 
     @Test
-    public void a_block_processor_instance_should_be_executed_when_registered_listing_block_is_found_in_document()
-            throws IOException {
+    public void a_block_processor_instance_should_be_executed_when_registered_listing_block_is_found_in_document() {
 
         Map<String, Object> config = new HashMap<String, Object>();
         config.put(Contexts.KEY, Arrays.asList(Contexts.LISTING));
@@ -877,7 +874,7 @@ public class WhenJavaExtensionGroupIsRegistered {
     }
 
     @Test
-    public void should_create_toc_with_treeprocessor() throws Exception {
+    public void should_create_toc_with_treeprocessor() {
         this.asciidoctor.createGroup()
             .treeprocessor(new Treeprocessor() {
                 @Override
@@ -896,7 +893,7 @@ public class WhenJavaExtensionGroupIsRegistered {
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("documentwithtoc.adoc"),
-                Options.builder().headerFooter(true).toFile(false).safe(SafeMode.UNSAFE).build());
+                Options.builder().standalone(true).toFile(false).safe(SafeMode.UNSAFE).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element toc = doc.getElementById("toc");
@@ -959,8 +956,7 @@ public class WhenJavaExtensionGroupIsRegistered {
     }
 
     @Test
-    public void should_unregister_block_processor()
-        throws IOException {
+    public void should_unregister_block_processor() {
 
         Map<String, Object> config = new HashMap<String, Object>();
         config.put("contexts", Arrays.asList(":paragraph"));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -213,7 +213,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("simple.adoc"),
-                options().headerFooter(true).safe(SafeMode.SERVER).toFile(false).get());
+                options().standalone(true).safe(SafeMode.SERVER).toFile(false).get());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -233,7 +233,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("simple.adoc"),
-                options().headerFooter(true).safe(SafeMode.SERVER).toFile(false).get());
+                options().standalone(true).safe(SafeMode.SERVER).toFile(false).get());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -988,7 +988,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 classpath.getResource("documentwithtoc.adoc"),
-                options().headerFooter(true).toFile(false).safe(SafeMode.UNSAFE).get());
+                options().standalone(true).toFile(false).safe(SafeMode.UNSAFE).get());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element toc = doc.getElementById("toc");

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionGroupIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionGroupIsRegistered.java
@@ -319,7 +319,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                 "* hidden till clicked            \n" +
                 "* hidden till clicked 2          \n" +
                 "====                             ",
-            options().toFile(false).safe(SafeMode.SAFE).headerFooter(true).get());
+            options().toFile(false).safe(SafeMode.SAFE).standalone(true).get());
 
         final Document document = Jsoup.parse(content);
         final Iterator<Element> elems = document.getElementsByTag("style").iterator();

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
@@ -267,7 +267,7 @@ public class WhenRubyExtensionIsRegistered {
                 "* hidden till clicked            \n" +
                 "* hidden till clicked 2          \n" +
                 "====                             ",
-                options().toFile(false).safe(SafeMode.SAFE).headerFooter(true).get());
+                options().toFile(false).safe(SafeMode.SAFE).standalone(true).get());
 
         final Document document = Jsoup.parse(content);
         final Iterator<Element> elems = document.getElementsByTag("style").iterator();

--- a/asciidoctorj-distribution/src/test/groovy/org/asciidoctor/diagram/WhenAPdfDocumentIsRenderedToStream.groovy
+++ b/asciidoctorj-distribution/src/test/groovy/org/asciidoctor/diagram/WhenAPdfDocumentIsRenderedToStream.groovy
@@ -84,7 +84,7 @@ c
         asciidoctor.convert(testDoc,
                 OptionsBuilder.options()
                         .backend(BACKEND_PDF)
-                        .headerFooter(true)
+                        .standalone(true)
                         .attributes(attrs)
                         .safe(SafeMode.UNSAFE)
                         .toStream(out))
@@ -95,7 +95,7 @@ c
         asciidoctor.convert(testDoc,
                 OptionsBuilder.options()
                         .backend(BACKEND_PDF)
-                        .headerFooter(true)
+                        .standalone(true)
                         .attributes(attrs)
                         .safe(SafeMode.UNSAFE)
                         .toFile(referenceFile))

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/OptionsTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/OptionsTest.java
@@ -38,7 +38,7 @@ public class OptionsTest {
                 asciidoctor.convert(
                         "Hello World",
                         Options.builder()            // <1>
-                                .headerFooter(false) // <2>
+                                .standalone(false)   // <2>
                                 .build());           // <3>
 
         assertThat(result, startsWith("<div "));
@@ -66,7 +66,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void convert_in_unsafe_mode() throws Exception {
+    public void convert_in_unsafe_mode() {
 //tag::unsafeConversion[]
         File sourceFile =
 //end::unsafeConversion[]
@@ -113,7 +113,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void use_font_awesome_icons() throws Exception {
+    public void use_font_awesome_icons() {
 //tag::attributeFontIcons[]
         String result =
             asciidoctor.convert(
@@ -122,11 +122,11 @@ public class OptionsTest {
                     "{foo}",
                     Options.builder()
                             .toFile(false)
-                            .headerFooter(false)
+                            .standalone(false)
                             .attributes(
                                     Attributes.builder()                                          // <1>        
                                             .icons(Attributes.FONT_ICONS)                         // <2>
-                                            .attribute("foo", "bar") // <3>
+                                            .attribute("foo", "bar")   // <3>
                                             .build())
                             .build());
         assertThat(result, containsString("<i class=\"fa icon-note\" title=\"Note\"></i>"));

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/CopyrightFooterPostprocessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/CopyrightFooterPostprocessorTest.java
@@ -36,7 +36,7 @@ public class CopyrightFooterPostprocessorTest {
         String result =
                 asciidoctor.convertFile(doc,
                         Options.builder()
-                                .headerFooter(true)                                            // <2>
+                                .standalone(true)                                            // <2>
                                 .toFile(false)
                                 .build());
 

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/RobotsDocinfoProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/RobotsDocinfoProcessorTest.java
@@ -11,9 +11,6 @@ import org.jsoup.nodes.Element;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.File;
-
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -38,7 +35,7 @@ public class RobotsDocinfoProcessorTest {
         String result = asciidoctor.convert(
                 src,
                 Options.builder()
-                        .headerFooter(true)                      // <2>
+                        .standalone(true)                        // <2>
                         .safe(SafeMode.SERVER)                   // <3>
                         .toFile(false)
                         .build());

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessorTest.java
@@ -33,7 +33,7 @@ public class TerminalCommandTreeprocessorTest {
         String referenceResult = asciidoctor.convertFile(
                 referenceDocument,
                 OptionsBuilder.options()
-                        .headerFooter(false)
+                        .standalone(false)
                         .toFile(false));
 
 //tag::include[]
@@ -47,7 +47,7 @@ public class TerminalCommandTreeprocessorTest {
         String result = asciidoctor.convertFile(
                 src,
                 OptionsBuilder.options()
-                        .headerFooter(false)
+                        .standalone(false)
                         .toFile(false));
 //end::include[]
 
@@ -62,7 +62,7 @@ public class TerminalCommandTreeprocessorTest {
         String referenceResult = asciidoctor.convertFile(
                 referenceDocument,
                 OptionsBuilder.options()
-                        .headerFooter(false)
+                        .standalone(false)
                         .toFile(false));
 
 //tag::include-extension-registry[]
@@ -83,7 +83,7 @@ public class TerminalCommandTreeprocessorTest {
         String result = asciidoctor.convertFile(
             src,
             Options.builder()
-                .headerFooter(false)
+                .standalone(false)
                 .toFile(false)
                 .build());
 //end::include-extension-registry[]

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/YellBlockProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/YellBlockProcessorTest.java
@@ -41,7 +41,7 @@ public class YellBlockProcessorTest {
     }
 
     @Test
-    public void should_invoke_block_processor_with_attributes() throws Exception {
+    public void should_invoke_block_processor_with_attributes() {
         File yellblock_adoc = //...
             classpathResources.getResource("yell-block-attributes.adoc");
 
@@ -53,7 +53,7 @@ public class YellBlockProcessorTest {
     }
 
     @Test
-    public void should_invoke_block_processor_with_positional_attributes() throws Exception {
+    public void should_invoke_block_processor_with_positional_attributes() {
         File yellblock_adoc = //...
             classpathResources.getResource("yell-block-positional.adoc");
 

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/HighlightJsHighlighterTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/HighlightJsHighlighterTest.java
@@ -8,7 +8,6 @@ import org.asciidoctor.SafeMode;
 import org.asciidoctor.util.ClasspathResources;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -33,7 +32,7 @@ public class HighlightJsHighlighterTest {
     public TemporaryFolder tempDir;
 
     @Test
-    public void should_invoke_syntax_highlighter() throws Exception {
+    public void should_invoke_syntax_highlighter() {
 //tag::include[]
         File sources_adoc = //...
 //end::include[]
@@ -46,7 +45,7 @@ public class HighlightJsHighlighterTest {
 
         String result = asciidoctor.convertFile(sources_adoc,
             OptionsBuilder.options()
-                .headerFooter(true) // <2>
+                .standalone(true) // <2>
                 .toFile(false)
                 .attributes(AttributesBuilder.attributes().sourceHighlighter("myhighlightjs"))); // <3>
 
@@ -56,7 +55,7 @@ public class HighlightJsHighlighterTest {
     }
 
     @Test
-    public void should_invoke_syntax_highlighter_with_3_params() throws Exception {
+    public void should_invoke_syntax_highlighter_with_3_params() {
         File sources_adoc =
             classpathResources.getResource("sources.adoc");
 
@@ -66,7 +65,7 @@ public class HighlightJsHighlighterTest {
 
         String result = asciidoctor.convertFile(sources_adoc,
             OptionsBuilder.options()
-                .headerFooter(true)
+                .standalone(true)
                 .toFile(false)
                 .attributes(AttributesBuilder.attributes().sourceHighlighter("myhighlightjs")));
 
@@ -75,7 +74,7 @@ public class HighlightJsHighlighterTest {
     }
 
     @Test
-    public void should_invoke_formatting_syntax_highlighter() throws Exception {
+    public void should_invoke_formatting_syntax_highlighter() {
         File sources_adoc =
             classpathResources.getResource("sources.adoc");
 
@@ -87,7 +86,7 @@ public class HighlightJsHighlighterTest {
 
         String result = asciidoctor.convertFile(sources_adoc,
             OptionsBuilder.options()
-                .headerFooter(true)
+                .standalone(true)
                 .toFile(false)
                 .attributes(AttributesBuilder.attributes().sourceHighlighter("myhighlightjs")));
 
@@ -114,7 +113,7 @@ public class HighlightJsHighlighterTest {
 
         asciidoctor.convertFile(sources_adoc,
             OptionsBuilder.options()
-                .headerFooter(true)
+                .standalone(true)
                 .toDir(toDir)              // <1>
                 .safe(SafeMode.UNSAFE)
                 .attributes(AttributesBuilder.attributes()

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/OrderTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/OrderTest.java
@@ -45,7 +45,7 @@ public class OrderTest {
 
         asciidoctor.convertFile(sources_adoc,
             Options.builder()
-                .headerFooter(true)
+                .standalone(true)
                 .toDir(toDir)
                 .safe(SafeMode.UNSAFE)
                 .attributes(Attributes.builder()

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/PrismJsHighlighterTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/PrismJsHighlighterTest.java
@@ -49,7 +49,7 @@ public class PrismJsHighlighterTest {
 
         asciidoctor.convertFile(sources_adoc,
             OptionsBuilder.options()
-                .headerFooter(true)
+                .standalone(true)
                 .toDir(toDir)
                 .safe(SafeMode.UNSAFE)
                 .attributes(AttributesBuilder.attributes()

--- a/asciidoctorj-springboot-integration-test/springboot-app/src/main/java/org/asciidoctor/it/springboot/AsciidoctorService.java
+++ b/asciidoctorj-springboot-integration-test/springboot-app/src/main/java/org/asciidoctor/it/springboot/AsciidoctorService.java
@@ -19,7 +19,7 @@ public class AsciidoctorService {
         return Options.builder()
                 .backend("html5")
                 .safe(SafeMode.SAFE)
-                .headerFooter(true)
+                .standalone(true)
                 .toFile(false)
                 .build();
     }

--- a/asciidoctorj-test-support/src/main/java/org/asciidoctor/util/ClasspathResources.java
+++ b/asciidoctorj-test-support/src/main/java/org/asciidoctor/util/ClasspathResources.java
@@ -17,7 +17,7 @@ public class ClasspathResources extends ClasspathHelper implements TestRule {
         setClassloader(clazz);
     }
 
-    protected void before(Class<?> clazz) throws Throwable {
+    protected void before(Class<?> clazz) {
         super.setClassloader(clazz);
     }
 

--- a/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/AsciidoctorServlet.java
+++ b/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/AsciidoctorServlet.java
@@ -1,7 +1,5 @@
 package org.asciidoctor;
 
-
-import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -16,19 +14,16 @@ public class AsciidoctorServlet extends HttpServlet {
     private Asciidoctor asciidoctor;
 
     @Override
-    public void init() throws ServletException {
+    public void init() {
         asciidoctor = Asciidoctor.Factory.create();
-
     }
 
     @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         resp.setStatus(200);
         try (InputStreamReader reader = new InputStreamReader(req.getInputStream());
              OutputStreamWriter writer = new OutputStreamWriter(resp.getOutputStream())) {
             asciidoctor.convert(reader, writer, OptionsBuilder.options().get());
         }
-
     }
 }

--- a/docs/modules/ROOT/pages/asciidoctor-api-options.adoc
+++ b/docs/modules/ROOT/pages/asciidoctor-api-options.adoc
@@ -20,115 +20,6 @@ include::example$org/asciidoctor/integrationguide/OptionsTest.java[tags=simpleOp
 
 NOTE: The `convert` method is overloaded so `org.asciidoctor.Options`, `org.asciidoctor.OptionsBuild` or `java.util.Map` can be used.
 
-== toFile
-
-Via the option `toFile` it is possible to define if a document should be written to a file at all and to which file.
-
-To make the API return the converted document and not write to a file set `toFile(false)`.
-
-To make Asciidoctor write to the default file set `toFile(true)`.
-The default file is computed by taking the base name of the input file and adding the default suffix for the target format like `.html` or `.pdf`.
-That is for the input file `test.adoc` the resulting file would be in the same directory with the name `test.html`. +
-*This is also the way the CLI behaves.*
-
-To write to a certain file set `toFile(targetFile)`.
-This is also necessary if you want to convert string content to files.
-
-The following example shows how to convert content to a dedicated file:
-
-[source,java,indent=0]
-.Example for converting to a dedicated file
-----
-include::example$org/asciidoctor/integrationguide/OptionsTest.java[tags=optionToFile]
-----
-<1> Set the option `toFile` so that the result will be written to the file pointed to by `targetFile`.
-<2> Set the safe mode to `UNSAFE` so that files can be written.
-See <<safemode>> for a description of this option.
-
-[[safemode]]
-== safe
-
-Asciidoctor provides security levels that control the read and write access of attributes, the include directive, macros, and scripts while a document is processing.
-Each level includes the restrictions enabled in the prior security level.
-All safe modes are defined by the enum `org.asciidoctor.SafeMode`.
-
-include::partial$safe-modes.adoc[]
-
-So if you want to render documents in the same way as the CLI does you have to set the safe mode to `Unsafe`.
-Without it you will for example not get the stylesheet embedded into the resulting document.
-
-[source,java,indent=0]
-.Converting a document in unsafe mode
-----
-include::example$org/asciidoctor/integrationguide/OptionsTest.java[tags=unsafeConversion]
-----
-<1> Sets the safe mode from `SECURE` to `UNSAFE`.
-<2> Don't convert the file to another file but to a string so that we can easier verify the contents.
-
-The example above will succeed with these two asciidoc files:
-
-[source,asciidoc,indent=0]
-.includingcontent.adoc
---
-  = Including content
-
-  include::includedcontent.adoc[]
---
-
-[source,asciidoc]
-.includedcontent.adoc
-----
-This is included content
-----
-
-== backend
-
-Defines the target format for which the document should be converted.
-Among the possible values are `html5`, `pdf` or `docbook`.
-
-[source,java,indent=0]
-.Converting a document to PDF
-----
-include::example$org/asciidoctor/integrationguide/OptionsTest.java[tags=optionsPDFBackend]
-----
-
-== inPlace
-
-Tells the converter to store the output to a file adjacent to the input file.
-This is `true` by default.
-
-[source,java,indent=0]
-.Setting inPlace option
-----
-OptionsBuilder optionsBuilder =
-            Options.builder().inPlace(true);
-----
-
-== templateDirs
-
-Specifies a directory of {url-tilt}[Tilt]-compatible templates to be used instead of the default built-in templates.
-
-[source,java]
-.Setting templateDirs option
-----
-OptionsBuilder optionsBuilder =
-            Options.builder().templateDirs(new File("templates_path"));
-----
-
-[[sourcemap]]
-== sourcemap
-
-Keeps track of the file and line number for each parsed block.
-This is useful for tooling applications where the association between the converted output and the source file is important.
-The default for this option is `false`.
-
-[source,java]
-.Setting the option sourcemap
-----
-OptionsBuilder optionsBuilder =
-            Options.builder().sourcemap(true);
-----
-
 == attributes
 
 This option allows to define document attributes externally.
@@ -208,3 +99,127 @@ attributesMap.put("my-attribute", "my-value");
 Attributes.builder()
             .attributes(attributesMap);
 ----
+
+== backend
+
+Defines the target format for which the document should be converted.
+Among the possible values are `html5`, `pdf` or `docbook`.
+
+[source,java,indent=0]
+.Converting a document to PDF
+----
+include::example$org/asciidoctor/integrationguide/OptionsTest.java[tags=optionsPDFBackend]
+----
+
+== inPlace
+
+Tells the converter to store the output to a file adjacent to the input file.
+This is `true` by default.
+
+[source,java,indent=0]
+.Setting inPlace option
+----
+OptionsBuilder optionsBuilder =
+            Options.builder().inPlace(true);
+----
+
+[[safemode]]
+== safe
+
+Asciidoctor provides security levels that control the read and write access of attributes, the include directive, macros, and scripts while a document is processing.
+Each level includes the restrictions enabled in the prior security level.
+All safe modes are defined by the enum `org.asciidoctor.SafeMode`.
+
+include::partial$safe-modes.adoc[]
+
+So if you want to render documents in the same way as the CLI does you have to set the safe mode to `Unsafe`.
+Without it you will for example not get the stylesheet embedded into the resulting document.
+
+[source,java,indent=0]
+.Converting a document in unsafe mode
+----
+include::example$org/asciidoctor/integrationguide/OptionsTest.java[tags=unsafeConversion]
+----
+<1> Sets the safe mode from `SECURE` to `UNSAFE`.
+<2> Don't convert the file to another file but to a string so that we can easier verify the contents.
+
+The example above will succeed with these two asciidoc files:
+
+[source,asciidoc,indent=0]
+.includingcontent.adoc
+--
+  = Including content
+
+  include::includedcontent.adoc[]
+--
+
+[source,asciidoc]
+.includedcontent.adoc
+----
+This is included content
+----
+
+[[sourcemap]]
+== sourcemap
+
+Keeps track of the file and line number for each parsed block.
+This is useful for tooling applications where the association between the converted output and the source file is important.
+The default for this option is `false`.
+
+[source,java]
+.Setting the option sourcemap
+----
+OptionsBuilder optionsBuilder =
+            Options.builder().sourcemap(true);
+----
+
+== standalone
+
+If `true`, generates a standalone output document (which includes the shell around the body content, such as the header and footer).
+When converting to a file, the default value is `true`.
+Otherwise, the default value is `false`.
+
+[source,java]
+.Setting the option sourcemap
+----
+OptionsBuilder optionsBuilder =
+            Options.builder().standalone(false);
+----
+
+NOTE: This option replaces and works in the same way as the previous `headerFooter`.
+
+== templateDirs
+
+Specifies a directory of {url-tilt}[Tilt]-compatible templates to be used instead of the default built-in templates.
+
+[source,java]
+.Setting templateDirs option
+----
+OptionsBuilder optionsBuilder =
+            Options.builder().templateDirs(new File("templates_path"));
+----
+
+== toFile
+
+Via the option `toFile` it is possible to define if a document should be written to a file at all and to which file.
+
+To make the API return the converted document and not write to a file set `toFile(false)`.
+
+To make Asciidoctor write to the default file set `toFile(true)`.
+The default file is computed by taking the base name of the input file and adding the default suffix for the target format like `.html` or `.pdf`.
+That is for the input file `test.adoc` the resulting file would be in the same directory with the name `test.html`. +
+*This is also the way the CLI behaves.*
+
+To write to a certain file set `toFile(targetFile)`.
+This is also necessary if you want to convert string content to files.
+
+The following example shows how to convert content to a dedicated file:
+
+[source,java,indent=0]
+.Example for converting to a dedicated file
+----
+include::example$org/asciidoctor/integrationguide/OptionsTest.java[tags=optionToFile]
+----
+<1> Set the option `toFile` so that the result will be written to the file pointed to by `targetFile`.
+<2> Set the safe mode to `UNSAFE` so that files can be written.
+See <<safemode>> for a description of this option.

--- a/docs/modules/extensions/pages/docinfo-processor.adoc
+++ b/docs/modules/extensions/pages/docinfo-processor.adoc
@@ -1,7 +1,7 @@
 [[docinfoprocessor]]
 = Docinfo Processor
 
-Docinfo Processors are primarily targeted for the HTML and DocBook5 target format.
+Docinfo Processors are primarily targeted for the HTML and DocBook5 formats.
 A Docinfo Processor basically allows to add content to the HTML header or at the end of the HTML body.
 For the DocBook5 target format a Docinfo Processor can add content to the info element or at the very end of the document, just before the closing tag of the root element.
 
@@ -21,14 +21,14 @@ Content is added to the header via `LocationType.HEADER` and to the footer via `
 ====
 For the example to work make sure:
 
-* `header_footer` option is not set to `false`, otherwise these will not be added to the document.
+* `standalone` option is not set to `true`, otherwise these will not be added to the document.
 * `safe` mode option is set to at least `SECURE`
 
 .Options configuration example
 [source,java]
 ----
 Options.builder()
-        .headerFooter(true)
+        .standalone(true)
         .safe(SafeMode.SERVER)
         .build();
 ----


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Replace deprecated 'headerFooter' by 'standalone'
* Replace headerFooter methods in OptionsBuild & Options
* Update referenes to the old methods
* Added 'standalone' description to docs
Other changes included:
* Re-ordered options in docs to follow alphabetical order
* Remove some unnecessary throws from tests
* Add missing '@deprecated' to templateDir method

How does it achieve that?

Simply rename method and change the use of the `header_footer` option in the internal map by `standalone`.

Are there any alternative ways to implement this?

We could have deprecated the `headerFooter` method but since this is for v3.0.0...breaking changes are ok.
I'll create a PR to deprecate in v2.5.x

Are there any implications of this pull request? Anything a user must know?
No.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1160

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc