### PR TITLE
Use junit-pioneer to simplify polluted tests

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -53,6 +53,7 @@ Build Improvement::
 * Fix upstream tests forcing SNAPSHOT on Asciidoctor gem installation (#1123) (@abelsromero)
 * Fix upstream build removing the explicit plugin repository (#1131)
 * Set JUnit5 as default test engine (#1186) (@abelsromero)
+* Removed pollutedTest Gradle task using junit-pioneer (#1193) (@abelsromero)
 
 == 2.5.4 (2022-06-30)
 

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -95,9 +95,7 @@ jar {
 }
 
 test {
-  useJUnitPlatform() {
-    excludeTags("polluted")
-  }
+  useJUnitPlatform()
 }
 
 task createVersionFile {
@@ -112,29 +110,5 @@ version.asciidoctor: $asciidoctorGemVersion
 """
   }
 }
+
 jar.dependsOn createVersionFile
-
-task pollutedTest(type: Test) {
-  useJUnitPlatform() {
-    includeTags 'polluted'
-  }
-  forkEvery = 10
-  minHeapSize = '128m'
-  maxHeapSize = '1024m'
-  jvmArgs '-XX:-UseGCOverheadLimit'
-
-  environment 'GEM_PATH', '/some/path'
-  environment 'GEM_HOME', '/some/other/path'
-
-  testLogging {
-    // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
-    // events 'standard_out', 'standard_error'
-    afterSuite { desc, result ->
-      if (!desc.parent && logger.infoEnabled) {
-        logger.info "Test results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
-      }
-    }
-  }
-}
-
-test.dependsOn pollutedTest

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.java
@@ -4,12 +4,17 @@ import org.asciidoctor.categories.Polluted;
 import org.asciidoctor.jruby.AsciidoctorJRuby;
 import org.asciidoctor.jruby.internal.JRubyRuntimeContext;
 import org.jruby.Ruby;
-import org.jruby.RubyString;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * This test checks if the Ruby instance for an Asciidoctor instance is
@@ -20,51 +25,77 @@ import static org.junit.Assert.assertThat;
 @Polluted
 public class WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath {
 
-    @Test
-    public void should_not_have_gempath_in_ruby_env_when_created_with_null_gempath() {
+    @ParameterizedTest(name = "should_not_have_gempath_in_ruby_env_when_created_with_{1}")
+    @MethodSource("emptyGempathAsciidoctorProvider")
+    public void should_not_have_gempath_in_ruby_env_when_created_with_(Asciidoctor asciidoctor, String testDescription) {
         // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
-        assertThat(System.getenv("GEM_PATH"), notNullValue());
-        assertThat(System.getenv("GEM_HOME"), notNullValue());
-
-        // When: A new Asciidoctor instance is created passing in a null GEM_PATH
-        Asciidoctor asciidoctor = AsciidoctorJRuby.Factory.create((String) null);
+        assertThat(System.getenv("GEM_PATH")).isNotEmpty();
+        assertThat(System.getenv("GEM_HOME")).isNotEmpty();
 
         // Then: The org.jruby.JRuby instance does not see this variable
         Ruby rubyRuntime = JRubyRuntimeContext.get(asciidoctor);
-        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is(rubyRuntime.getNil()));
-        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is(rubyRuntime.getNil()));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']")).isEqualTo(rubyRuntime.getNil());
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']")).isEqualTo(rubyRuntime.getNil());
     }
 
-    @Test
-    public void should_have_gempath_in_ruby_env_when_created_with_default_create() {
-        // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
-        assertThat(System.getenv("GEM_PATH"), notNullValue());
-        assertThat(System.getenv("GEM_HOME"), notNullValue());
-
-        // When: A new Asciidoctor instance is created passing in no GEM_PATH
-        Asciidoctor asciidoctor = AsciidoctorJRuby.Factory.create();
-
-        // Then: The org.jruby.JRuby instance sees this variable
-        Ruby rubyRuntime = JRubyRuntimeContext.get(asciidoctor);
-        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is(rubyRuntime.getNil()));
-        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is(rubyRuntime.getNil()));
+    private static Stream<Arguments> emptyGempathAsciidoctorProvider() {
+        return Stream.of(
+                arguments(AsciidoctorJRuby.Factory.create(), "default_create"),
+                arguments(AsciidoctorJRuby.Factory.create((String) null), "null_gempath")
+        );
     }
 
-    @Test
-    public void should_have_gempath_in_ruby_env_when_created_with_gempath() {
+    @ParameterizedTest(name = "should_have_gempath_in_ruby_env_when_created_with_{3}")
+    @MethodSource("modifiedGempathAsciidoctorProvider")
+    public void should_have_gempath_in_ruby_env_when_created_with_(Asciidoctor asciidoctor,
+                                                                   String expectedGemPath,
+                                                                   String expectedGemHome,
+                                                                   String testDescription) {
         // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
-        final String gemPath = "/another/path";
-        assertThat(System.getenv("GEM_PATH"), notNullValue());
-        assertThat(System.getenv("GEM_HOME"), notNullValue());
-
-        // When: A new Asciidoctor instance is created passing in a null GEM_PATH
-        Asciidoctor asciidoctor = AsciidoctorJRuby.Factory.create(gemPath);
+        assertThat(System.getenv("GEM_PATH")).isNotEmpty();
+        assertThat(System.getenv("GEM_HOME")).isNotEmpty();
 
         // Then: The org.jruby.JRuby instance does not see this variable
         Ruby rubyRuntime = JRubyRuntimeContext.get(asciidoctor);
-        RubyString rubyGemPath = rubyRuntime.newString(gemPath);
-        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']"), is((Object) rubyGemPath));
-        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']"), is((Object) rubyGemPath));
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']").asJavaString()).isEqualTo(expectedGemPath);
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']").asJavaString()).isEqualTo(expectedGemHome);
     }
 
+    private static Stream<Arguments> modifiedGempathAsciidoctorProvider() {
+        final ClassLoader customClassloader = new String().getClass().getClassLoader();
+        final String customGemPath = "/another/gempath";
+        return Stream.of(
+                arguments(AsciidoctorJRuby.Factory.create(customGemPath),
+                        customGemPath, customGemPath, "gempath"),
+                arguments(AsciidoctorJRuby.Factory.create(customClassloader),
+                        Polluted.GEM_PATH, Polluted.GEM_HOME, "classloader"),
+                arguments(AsciidoctorJRuby.Factory.create(customClassloader, customGemPath),
+                        customGemPath, customGemPath, "classloader_and_custom_gempath")
+        );
+    }
+
+    @Test
+    public void should_have_gempath_in_ruby_env_when_created_with_custom_paths() {
+        final String[] loadPaths = {"/load/path1", "/load/path2"};
+        final String customGemPath = "/another/custom/gempath";
+        // Given: Our environment is polluted (Cannot set these env vars here, so just check that gradle has set them correctly)
+        assertThat(System.getenv("GEM_PATH")).isNotEmpty();
+        assertThat(System.getenv("GEM_HOME")).isNotEmpty();
+
+        Asciidoctor asciidoctor = AsciidoctorJRuby.Factory.create(List.of(loadPaths), customGemPath);
+
+        // Then: The org.jruby.JRuby instance does not see this variable
+        Ruby rubyRuntime = JRubyRuntimeContext.get(asciidoctor);
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_PATH']").asJavaString()).isEqualTo(customGemPath);
+        assertThat(rubyRuntime.evalScriptlet("ENV['GEM_HOME']").asJavaString()).isEqualTo(customGemPath);
+        assertThat(getLoadPaths(rubyRuntime)).contains(loadPaths);
+    }
+
+    private static List<String> getLoadPaths(Ruby rubyRuntime) {
+        return (List<String>) rubyRuntime.getLoadService().getLoadPath()
+                .convertToArray()
+                .stream()
+                .map(v -> v.toString())
+                .collect(Collectors.toList());
+    }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/categories/Polluted.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/categories/Polluted.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.categories;
 
-import org.junit.jupiter.api.Tag;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -13,6 +13,10 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@Tag("polluted")
+@SetEnvironmentVariable(key = "GEM_PATH", value = Polluted.GEM_PATH)
+@SetEnvironmentVariable(key = "GEM_HOME", value = Polluted.GEM_HOME)
 public @interface Polluted {
+
+    String GEM_PATH = "/some/path";
+    String GEM_HOME = "/some/other/path";
 }

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ ext {
   jsoupVersion = '1.14.3'
   junit4Version = '4.13.2'
   junit5Version = '5.9.2'
+  junitPioneerVersion = '2.0.1'
   assertjVersion = '3.24.2'
   nettyVersion = '4.1.58.Final'
   saxonVersion = '9.9.0-2'
@@ -139,8 +140,10 @@ subprojects {
   if (usesJUnit5(it.project)) {
     dependencies {
       testImplementation(platform("org.junit:junit-bom:$junit5Version"))
-      testImplementation("org.junit.jupiter:junit-jupiter-api")
-      testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+      testImplementation "org.junit.jupiter:junit-jupiter-api"
+      testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+      testImplementation "org.junit.jupiter:junit-jupiter-params"
+      testImplementation "org.junit-pioneer:junit-pioneer:$junitPioneerVersion"
     }
   }
 
@@ -192,6 +195,10 @@ subprojects {
           logger.info "Test results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
         }
       }
+    }
+    if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows()) {
+      // Allow junit-pioneer environment manipulation on Windows + Java17+
+      jvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED']
     }
   }
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*

Simplify Gradle build and fix some IDE integration issues. See #1193 for details.

*How does it achieve that?*

* Add junit-pioneer to inject environment variables into tests. This allows removing custom Gradle task pollutedTest and running them normally.
* Refactor WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath as a parametrized tests.
* Add missing cases for Asciidoctor Factory in WhenAnAsciidoctorClassIsInstantiatedInAnEnvironmentWithGemPath.

*Are there any alternative ways to implement this?*

Discussed in #1193.

*Are there any implications of this pull request? Anything a user must know?*

No, if anything, it should be easier for contributors now.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1193


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc