### PR TITLE
Retrieve all images in catalog during conversion

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,8 @@ Improvement::
 * Add required `--add-opens` to cli launch script to remove Jdk warnings (#1155) (@abelsromero)
 * Rename deprecated `headerFooter` option to the new `standalone` with same functionality (#1155) (@abelsromero)
 * Remove class `AsciidoctorUtils` to remove complexity and unused logging (#1169) (@abelsromero)
+* Expose ImageReferences in the catalog (#1166) (@abelsromero)
+* Return Document AST when using convert or convertFile with appropriate options (#1171) (@abelsromero)
 
 Bug Fixes::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Catalog.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Catalog.java
@@ -16,6 +16,14 @@ public interface Catalog {
     List<Footnote> getFootnotes();
 
     /**
+     * Retrieves the images from the source document.
+     * Note that inline images are only available after `Document.getContent()` has been called.
+     *
+     * @return images occurring in document.
+     */
+    List<ImageReference> getImages();
+
+    /**
      * Refs is a map of asciidoctor ids to asciidoctor document elements.
      *
      * For example, by default, each section is automatically assigned an id.
@@ -29,4 +37,5 @@ public interface Catalog {
      * @return a map of ids to elements that asciidoctor has collected from the document.
      */
     Map<String, Object> getRefs();
+
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ImageReference.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ImageReference.java
@@ -1,0 +1,8 @@
+package org.asciidoctor.ast;
+
+public interface ImageReference {
+
+    String getTarget();
+
+    String getImagesdir();
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/CatalogImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/CatalogImpl.java
@@ -2,17 +2,18 @@ package org.asciidoctor.jruby.ast.impl;
 
 import org.asciidoctor.ast.Catalog;
 import org.asciidoctor.ast.Footnote;
+import org.asciidoctor.ast.ImageReference;
 import org.asciidoctor.jruby.internal.RubyHashMapDecorator;
 import org.jruby.RubyArray;
 import org.jruby.RubyHash;
 import org.jruby.RubyStruct;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-public class CatalogImpl implements Catalog  {
+public class CatalogImpl implements Catalog {
 
     private final Map<String, Object> catalog;
 
@@ -22,17 +23,23 @@ public class CatalogImpl implements Catalog  {
 
     @Override
     public List<Footnote> getFootnotes() {
-        RubyArray<?> rubyFootnotes = (RubyArray<?>) catalog.get("footnotes");
-        List<Footnote> footnotes = new ArrayList<>();
-        for (Object f : rubyFootnotes) {
-            footnotes.add(FootnoteImpl.getInstance((RubyStruct) f));
-        }
-        return footnotes;
+        return (List<Footnote>) ((RubyArray) catalog.get("footnotes"))
+                .stream()
+                .map(o -> FootnoteImpl.getInstance((RubyStruct) o))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public List<ImageReference> getImages() {
+        return (List<ImageReference>) ((RubyArray) catalog.get("images"))
+                .stream()
+                .map(o -> ImageReferenceImpl.getInstance((RubyStruct) o))
+                .collect(Collectors.toUnmodifiableList());
     }
 
     @Override
     public Map<String, Object> getRefs() {
-        Map <String,Object> refs = new RubyHashMapDecorator((RubyHash) catalog.get("refs"), String.class);
+        Map<String, Object> refs = new RubyHashMapDecorator((RubyHash) catalog.get("refs"), String.class);
         return Collections.unmodifiableMap(refs);
     }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/FootnoteImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/FootnoteImpl.java
@@ -1,8 +1,7 @@
 package org.asciidoctor.jruby.ast.impl;
 
-import org.jruby.RubyStruct;
-
 import org.asciidoctor.ast.Footnote;
+import org.jruby.RubyStruct;
 import org.jruby.javasupport.JavaEmbedUtils;
 
 public class FootnoteImpl implements Footnote {
@@ -15,11 +14,11 @@ public class FootnoteImpl implements Footnote {
     private String id;
     private String text;
 
-    private static Object aref(RubyStruct s, String key)  {
-       return JavaEmbedUtils.rubyToJava(s.aref(s.getRuntime().newString(key)));
+    private static Object aref(RubyStruct s, String key) {
+        return JavaEmbedUtils.rubyToJava(s.aref(s.getRuntime().newString(key)));
     }
 
-    public static Footnote getInstance(Long index, String id, String text)  {
+    public static Footnote getInstance(Long index, String id, String text) {
         FootnoteImpl footnote = new FootnoteImpl();
         footnote.index = index;
         footnote.id = id;
@@ -35,11 +34,17 @@ public class FootnoteImpl implements Footnote {
     }
 
     @Override
-    public Long getIndex() { return index; }
+    public Long getIndex() {
+        return index;
+    }
 
     @Override
-    public String getId() { return id; }
+    public String getId() {
+        return id;
+    }
 
     @Override
-    public String getText() { return text; }
+    public String getText() {
+        return text;
+    }
 }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ImageReferenceImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ImageReferenceImpl.java
@@ -1,0 +1,39 @@
+package org.asciidoctor.jruby.ast.impl;
+
+import org.asciidoctor.ast.ImageReference;
+import org.jruby.RubyStruct;
+import org.jruby.javasupport.JavaEmbedUtils;
+
+public class ImageReferenceImpl implements ImageReference {
+
+    private static final String IMAGESDIR_KEY_NAME = "imagesdir";
+    private static final String TARGET_KEY_NAME = "target";
+
+    private final String target;
+    private final String imagesdir;
+
+    private ImageReferenceImpl(String target, String imagesdir) {
+        this.target = target;
+        this.imagesdir = imagesdir;
+    }
+
+    static ImageReference getInstance(RubyStruct rubyFootnote) {
+        final String target = (String) aref(rubyFootnote, TARGET_KEY_NAME);
+        final String imagesdir = (String) aref(rubyFootnote, IMAGESDIR_KEY_NAME);
+        return new ImageReferenceImpl(target, imagesdir);
+    }
+
+    private static Object aref(RubyStruct s, String key) {
+        return JavaEmbedUtils.rubyToJava(s.aref(s.getRuntime().newString(key)));
+    }
+
+    @Override
+    public String getTarget() {
+        return target;
+    }
+
+    @Override
+    public String getImagesdir() {
+        return imagesdir;
+    }
+}

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyGemsPreloader.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyGemsPreloader.java
@@ -1,11 +1,10 @@
 package org.asciidoctor.jruby.internal;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.asciidoctor.Attributes;
 import org.asciidoctor.Options;
 import org.jruby.Ruby;
+
+import java.util.Map;
 
 public class RubyGemsPreloader {
 
@@ -15,18 +14,16 @@ public class RubyGemsPreloader {
     private static final String PDF = "pdf";
     private static final String REVEALJS = "asciidoctor-revealjs";
 
-    private static final Map<String, String> optionToRequiredGem = new HashMap<String, String>() {
-        {
-            put(Attributes.SOURCE_HIGHLIGHTER, "require 'coderay'");
-            put(Options.ERUBY, "require 'erubis'");
-            put(Options.TEMPLATE_DIRS, "require 'tilt'");
-            put(Attributes.DATA_URI, "require 'base64'");
-            put(Attributes.CACHE_URI, "require 'open-uri/cached'");
-            put(EPUB3, "require 'asciidoctor-epub3'");
-            put(PDF, "require 'asciidoctor-pdf'");
-            put(REVEALJS, "require 'asciidoctor-revealjs'");
-        }
-    };
+    private static final Map<String, String> optionToRequiredGem = Map.of(
+            Options.ERUBY, "require 'erubis'",
+            Options.TEMPLATE_DIRS, "require 'tilt'",
+            Attributes.CACHE_URI, "require 'open-uri/cached'",
+            Attributes.DATA_URI, "require 'base64'",
+            Attributes.SOURCE_HIGHLIGHTER, "require 'coderay'",
+            EPUB3, "require 'asciidoctor-epub3'",
+            PDF, "require 'asciidoctor-pdf'",
+            REVEALJS, "require 'asciidoctor-revealjs'"
+    );
 
     private Ruby rubyRuntime;
 
@@ -60,16 +57,16 @@ public class RubyGemsPreloader {
         if (isOptionSet(options, Options.TEMPLATE_DIRS)) {
             preloadLibrary(Options.TEMPLATE_DIRS);
         }
-        
-        if(isOptionSet(options, Options.BACKEND) && "epub3".equalsIgnoreCase((String) options.get(Options.BACKEND))) {
+
+        if (isOptionSet(options, Options.BACKEND) && "epub3".equalsIgnoreCase((String) options.get(Options.BACKEND))) {
             preloadLibrary(EPUB3);
         }
 
-        if(isOptionSet(options, Options.BACKEND) && "pdf".equalsIgnoreCase((String) options.get(Options.BACKEND))) {
+        if (isOptionSet(options, Options.BACKEND) && "pdf".equalsIgnoreCase((String) options.get(Options.BACKEND))) {
             preloadLibrary(PDF);
         }
 
-        if(isOptionSet(options, Options.BACKEND) && "revealjs".equalsIgnoreCase((String) options.get(Options.BACKEND))) {
+        if (isOptionSet(options, Options.BACKEND) && "revealjs".equalsIgnoreCase((String) options.get(Options.BACKEND))) {
             preloadLibrary(REVEALJS);
         }
     }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTwoAsciidoctorInstancesAreCreated.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTwoAsciidoctorInstancesAreCreated.groovy
@@ -1,7 +1,6 @@
 package org.asciidoctor
 
 import org.asciidoctor.ast.Block
-import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.extension.BlockMacroProcessor
 import spock.lang.Specification
@@ -13,7 +12,6 @@ class WhenTwoAsciidoctorInstancesAreCreated extends Specification {
     private static final String TEST_STRING = 'Hello World'
 
     def "then every Asciidoctor instance has its own extension registry"() {
-
         given:
         String document = '''= Test document
 
@@ -21,16 +19,16 @@ testmacro::Test[]
 '''
 
         when:
-        Asciidoctor asciidoctor1 = Asciidoctor.Factory.create(getClass().classLoader)
-        Asciidoctor asciidoctor2 = Asciidoctor.Factory.create(getClass().classLoader)
+        Asciidoctor asciidoctor1 = Asciidoctor.Factory.create()
+        Asciidoctor asciidoctor2 = Asciidoctor.Factory.create()
 
         asciidoctor1.javaExtensionRegistry().blockMacro('testmacro', TestBlockMacroProcessor)
 
         then:
-        asciidoctor1.convert(document, OptionsBuilder.options().standalone(false)).contains(TEST_STRING)
-        !asciidoctor2.convert(document, OptionsBuilder.options().standalone(false)).contains(TEST_STRING)
+        def standaloneDisabledOptions = Options.builder().standalone(false).build()
+        asciidoctor1.convert(document, standaloneDisabledOptions).contains(TEST_STRING)
+        !asciidoctor2.convert(document, standaloneDisabledOptions).contains(TEST_STRING)
     }
-
 
     static class TestBlockMacroProcessor extends BlockMacroProcessor {
         TestBlockMacroProcessor(String macroName) {

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/WhenFootnotesAreUsed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/WhenFootnotesAreUsed.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.converter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.Document
 import org.asciidoctor.ast.Footnote
@@ -13,22 +13,23 @@ import org.junit.runner.RunWith
 import spock.lang.Specification
 
 import static org.hamcrest.Matchers.contains
-import static org.hamcrest.Matchers.empty
 import static org.hamcrest.Matchers.samePropertyValuesAs
 import static org.junit.Assert.assertThat
 
 /**
  * Tests that footnotes can be accessed from converter.
  *
- * Note that it is a current limitation of asciidoctor that footnotes are not available until
- * after they have been converted for the document.
+ * Note that it is a current limitation of asciidoctor that footnotes are not
+ * available until after they have been converted for the document.
  */
 @RunWith(ArquillianSputnik)
 class WhenFootnotesAreUsed extends Specification {
+
     static final String CONVERTER_BACKEND = 'footnote'
 
     @ArquillianResource
     private Asciidoctor asciidoctor
+
     private static List<Footnote> footnotesBeforeConvert
     private static List<Footnote> footnotesAfterConvert
 
@@ -42,15 +43,15 @@ class WhenFootnotesAreUsed extends Specification {
          * we simply want to force the conversion to verify that footnotes
          * are populated.
          */
+
         @Override
         String convert(ContentNode node, String transform, Map<Object, Object> opts) {
             if (node instanceof Document) {
                 def doc = (Document) node
-                footnotesBeforeConvert = doc.catalog.footnotes.collect()
+                footnotesBeforeConvert = doc.catalog.footnotes
                 doc.content
-                footnotesAfterConvert = doc.catalog.footnotes.collect()
-            }
-            else if (node instanceof StructuralNode) {
+                footnotesAfterConvert = doc.catalog.footnotes
+            } else if (node instanceof StructuralNode) {
                 ((StructuralNode) node).content
             }
         }
@@ -63,7 +64,8 @@ class WhenFootnotesAreUsed extends Specification {
     }
 
     def convert(String document) {
-        asciidoctor.convert(document, OptionsBuilder.options().backend(CONVERTER_BACKEND))
+        def options = Options.builder().backend(CONVERTER_BACKEND).build()
+        asciidoctor.convert(document, options)
     }
 
     def footnote(Long index, String id, String text) {
@@ -78,8 +80,8 @@ class WhenFootnotesAreUsed extends Specification {
         convert(document)
 
         then:
-        assertThat(footnotesBeforeConvert, empty())
-        assertThat(footnotesAfterConvert, empty())
+        footnotesBeforeConvert.isEmpty()
+        footnotesAfterConvert.isEmpty()
     }
 
     def 'when a footnote is is in source doc, it should be accessible from converter'() {
@@ -90,9 +92,9 @@ class WhenFootnotesAreUsed extends Specification {
         convert(document)
 
         then:
-        assertThat(footnotesBeforeConvert, empty())
+        footnotesBeforeConvert.isEmpty()
         assertThat(footnotesAfterConvert,
-                contains(samePropertyValuesAs(footnote(1,'fid','we shall find out!'))))
+                contains(samePropertyValuesAs(footnote(1, 'fid', 'we shall find out!'))))
     }
 
     def 'when footnotes are in source doc, they should be accessible from the converter'() {
@@ -108,9 +110,9 @@ An existing footnote can be referenced.footnote:myid1[]
         convert(document)
 
         then:
-        assertThat(footnotesBeforeConvert, empty())
+        footnotesBeforeConvert.isEmpty()
         assertThat(footnotesAfterConvert,
-                contains(samePropertyValuesAs(footnote(1,'myid1','first footnote')),
-                         samePropertyValuesAs(footnote(2, null, 'second footnote'))))
+                contains(samePropertyValuesAs(footnote(1, 'myid1', 'first footnote')),
+                        samePropertyValuesAs(footnote(2, null, 'second footnote'))))
     }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenReaderIsManipulatedInExtension.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenReaderIsManipulatedInExtension.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -32,7 +32,7 @@ public class WhenReaderIsManipulatedInExtension {
         javaExtensionRegistry.preprocessor(NumberLinesPreprocessor.class);
 
         File inputFile = classpath.getResource("rendersample.asciidoc");
-        asciidoctor.convertFile(inputFile, new HashMap<String, Object>());
+        asciidoctor.convertFile(inputFile, Map.of());
 
         File outpuFile = new File(inputFile.getParent(), "rendersample.asciidoc");
         assertThat(outpuFile.exists(), is(true));
@@ -48,10 +48,10 @@ public class WhenReaderIsManipulatedInExtension {
 
         asciidoctor.convertFile(
                 classpath.getResource("rendersample.asciidoc"),
-                new HashMap<String, Object>());
+                Map.of());
 
         File inputFile = classpath.getResource("rendersample.asciidoc");
-        asciidoctor.convertFile(inputFile, new HashMap<String, Object>());
+        asciidoctor.convertFile(inputFile, Map.of());
 
         File outpuFile = new File(inputFile.getParent(), "rendersample.asciidoc");
         assertThat(outpuFile.exists(), is(true));
@@ -67,10 +67,10 @@ public class WhenReaderIsManipulatedInExtension {
 
         asciidoctor.convertFile(
                 classpath.getResource("rendersample.asciidoc"),
-                new HashMap<String, Object>());
+                Map.of());
 
         File inputFile = classpath.getResource("rendersample.asciidoc");
-        asciidoctor.convertFile(inputFile, new HashMap<String, Object>());
+        asciidoctor.convertFile(inputFile, Map.of());
 
         File outpuFile = new File(inputFile.getParent(), "rendersample.asciidoc");
         assertThat(outpuFile.exists(), is(true));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/TestImageReference.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/TestImageReference.java
@@ -1,0 +1,33 @@
+package org.asciidoctor.jruby.ast.impl;
+
+import org.asciidoctor.ast.ImageReference;
+
+/**
+ * Test implementation of {@link ImageReference}.
+ * Cannot use default implementation because it's package protected.
+ */
+public class TestImageReference implements ImageReference {
+
+    private final String target;
+    private final String imagesdir;
+
+    public TestImageReference(String target) {
+        this.target = target;
+        this.imagesdir = null;
+    }
+
+    public TestImageReference(String target, String imagesdir) {
+        this.target = target;
+        this.imagesdir = imagesdir;
+    }
+
+    @Override
+    public String getTarget() {
+        return target;
+    }
+
+    @Override
+    public String getImagesdir() {
+        return imagesdir;
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/internal/WhenReadingImagesFromCatalogAsset.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/internal/WhenReadingImagesFromCatalogAsset.java
@@ -1,0 +1,188 @@
+package org.asciidoctor.jruby.internal;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
+import org.asciidoctor.SafeMode;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.ImageReference;
+import org.asciidoctor.jruby.ast.impl.TestImageReference;
+import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+public class WhenReadingImagesFromCatalogAsset {
+
+    @ArquillianResource
+    private ClasspathResources classpath;
+
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
+
+    @ArquillianResource
+    private TemporaryFolder testFolder;
+
+    static final TestImageReference[] BLOCK_IMAGES = new TestImageReference[]{
+            new TestImageReference("images/block-image.jpg")
+    };
+
+    static final TestImageReference[] ALL_IMAGES = new TestImageReference[]{
+            new TestImageReference("images/block-image.jpg"),
+            new TestImageReference("images/inline-image.png")
+    };
+
+    @Test
+    public void shouldReturnEmptyWhenThereAreNoImages() {
+        final Options options = Options.builder()
+                .catalogAssets(true)
+                .build();
+
+        Document document = asciidoctor.load("= Hello", options);
+        List<ImageReference> images = document.getCatalog().getImages();
+
+        assertThat(images)
+                .isEmpty();
+    }
+
+    @Test
+    public void shouldReturnNullImagesDirWhenNotSet() {
+        final Options options = Options.builder()
+                .catalogAssets(true)
+                .build();
+        final String content = getAsciiDocWithImagesContent();
+
+        Document document = asciidoctor.load(content, options);
+        List<ImageReference> images = document.getCatalog().getImages();
+
+        assertThat(images)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(BLOCK_IMAGES);
+    }
+
+    @Test
+    public void shouldReturnImagesDirWhenSet() {
+        final Options options = Options.builder()
+                .catalogAssets(true)
+                .attributes(Attributes.builder()
+                        .imagesDir("some-path")
+                        .build())
+                .build();
+        final String content = getAsciiDocWithImagesContent();
+
+        Document document = asciidoctor.load(content, options);
+        List<ImageReference> images = document.getCatalog().getImages();
+
+        assertThat(images)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(new TestImageReference("images/block-image.jpg", "some-path"));
+    }
+
+    @Test
+    public void shouldNotCatalogInlineImagesWhenNotConverting() {
+        final Options options = Options.builder()
+                .catalogAssets(true)
+                .build();
+        final String content = getAsciiDocWithImagesContent();
+
+        Document document = asciidoctor.load(content, options);
+
+        List<ImageReference> images = document.getCatalog().getImages();
+        assertThat(images)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(BLOCK_IMAGES);
+    }
+
+    @Test
+    public void shouldCatalogInlineImagesWhenProcessingContentAfterLoad() {
+        final Options options = Options.builder()
+                .catalogAssets(true)
+                .build();
+        final String content = getAsciiDocWithImagesContent();
+
+        Document document = asciidoctor.load(content, options);
+        document.getContent();
+
+        List<ImageReference> images = document.getCatalog().getImages();
+        assertThat(images)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(ALL_IMAGES);
+    }
+
+    @Test
+    public void shouldNotCatalogImagesWhenCatalogAssetsIsFalse() {
+        final Options options = Options.builder()
+                .catalogAssets(false)
+                .build();
+        final String content = getAsciiDocWithImagesContent();
+
+        Document document = asciidoctor.load(content, options);
+        document.getContent();
+
+        List<ImageReference> images = document.getCatalog().getImages();
+        assertThat(images).isEmpty();
+    }
+
+    @Test
+    public void shouldCatalogAllImagesWhenUsingConvertFile() throws IOException {
+        final Options options = Options.builder()
+                .catalogAssets(true)
+                .safe(SafeMode.UNSAFE)
+                .toFile(testFolder.newFile())
+                .build();
+        final File file = getAsciiDocWithImagesFile();
+
+        var document = asciidoctor.convertFile(file, options, Document.class);
+
+        assertThat(document)
+                .isInstanceOf(Document.class);
+
+        List<ImageReference> images = document.getCatalog().getImages();
+        assertThat(images)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(ALL_IMAGES);
+    }
+
+    @Test
+    public void shouldCatalogAllImagesWhenUsingConvert() throws IOException {
+        final Options options = Options.builder()
+                .catalogAssets(true)
+                .safe(SafeMode.UNSAFE)
+                .toFile(testFolder.newFile())
+                .build();
+        final String content = getAsciiDocWithImagesContent();
+
+        var document = asciidoctor.convert(content, options, Document.class);
+
+        assertThat(document)
+                .isInstanceOf(Document.class);
+
+        List<ImageReference> images = document.getCatalog().getImages();
+        assertThat(images)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(ALL_IMAGES);
+    }
+
+    private String getAsciiDocWithImagesContent() {
+        try {
+            return Files.readString(getAsciiDocWithImagesFile().toPath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private File getAsciiDocWithImagesFile() {
+        return classpath.getResource("sample-with-images.adoc");
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/internal/WhenReadingImagesFromCatalogAssetFromConverter.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/internal/WhenReadingImagesFromCatalogAssetFromConverter.java
@@ -1,0 +1,145 @@
+package org.asciidoctor.jruby.internal;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.asciidoctor.arquillian.api.Unshared;
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.ImageReference;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.converter.StringConverter;
+import org.asciidoctor.jruby.ast.impl.TestImageReference;
+import org.asciidoctor.util.ClasspathResources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+public class WhenReadingImagesFromCatalogAssetFromConverter {
+
+    @ArquillianResource
+    private ClasspathResources classpath;
+
+    @ArquillianResource(Unshared.class)
+    private Asciidoctor asciidoctor;
+
+    static final String CONVERTER_BACKEND = "custom-backend";
+
+    static final TestImageReference[] BLOCK_IMAGES = new TestImageReference[]{
+            new TestImageReference("images/block-image.jpg")
+    };
+
+    static final TestImageReference[] ALL_IMAGES = new TestImageReference[]{
+            new TestImageReference("images/block-image.jpg"),
+            new TestImageReference("images/inline-image.png")
+    };
+
+    private static List<ImageReference> imagesBeforeConvert;
+    private static List<ImageReference> imagesAfterConvert;
+
+    @Before
+    public void beforeEach() {
+        final var javaConverterRegistry = asciidoctor.javaConverterRegistry();
+        javaConverterRegistry.converters().clear();
+        javaConverterRegistry.register(TestConverter.class, CONVERTER_BACKEND);
+
+        imagesBeforeConvert = null;
+        imagesAfterConvert = null;
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenThereAreNoImages() {
+        final String content = "";
+
+        convert(content);
+
+        assertThat(imagesBeforeConvert).isEmpty();
+        assertThat(imagesAfterConvert).isEmpty();
+    }
+
+    @Test
+    public void shouldNotCatalogAnyImageWhenUsingLoad() {
+        final String content = getAsciiDodWithImagesDocument();
+
+        load(content);
+
+        assertThat(imagesBeforeConvert).isNull();
+        assertThat(imagesAfterConvert).isNull();
+    }
+
+    @Test
+    public void shouldReturnAllImages() {
+        final String content = getAsciiDodWithImagesDocument();
+
+        convert(content);
+
+        assertThat(imagesBeforeConvert)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(BLOCK_IMAGES);
+        assertThat(imagesAfterConvert)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(ALL_IMAGES);
+    }
+
+    private String convert(String document) {
+        var options = optionsWithConverter();
+        return asciidoctor.convert(document, options);
+    }
+
+    private void load(String document) {
+        var options = optionsWithConverter();
+        asciidoctor.load(document, options);
+    }
+
+    private static Options optionsWithConverter() {
+        return Options.builder()
+                .catalogAssets(true)
+                .backend(CONVERTER_BACKEND)
+                .build();
+    }
+
+    private String getAsciiDodWithImagesDocument() {
+        try {
+            return Files.readString(classpath.getResource("sample-with-images.adoc").toPath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class TestConverter extends StringConverter {
+
+        public TestConverter(String backend, Map<String, Object> opts) {
+            super(backend, opts);
+        }
+
+        /*
+         * For this conversion test we do not care about the conversion result,
+         * we simply want to force the conversion to verify that images references
+         * are populated.
+         */
+
+        @Override
+        public String convert(ContentNode node, String transform, Map<Object, Object> opts) {
+            String content = "";
+            if (node instanceof Document) {
+                var doc = (Document) node;
+                imagesBeforeConvert = doc.getCatalog().getImages();
+                // force content to process inline images
+                content = (String) doc.getContent();
+                imagesAfterConvert = doc.getCatalog().getImages();
+            } else if (node instanceof StructuralNode) {
+                content = (String) ((StructuralNode) node).getContent();
+            }
+            return content;
+        }
+    }
+}

--- a/asciidoctorj-core/src/test/resources/sample-with-images.adoc
+++ b/asciidoctorj-core/src/test/resources/sample-with-images.adoc
@@ -1,0 +1,9 @@
+= This is a title
+
+== A few images
+
+A block image
+
+image::images/block-image.jpg[]
+
+An inlined image image:images/inline-image.png[] in the text.


### PR DESCRIPTION
## Kind of change

- [x] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
**DRAFT PR, WIP**

Offer users the option to obtain images from the assets catalog.
**However**, it only works when calling `load()+getContent()`, and unlike in Asciidoctor Ruby, we cannot call `convert` because it fails (see [comment](https://github.com/asciidoctor/asciidoctorj/issues/1166#issuecomment-1500921789)).

How does it achieve that?

Exposes the images properties from the catalog.
However, this PR is not done yet untill:
- [ ] Fix using `convert` to obtain the `Document` instance
- [ ] Fix catalog not being available when using custom converters (see failing test `WhenReadingImagesFromCatalogAssetFromConverter`) :point_right: I think that fixing the first issue should fix this.
- [ ] Docs

Are there any alternative ways to implement this?

WIP

Are there any implications of this pull request? Anything a user must know?

Not

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1166 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc