### PR TITLE
Fix 1158 concurrent conversion to stream

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,7 @@ Bug Fixes::
 * Cell nodes do not inherit from StructuralNode (#1086) (@rahmanusta)
 * Avoid throwing an exception when using AsciidoctorJ CLI and reading input from stdin (#1105) (@AlexCzar)
 * Remove destinationDir Option from API (use toDir instead) (#853, #941) (@abelsromero)
+* Fix ConcurrentModificationException when converting to stream concurrently (#1158) (@rocketraman)
 
 Build Improvement::
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -10,7 +10,6 @@ import org.asciidoctor.extension.ExtensionGroup;
 import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.extension.RubyExtensionRegistry;
 import org.asciidoctor.jruby.AsciidoctorJRuby;
-import org.asciidoctor.jruby.DirectoryWalker;
 import org.asciidoctor.jruby.ast.impl.DocumentHeaderImpl;
 import org.asciidoctor.jruby.ast.impl.NodeConverter;
 import org.asciidoctor.jruby.converter.internal.ConverterRegistryExecutor;
@@ -22,13 +21,30 @@ import org.asciidoctor.jruby.syntaxhighlighter.internal.SyntaxHighlighterRegistr
 import org.asciidoctor.log.LogHandler;
 import org.asciidoctor.log.LogRecord;
 import org.asciidoctor.syntaxhighlighter.SyntaxHighlighterRegistry;
-import org.jruby.*;
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyHash;
+import org.jruby.RubyInstanceConfig;
+import org.jruby.RubyModule;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
@@ -59,6 +75,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
         this.rubyGemsPreloader = new RubyGemsPreloader(this.rubyRuntime);
         this.logHandlers.add(new JULLogHandler());
+        RubyOutputStreamWrapper.createOutputStreamWrapperClass(this.rubyRuntime);
     }
 
     public static JRubyAsciidoctor create() {
@@ -183,7 +200,6 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
         return toDocumentHeader(document);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public DocumentHeader readDocumentHeader(String content) {
 
@@ -214,10 +230,6 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
             }
         }
         return asciidoctorContent;
-    }
-
-    private List<File> scanForAsciiDocFiles(DirectoryWalker directoryWalker) {
-        return directoryWalker.scan();
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyOutputStreamWrapper.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyOutputStreamWrapper.java
@@ -22,7 +22,7 @@ public class RubyOutputStreamWrapper extends RubyObject {
 
   private int bytesWritten = 0;
 
-  public static IRubyObject wrap(final Ruby rubyRuntime, final OutputStream out) {
+  static IRubyObject wrap(final Ruby rubyRuntime, final OutputStream out) {
 
     final RubyClass rubyClass = getOutputStreamWrapperClass(rubyRuntime);
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyOutputStreamWrapper.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyOutputStreamWrapper.java
@@ -8,7 +8,6 @@ import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -25,7 +24,7 @@ public class RubyOutputStreamWrapper extends RubyObject {
 
   public static IRubyObject wrap(final Ruby rubyRuntime, final OutputStream out) {
 
-    final RubyClass rubyClass = getOrCreateOutputStreamWrapperClass(rubyRuntime);
+    final RubyClass rubyClass = getOutputStreamWrapperClass(rubyRuntime);
 
     final IRubyObject wrapper = rubyClass.allocate();
 
@@ -46,23 +45,15 @@ public class RubyOutputStreamWrapper extends RubyObject {
     return out;
   }
 
-  public static RubyClass getOrCreateOutputStreamWrapperClass(final Ruby rubyRuntime) {
+  static void createOutputStreamWrapperClass(final Ruby rubyRuntime) {
     RubyModule asciidoctorModule = rubyRuntime.getModule("AsciidoctorJ");
-    RubyClass outputStreamWrapperClass = asciidoctorModule.getClass(RUBY_CLASS_NAME);
-    if (outputStreamWrapperClass != null) {
-      return outputStreamWrapperClass;
-    }
-
-    final RubyClass rubyClass = asciidoctorModule.defineClassUnder(RUBY_CLASS_NAME, rubyRuntime.getObject(), new ObjectAllocator() {
-      @Override
-      public IRubyObject allocate(final Ruby runtime, final RubyClass klazz) {
-        return new RubyOutputStreamWrapper(runtime, klazz);
-      }
-    });
-
+    final RubyClass rubyClass = asciidoctorModule.defineClassUnder(RUBY_CLASS_NAME, rubyRuntime.getObject(), RubyOutputStreamWrapper::new);
     rubyClass.defineAnnotatedMethods(RubyOutputStreamWrapper.class);
+  }
 
-    return rubyClass;
+  private static RubyClass getOutputStreamWrapperClass(final Ruby rubyRuntime) {
+    RubyModule asciidoctorModule = rubyRuntime.getModule("AsciidoctorJ");
+    return asciidoctorModule.getClass(RUBY_CLASS_NAME);
   }
 
   @JRubyMethod(name = "write", required = 1)


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Fix the issue reported in #1158.
When converting to a stream a new RubyClass is created lazily.
This step is not protected with a mutex, so that JRuby can fail.
This PR wants to fix this so that this exception does not occur when converting documents in parallel with one Asciidoctor instance.

How does it achieve that?

Eagerly create the class when initializing the Asciidoctor instance.

Are there any alternative ways to implement this?

Yes, the class could be created lazily and a mutex could guarantee mutual exclusion so that the class is created only once.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1158 on the main branch 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc