### PR TITLE
Fix invalid http://asciidoctor.org references

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,5 @@
 = Asciidoctor Changelog
-:url-asciidoctor: http://asciidoctor.org
+:url-asciidoctor: https://asciidoctor.org
 :url-asciidoc: {url-asciidoctor}/docs/what-is-asciidoc
 :url-repo: https://github.com/asciidoctor/asciidoctorj
 :icons: font
@@ -53,6 +53,10 @@ Build Improvement::
 * Fix upstream tests forcing SNAPSHOT on Asciidoctor gem installation (#1123) (@abelsromero)
 * Fix upstream build removing the explicit plugin repository (#1131)
 * Set JUnit5 as default test engine (#1186) (@abelsromero)
+
+Documentation::
+
+* Fix invalid 'http://asciidoctor.org' references in docs and JavaDocs (#1195) (@abelsromero)
 
 == 2.5.4 (2022-06-30)
 

--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ endif::[]
 :dagger: &#8224;
 // URIs:
 ifdef::awestruct[:uri-docs: link:/docs]
-ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
+ifndef::awestruct[:uri-docs: https://asciidoctor.org/docs]
 :uri-asciidoctor: {uri-docs}/what-is-asciidoctor
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
@@ -104,10 +104,10 @@ public class Attributes {
     }
 
     /**
-     * Allow Asciidoctor to read content from an URI.
-     * Additionally the option {@link SafeMode} must be less than {@link SafeMode#SECURE} to enable inclusion of content from an URI.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#include-content-from-a-uri">Asciidoctor User Manual</a>
-     * @param allowUriRead {@code true} to enable inclusion of content from an URI
+     * Allow Asciidoctor to read content from a URI.
+     * Additionally, the option {@link SafeMode} must be less than {@link SafeMode#SECURE} to enable inclusion of content from a URI.
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/directives/include-uri/">Include Content by URI</a>
+     * @param allowUriRead {@code true} to enable inclusion of content from a URI
      */
     public void setAllowUriRead(boolean allowUriRead) {
         this.attributes.put(ALLOW_URI_READ, toAsciidoctorFlag(allowUriRead));
@@ -134,7 +134,7 @@ public class Attributes {
      *         <td>print a warning about the missing attribute</td>
      *     </tr>
      * </table>
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#catch-a-missing-or-undefined-attribute">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing">Handle Unresolved References: Missing attribute</a>
      * @param attributeMissing One of the constants shown in the table above.
      */
     public void setAttributeMissing(String attributeMissing) {
@@ -154,7 +154,7 @@ public class Attributes {
      *         <td>drop the line that contains this expression (default setting and compliant behavior)</td>
      *     </tr>
      * </table>
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#catch-a-missing-or-undefined-attribute">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#undefined">Handle Unresolved References: Undefined attribute</a>
      * @param attributeUndefined One of the constants shown in the table above.
      */
     public void setAttributeUndefined(String attributeUndefined) {
@@ -182,7 +182,7 @@ public class Attributes {
      *     <li>{@code inline}</li>
      *     <li>{@code manpage}</li>
      * </ul>
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#document-types">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/document/doctype/">Document Type</a>
      * @param docType One of the constants mentioned above.
      */
     public void setDocType(String docType) {
@@ -191,7 +191,7 @@ public class Attributes {
 
     /**
      * Sets the directory to which images are resolved if the image target is a relative path.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#set-the-images-directory">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/macros/images-directory/">Set the Images Directory</a>
      * @param imagesDir The name of the directory.
      */
     public void setImagesDir(String imagesDir) {
@@ -200,7 +200,7 @@ public class Attributes {
 
     /**
      * Globally sets the source language attribute when rendering source blocks.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#source-code-blocks">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-highlighter/#source-language">Source Highlighting: source-language attribute</a>
      * @param sourceLanguage The default source language to use, e.g. {@code Java}.
      */
     public void setSourceLanguage(String sourceLanguage) {
@@ -215,7 +215,7 @@ public class Attributes {
      *     <li>highlightjs</li>
      *     <li>prettify</li>
      * </ul>
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#source-code-blocks">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-highlighter/#source-highlighter">Source Highlighting: source-highlighter attribute</a>
      * @param sourceHighlighter One of the constants mentioned above.
      */
     public void setSourceHighlighter(String sourceHighlighter) {
@@ -224,7 +224,7 @@ public class Attributes {
 
     /**
      * Defines how many documents can be recursively included.
-     * @see <a href="https://github.com/asciidoctor/asciidoctor/issues/581">Track include depth and enforce maximum depth #581</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#security-attributes">Security attributes</a>
      * @param maxIncludeDepth A positive integer.
      */
     public void setMaxIncludeDepth(int maxIncludeDepth) {
@@ -243,7 +243,7 @@ public class Attributes {
 
     /**
      * Enables or disables preserving of line breaks in a paragraph.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#line-breaks">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/blocks/hard-line-breaks/">Hard Line Breaks</a>
      * @param hardbreaks {@code true} to enable preserving of line breaks in paragraphs
      */
     public void setHardbreaks(boolean hardbreaks) {
@@ -251,8 +251,8 @@ public class Attributes {
     }
 
     /**
-     * Enables or disables caching of content read from URIs
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#include-content-from-a-uri">Asciidoctor User Manual</a>
+     * Enables or disables caching of content read from URIs.
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/directives/include-uri/#caching-uri-content">Caching URI content</a>
      * @param cacheUri {@code true} to enable caching of content read from URIs
      */
     public void setCacheUri(boolean cacheUri) {
@@ -261,7 +261,7 @@ public class Attributes {
 
     /**
      * Enables or disables rendering of the URI scheme when rendering URLs.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#url">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/macros/links/#hide-uri-scheme/">Hide the URL scheme</a>
      * @param hideUriScheme
      */
     public void setHideUriScheme(boolean hideUriScheme) {
@@ -271,7 +271,7 @@ public class Attributes {
     /**
      * Defines the prefix added to appendix sections.
      * The default value is {@code Appendix}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#user-appendix">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/sections/appendix/">Appendix</a>
      * @param appendixCaption The string that is prefixed to the section name in the appendix.
      */
     public void setAppendixCaption(String appendixCaption) {
@@ -281,7 +281,7 @@ public class Attributes {
 
     /**
      * Sets the interpreter to use for rendering stems, i.e. equations and formulas.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#activating-stem-support">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/stem/#activating-stem-support">Activating STEM support</a>
      * @param math The name of the interpreter, i.e. either {@code asciimath} or {@code latexmath}.
      */
     public void setMath(String math) {
@@ -595,9 +595,9 @@ public class Attributes {
 
     /**
      * Sets attributes in string form. An example of a valid string would be:
-     * 
+     * </p>
      * 'toc sectnums source-highlighter=coderay'
-     * 
+     * </p>
      * where you are adding three attributes: toc, sectnums and source-highlighter with value coderay.
      * 
      * @param attributes
@@ -611,9 +611,9 @@ public class Attributes {
 
     /**
      * Sets attributes in array form. An example of a valid array would be:
-     * 
+     * </p>
      * '['toc', 'sectnums']'
-     * 
+     * </p>
      * where you are adding two attributes: toc and sectnums.
      * 
      * @param attributes

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
@@ -7,37 +7,37 @@ public interface StructuralNode extends ContentNode {
 
     /**
      * Constant for special character replacement substitution like {@code <} to {@code &amp;lt;}.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#special-characters">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/special-characters/">Special Character Substitutions</a>
      */
     String SUBSTITUTION_SPECIAL_CHARACTERS = "specialcharacters";
 
     /**
      * Constant for quote replacements like {@code *bold*} to <b>{@code bold}</b>.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#quotes">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/">Quotes Substitutions</a>
      */
     String SUBSTITUTION_QUOTES             = "quotes";
 
     /**
      * Constant for attribute replacements like {@code {foo}}.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#attributes-2">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/attributes/">Attribute References Substitution</a>
      */
     String SUBSTITUTION_ATTRIBUTES         = "attributes";
 
     /**
      * Constant for replacements like {@code (C)} to {@code &#169;}.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#replacements">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/">Character Replacement Substitutions</a>
      */
     String SUBSTITUTION_REPLACEMENTS       = "replacements";
 
     /**
      * Constant for macro replacements like {@code mymacro:target[]}.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs-mac">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/macros/">Macro Substitutions</a>
      */
     String SUBSTITUTION_MACROS             = "macros";
 
     /**
      * Constant for post replacements like creating line breaks from a trailing {@code +} in a line.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#post-replacements">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/post-replacements/">Post Replacement Substitutions</a>
      */
     String SUBSTITUTION_POST_REPLACEMENTS  = "post_replacements";
 
@@ -111,42 +111,42 @@ public interface StructuralNode extends ContentNode {
     /**
      * Returns the list of enabled substitutions.
      * @return A list of substitutions enabled for this node, e.g. <code>["specialcharacters", "quotes", "attributes", "replacements", "macros", "post_replacements"]</code> for paragraphs.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Asciidoctor User Manual</a>
      */
     List<String> getSubstitutions();
 
     /**
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_POST_REPLACEMENTS}
      * @return <code>true</code> if the name of the given substitution is enabled.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Asciidoctor User Manual</a>
      */
     boolean isSubstitutionEnabled(String substitution);
 
     /**
      * Removes the given substitution from this node.
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_QUOTES}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Substitutions</a>
      */
     void removeSubstitution(String substitution);
 
     /**
      * Adds the given substitution to this node at the end of the substitution list.
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_MACROS}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Substitutions</a>
      */
     void addSubstitution(String substitution);
 
     /**
      * Adds the given substitution to this node at the beginning of the substitution list.
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_ATTRIBUTES}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Substitutions</a>
      */
     void prependSubstitution(String substitution);
 
     /**
      * Sets the given substitutions on this node overwriting all other substitutions.
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_SPECIAL_CHARACTERS}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Substitutions</a>
      */
     void setSubstitutions(String... substitution);
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/PreprocessorTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/PreprocessorTest.java
@@ -33,7 +33,7 @@ public class PreprocessorTest {
                 "permalink: /sample/\n" +
                 "---\n" +
                 "= Sample Page\n" +
-                ":url-asciidoctor: http://asciidoctor.org\n" +
+                ":url-asciidoctor: https://asciidoctor.org\n" +
                 "\n" +
                 "This is a sample page composed in AsciiDoc.\n" +
                 "Jekyll converts it to HTML using {url-asciidoctor}[Asciidoctor].\n" +

--- a/asciidoctorj-core/src/test/resources/document-with-arrays.adoc
+++ b/asciidoctorj-core/src/test/resources/document-with-arrays.adoc
@@ -1,6 +1,6 @@
 = Asciidoctor Changelog
 
-http://asciidoctor.org[Asciidoctor] is an open source text processor and publishing toolchain for converting http://asciidoctor.org[AsciiDoc] markup into HTML, DocBook and custom formats.
+https://asciidoctor.org[Asciidoctor] is an open source text processor and publishing toolchain for converting https://asciidoctor.org[AsciiDoc] markup into HTML, DocBook and custom formats.
 
 This document provides a high-level view of the changes introduced in Asciidoctor by release.
 For a detailed view of what has changed, refer to the https://github.com/asciidoctor/asciidoctor/commits/main[commit history] on GitHub.

--- a/chocolatey/asciidoctorj.nuspec
+++ b/chocolatey/asciidoctorj.nuspec
@@ -19,10 +19,10 @@
     -b pdf mydocument.adoc". You MUST install a Java runtime such as jre8, corretto8jre, or
     adoptopenjdk8jre yourself. This package doesn't presume to choose for you.
     </description>
-    <projectUrl>http://asciidoctor.org/</projectUrl>
+    <projectUrl>https://asciidoctor.org/</projectUrl>
     <packageSourceUrl>https://github.com/geraldcombs/chocolatey-packages</packageSourceUrl>
     <projectSourceUrl>https://github.com/asciidoctor/asciidoctorj</projectSourceUrl>
-    <docsUrl>http://asciidoctor.org/docs/user-manual/</docsUrl>
+    <docsUrl>https://asciidoctor.org/docs/user-manual/</docsUrl>
     <mailingListUrl>https://asciidoctor.zulipchat.com/</mailingListUrl>
     <bugTrackerUrl>https://github.com/asciidoctor/asciidoctorj/issues</bugTrackerUrl>
     <tags>asciidoctor asciidoc docbook pdf</tags>

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -1,5 +1,5 @@
 = Installation
-:url-docs: http://asciidoctor.org/docs
+:url-docs: https://asciidoctor.org/docs
 :url-maven-guide: {url-docs}/install-and-use-asciidoctor-maven-plugin
 :url-gradle-guide: {url-docs}/install-and-use-asciidoctor-gradle-plugin
 

--- a/docs/modules/ROOT/pages/safe-mode-and-filesystem-access.adoc
+++ b/docs/modules/ROOT/pages/safe-mode-and-filesystem-access.adoc
@@ -25,4 +25,4 @@ String outfile = asciidoctor.convertFile(new File("sample.adoc"), options);
 We are going to explain in more detail options in xref:asciidoctor-api-options.adoc[] section.
 
 // TODO update url when final site is available
-You can read more about safe modes in http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely
+You can read more about safe modes in https://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely

--- a/docs/modules/guides/pages/optimization.adoc
+++ b/docs/modules/guides/pages/optimization.adoc
@@ -35,7 +35,7 @@ $ cat ./.jrubyrc
 compat.version=RUBY1_9
 compile.mode=OFF
 $ ./asciidoctorj -V
-AsciidoctorJ 1.5.2 [http://asciidoctor.org]
+AsciidoctorJ 1.5.2 [https://asciidoctor.org]
 Runtime Environment: jruby 1.7.20 (1.9.3)
 ----
 
@@ -47,7 +47,7 @@ Alternatively you can also set any system properties using the environment varia
 ----
 $ export ASCIIDOCTORJ_OPTS=-Djruby.compat.version=RUBY1_9
 $ asciidoctorj -V
-AsciidoctorJ 1.5.2 [http://asciidoctor.org]
+AsciidoctorJ 1.5.2 [https://asciidoctor.org]
 Runtime Environment: jruby 1.7.20 (1.9.3)
 ----
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*

Fix invalid http://asciidoctor.org references found in docs and JavaDocs.

*How does it achieve that?*

* Applied https where applicable
* Updated JavaDoc references to current links in https://docs.asciidoctor.org/

*Are there any alternative ways to implement this?*

No.

Are there any implications of this pull request? Anything a user must know?

No.

## Issue

Fixes #1195 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc