### PR TITLE
(v2.5.x) Fix invalid http://asciidoctor.org references

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,5 @@
 = Asciidoctor Changelog
-:url-asciidoctor: http://asciidoctor.org
+:url-asciidoctor: https://asciidoctor.org
 :url-asciidoc: {url-asciidoctor}/docs/what-is-asciidoc
 :url-repo: https://github.com/asciidoctor/asciidoctorj
 :icons: font
@@ -16,6 +16,10 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 Build / Infrastructure::
 
 * Fix Asciidoctor upstream CI tests (#1178) (@abelsromero)
+
+Documentation::
+
+* Fix invalid 'http://asciidoctor.org' references in docs and JavaDocs (#1195) (@abelsromero)
 
 == 2.5.8 (2023-04-15)
 

--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ endif::[]
 :dagger: &#8224;
 // URIs:
 ifdef::awestruct[:uri-docs: link:/docs]
-ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
+ifndef::awestruct[:uri-docs: https://asciidoctor.org/docs]
 :uri-asciidoctor: {uri-docs}/what-is-asciidoctor
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
@@ -104,10 +104,10 @@ public class Attributes {
     }
 
     /**
-     * Allow Asciidoctor to read content from an URI.
-     * Additionally the option {@link SafeMode} must be less than {@link SafeMode#SECURE} to enable inclusion of content from an URI.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#include-content-from-a-uri">Asciidoctor User Manual</a>
-     * @param allowUriRead {@code true} to enable inclusion of content from an URI
+     * Allow Asciidoctor to read content from a URI.
+     * Additionally, the option {@link SafeMode} must be less than {@link SafeMode#SECURE} to enable inclusion of content from a URI.
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/directives/include-uri/">Include Content by URI</a>
+     * @param allowUriRead {@code true} to enable inclusion of content from a URI
      */
     public void setAllowUriRead(boolean allowUriRead) {
         this.attributes.put(ALLOW_URI_READ, toAsciidoctorFlag(allowUriRead));
@@ -134,7 +134,7 @@ public class Attributes {
      *         <td>print a warning about the missing attribute</td>
      *     </tr>
      * </table>
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#catch-a-missing-or-undefined-attribute">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing">Handle Unresolved References: Missing attribute</a>
      * @param attributeMissing One of the constants shown in the table above.
      */
     public void setAttributeMissing(String attributeMissing) {
@@ -154,7 +154,7 @@ public class Attributes {
      *         <td>drop the line that contains this expression (default setting and compliant behavior)</td>
      *     </tr>
      * </table>
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#catch-a-missing-or-undefined-attribute">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#undefined">Handle Unresolved References: Undefined attribute</a>
      * @param attributeUndefined One of the constants shown in the table above.
      */
     public void setAttributeUndefined(String attributeUndefined) {
@@ -182,7 +182,7 @@ public class Attributes {
      *     <li>{@code inline}</li>
      *     <li>{@code manpage}</li>
      * </ul>
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#document-types">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/document/doctype/">Document Type</a>
      * @param docType One of the constants mentioned above.
      */
     public void setDocType(String docType) {
@@ -191,7 +191,7 @@ public class Attributes {
 
     /**
      * Sets the directory to which images are resolved if the image target is a relative path.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#set-the-images-directory">Asciidoctor User Manual</a>
+     *@see <a href="https://docs.asciidoctor.org/asciidoc/latest/macros/images-directory/">Set the Images Directory</a>
      * @param imagesDir The name of the directory.
      */
     public void setImagesDir(String imagesDir) {
@@ -200,7 +200,7 @@ public class Attributes {
 
     /**
      * Globally sets the source language attribute when rendering source blocks.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#source-code-blocks">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-highlighter/#source-language">Source Highlighting: source-language attribute</a>
      * @param sourceLanguage The default source language to use, e.g. {@code Java}.
      */
     public void setSourceLanguage(String sourceLanguage) {
@@ -215,7 +215,7 @@ public class Attributes {
      *     <li>highlightjs</li>
      *     <li>prettify</li>
      * </ul>
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#source-code-blocks">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-highlighter/#source-highlighter">Source Highlighting: source-highlighter attribute</a>
      * @param sourceHighlighter One of the constants mentioned above.
      */
     public void setSourceHighlighter(String sourceHighlighter) {
@@ -243,7 +243,7 @@ public class Attributes {
 
     /**
      * Enables or disables preserving of line breaks in a paragraph.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#line-breaks">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/blocks/hard-line-breaks/">Hard Line Breaks</a>
      * @param hardbreaks {@code true} to enable preserving of line breaks in paragraphs
      */
     public void setHardbreaks(boolean hardbreaks) {
@@ -252,7 +252,7 @@ public class Attributes {
 
     /**
      * Enables or disables caching of content read from URIs
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#include-content-from-a-uri">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/directives/include-uri/#caching-uri-content">Caching URI content</a>
      * @param cacheUri {@code true} to enable caching of content read from URIs
      */
     public void setCacheUri(boolean cacheUri) {
@@ -261,7 +261,7 @@ public class Attributes {
 
     /**
      * Enables or disables rendering of the URI scheme when rendering URLs.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#url">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/macros/links/#hide-uri-scheme/">Hide the URL scheme</a>
      * @param hideUriScheme
      */
     public void setHideUriScheme(boolean hideUriScheme) {
@@ -271,7 +271,7 @@ public class Attributes {
     /**
      * Defines the prefix added to appendix sections.
      * The default value is {@code Appendix}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#user-appendix">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/sections/appendix/">Appendix</a>
      * @param appendixCaption The string that is prefixed to the section name in the appendix.
      */
     public void setAppendixCaption(String appendixCaption) {
@@ -281,7 +281,7 @@ public class Attributes {
 
     /**
      * Sets the interpreter to use for rendering stems, i.e. equations and formulas.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#activating-stem-support">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/stem/#activating-stem-support">Activating STEM support</a>
      * @param math The name of the interpreter, i.e. either {@code asciimath} or {@code latexmath}.
      */
     public void setMath(String math) {

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
@@ -7,37 +7,37 @@ public interface StructuralNode extends ContentNode {
 
     /**
      * Constant for special character replacement substitution like {@code <} to {@code &amp;lt;}.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#special-characters">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/special-characters/">Special Character Substitutions</a>
      */
     String SUBSTITUTION_SPECIAL_CHARACTERS = "specialcharacters";
 
     /**
      * Constant for quote replacements like {@code *bold*} to <b>{@code bold}</b>.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#quotes">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/">Quotes Substitutions</a>
      */
     String SUBSTITUTION_QUOTES             = "quotes";
 
     /**
      * Constant for attribute replacements like {@code {foo}}.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#attributes-2">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/attributes/">Attribute References Substitution</a>
      */
     String SUBSTITUTION_ATTRIBUTES         = "attributes";
 
     /**
      * Constant for replacements like {@code (C)} to {@code &#169;}.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#replacements">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/">Character Replacement Substitutions</a>
      */
     String SUBSTITUTION_REPLACEMENTS       = "replacements";
 
     /**
      * Constant for macro replacements like {@code mymacro:target[]}.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs-mac">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/macros/">Macro Substitutions</a>
      */
     String SUBSTITUTION_MACROS             = "macros";
 
     /**
      * Constant for post replacements like creating line breaks from a trailing {@code +} in a line.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#post-replacements">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/post-replacements/">Post Replacement Substitutions</a>
      */
     String SUBSTITUTION_POST_REPLACEMENTS  = "post_replacements";
 
@@ -111,42 +111,42 @@ public interface StructuralNode extends ContentNode {
     /**
      * Returns the list of enabled substitutions.
      * @return A list of substitutions enabled for this node, e.g. <code>["specialcharacters", "quotes", "attributes", "replacements", "macros", "post_replacements"]</code> for paragraphs.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Asciidoctor User Manual</a>
      */
     List<String> getSubstitutions();
 
     /**
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_POST_REPLACEMENTS}
      * @return <code>true</code> if the name of the given substitution is enabled.
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Asciidoctor User Manual</a>
      */
     boolean isSubstitutionEnabled(String substitution);
 
     /**
      * Removes the given substitution from this node.
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_QUOTES}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Substitutions</a>
      */
     void removeSubstitution(String substitution);
 
     /**
      * Adds the given substitution to this node at the end of the substitution list.
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_MACROS}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Substitutions</a>
      */
     void addSubstitution(String substitution);
 
     /**
      * Adds the given substitution to this node at the beginning of the substitution list.
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_ATTRIBUTES}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Substitutions</a>
      */
     void prependSubstitution(String substitution);
 
     /**
      * Sets the given substitutions on this node overwriting all other substitutions.
      * @param substitution the name of a substitution, e.g. {@link #SUBSTITUTION_SPECIAL_CHARACTERS}
-     * @see <a href="http://asciidoctor.org/docs/user-manual/#subs">Asciidoctor User Manual</a>
+     * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/subs/">Substitutions</a>
      */
     void setSubstitutions(String... substitution);
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -300,7 +300,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
         logger.fine(String.join(" ", AsciidoctorUtils.toAsciidoctorCommand(options, "-")));
 
         if (AsciidoctorUtils.isOptionWithAttribute(options, Attributes.SOURCE_HIGHLIGHTER, "pygments")) {
-            logger.fine("In order to use Pygments with Asciidoctor, you need to install Pygments (and Python, if you don't have it yet). Read http://asciidoctor.org/news/#syntax-highlighting-with-pygments.");
+            logger.fine("In order to use Pygments with Asciidoctor, you need to install Pygments (and Python, if you don't have it yet). Read https://asciidoctor.org/news/#syntax-highlighting-with-pygments.");
         }
 
         String currentDirectory = rubyRuntime.getCurrentDirectory();

--- a/asciidoctorj-core/src/test/resources/document-with-arrays.adoc
+++ b/asciidoctorj-core/src/test/resources/document-with-arrays.adoc
@@ -1,6 +1,6 @@
 = Asciidoctor Changelog
 
-http://asciidoctor.org[Asciidoctor] is an open source text processor and publishing toolchain for converting http://asciidoctor.org[AsciiDoc] markup into HTML, DocBook and custom formats.
+https://asciidoctor.org[Asciidoctor] is an open source text processor and publishing toolchain for converting https://asciidoctor.org[AsciiDoc] markup into HTML, DocBook and custom formats.
 
 This document provides a high-level view of the changes introduced in Asciidoctor by release.
 For a detailed view of what has changed, refer to the https://github.com/asciidoctor/asciidoctor/commits/main[commit history] on GitHub.

--- a/chocolatey/asciidoctorj.nuspec
+++ b/chocolatey/asciidoctorj.nuspec
@@ -19,10 +19,10 @@
     -b pdf mydocument.adoc". You MUST install a Java runtime such as jre8, corretto8jre, or
     adoptopenjdk8jre yourself. This package doesn't presume to choose for you.
     </description>
-    <projectUrl>http://asciidoctor.org/</projectUrl>
+    <projectUrl>https://asciidoctor.org/</projectUrl>
     <packageSourceUrl>https://github.com/geraldcombs/chocolatey-packages</packageSourceUrl>
     <projectSourceUrl>https://github.com/asciidoctor/asciidoctorj</projectSourceUrl>
-    <docsUrl>http://asciidoctor.org/docs/user-manual/</docsUrl>
+    <docsUrl>https://asciidoctor.org/docs/user-manual/</docsUrl>
     <mailingListUrl>https://asciidoctor.zulipchat.com/</mailingListUrl>
     <bugTrackerUrl>https://github.com/asciidoctor/asciidoctorj/issues</bugTrackerUrl>
     <tags>asciidoctor asciidoc docbook pdf</tags>

--- a/docs/modules/ROOT/pages/convert-to-epub3.adoc
+++ b/docs/modules/ROOT/pages/convert-to-epub3.adoc
@@ -19,7 +19,7 @@ Here's how you can add the AsciidoctorJ EPUB3 jar to your Maven dependencies:
 ----
 
 Once you've added the AsciidoctorJ EPUB3 jar to your classpath, you can set the `backend` attribute to `epub3`.
-The document will be converted to the http://idpf.org/epub/30[EPUB3^] format.
+The document will be converted to the https://idpf.org/epub/30[EPUB3^] format.
 
 CAUTION: The [app]_asciidoctor-epub3_ gem is alpha.
 While it can be used successfully, there may be bugs and its functionality may change in incompatible ways before the first stable release.

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -1,5 +1,5 @@
 = Installation
-:url-docs: http://asciidoctor.org/docs
+:url-docs: https://asciidoctor.org/docs
 :url-maven-guide: {url-docs}/install-and-use-asciidoctor-maven-plugin
 :url-gradle-guide: {url-docs}/install-and-use-asciidoctor-gradle-plugin
 

--- a/docs/modules/ROOT/pages/safe-mode-and-filesystem-access.adoc
+++ b/docs/modules/ROOT/pages/safe-mode-and-filesystem-access.adoc
@@ -24,5 +24,4 @@ String outfile = asciidoctor.convertFile(new File("sample.adoc"), options);
 
 We are going to explain in more detail options in xref:asciidoctor-api-options.adoc[] section.
 
-// TODO update url when final site is available
-You can read more about safe modes in http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely
+You can read more about safe modes in https://docs.asciidoctor.org/asciidoctor/latest/safe-modes/.

--- a/docs/modules/guides/pages/optimization.adoc
+++ b/docs/modules/guides/pages/optimization.adoc
@@ -35,7 +35,7 @@ $ cat ./.jrubyrc
 compat.version=RUBY1_9
 compile.mode=OFF
 $ ./asciidoctorj -V
-AsciidoctorJ 1.5.2 [http://asciidoctor.org]
+AsciidoctorJ 1.5.2 [https://asciidoctor.org]
 Runtime Environment: jruby 1.7.20 (1.9.3)
 ----
 
@@ -47,7 +47,7 @@ Alternatively you can also set any system properties using the environment varia
 ----
 $ export ASCIIDOCTORJ_OPTS=-Djruby.compat.version=RUBY1_9
 $ asciidoctorj -V
-AsciidoctorJ 1.5.2 [http://asciidoctor.org]
+AsciidoctorJ 1.5.2 [https://asciidoctor.org]
 Runtime Environment: jruby 1.7.20 (1.9.3)
 ----
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*
Port of PR https://github.com/asciidoctor/asciidoctorj/pull/1196, but for branch v2.5.x.
From here :point_down:, the same stuff as in the other PR.
Fix invalid http://asciidoctor.org references found in docs and JavaDocs.

*How does it achieve that?*

* Applied https where applicable
* Updated JavaDoc references to current links in https://docs.asciidoctor.org/

*Are there any alternative ways to implement this?*

No.

Are there any implications of this pull request? Anything a user must know?

No.

## Issue

Fixes #1195 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc