### PR TITLE
Remove unnecessary tests reports destination

### DIFF
--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -135,15 +135,6 @@ task pollutedTest(type: Test) {
       }
     }
   }
-
-  reports {
-    html {
-      destination file("$buildDir/reports/pollutedTest")
-    }
-    junitXml {
-      destination file("$buildDir/pollutedTest-result")
-    }
-  }
 }
 
 test.dependsOn pollutedTest

--- a/asciidoctorj-wildfly-integration-test/build.gradle
+++ b/asciidoctorj-wildfly-integration-test/build.gradle
@@ -85,15 +85,6 @@ test {
         }
     }
 
-    reports {
-        html {
-            destination file("$buildDir/reports/integrationTest")
-        }
-        junitXml {
-            destination file("$buildDir/integrationTest")
-        }
-    }
-
     def jbossHome = file("build/wildfly-$wildflyVersion").absolutePath
     systemProperty('jboss.home', jbossHome)
     systemProperty('module.path', jbossHome + "/modules" + File.pathSeparator + file('build/modules').absolutePath)


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [X] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*

Simplify Gradle configuration removing an unnecessary configuration, see #1188 for details

*How does it achieve that?*

Just removes it, no other changes are necessary, reports path in CI still match.

*Are there any alternative ways to implement this?*

No :thinking: 

Are there any implications of this pull request? Anything a user must know?

No

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1188 

## Release notes

This is an internal change, I don't think it's worth adding to changelog.