### PR TITLE
Enable GH actions on branch 2.5.x

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - v2.5.x
   pull_request:
     branches:
       - main
+      - v2.5.x
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [X] Build improvement

## Description

What is the goal of this pull request?

Fix pipelines not running on PR on branch v2.5.x

How does it achieve that?

Pretty obvious fix in the configuration :sweat_smile: 
GH reads from the PR file, not the on main `branch`. I'll reuse the open PR on main to remove 2.5 from that.

Are there any alternative ways to implement this?
No

Are there any implications of this pull request? Anything a user must know?
No

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc

Not worth mentioning I think.