### PR TITLE
Remove deprecated methods in Options, OptionsBuilder, Attributes & AttributesBuilder

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -36,6 +36,7 @@ Improvement::
 * Expose ImageReferences in the catalog (#1166) (@abelsromero)
 * Return Document AST when using convert or convertFile with appropriate options (#1171) (@abelsromero)
 * Expose Links in the catalog (#1183) (@abelsromero)
+* BREAKING: Remove deprecated methods in Options, OptionsBuilder, Attributes & AttributesBuilder (#1199) (@abelsromero)
 
 Bug Fixes::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
@@ -10,13 +10,12 @@ import java.util.Map;
 public class Attributes {
 
     private static final char ATTRIBUTE_SEPARATOR = '=';
+
     private static Format DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
     private static Format TIME_FORMAT = new SimpleDateFormat("HH:mm:ss z");
 
     public static final String TOC = "toc";
-    public static final String TOC_POSITION = "toc-position";
     public static final String TOC_LEVELS = "toclevels";
-    public static final String TOC_2 = "toc2";
     public static final String BACKEND = Options.BACKEND;
     public static final String TITLE = "title";
     public static final String DOCTYPE = Options.DOCTYPE;
@@ -64,38 +63,9 @@ public class Attributes {
 
     private Map<String, Object> attributes = new LinkedHashMap<>();
 
-    /**
-     * @deprecated Use {@link #builder} instead.
-     */
-    @Deprecated
-    public Attributes() {
-        super();
+    Attributes() {
     }
     
-    /**
-     * @deprecated Use {@link #builder} instead.
-     */
-    @Deprecated
-    public Attributes(Map<String, Object> attributes) {
-        this.attributes = attributes;
-    }
-
-    /**
-     * @deprecated Use {@link #builder} instead.
-     */
-    @Deprecated
-    public Attributes(String[] attributes) {
-        this.setAttributes(attributes);
-    }
-
-    /**
-     * @deprecated Use {@link #builder} instead.
-     */
-    @Deprecated
-    public Attributes(String attributes) {
-        this.setAttributes(attributes);
-    }
-
     /**
      * @return Empty AttributesBuilder instance.
      */
@@ -326,19 +296,6 @@ public class Attributes {
      */
     public void setIgnoreUndefinedAttributes(boolean ignoreUndefinedAttributes) {
         this.attributes.put(IGNORE_UNDEFINED, toAsciidoctorFlag(ignoreUndefinedAttributes));
-    }
-
-    /**
-     * Sets table of contents 2 attribute.
-     * 
-     * @param placement
-     *            where toc is rendered.
-     * @deprecated Use {@link #setTableOfContents(Placement)}
-     */
-    @Deprecated
-    public void setTableOfContents2(Placement placement) {
-        this.attributes.put(TOC_2, toAsciidoctorFlag(true));
-        this.attributes.put(TOC_POSITION, placement.getPosition());
     }
 
     /**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/AttributesBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/AttributesBuilder.java
@@ -2,7 +2,6 @@ package org.asciidoctor;
 
 import java.net.URI;
 import java.util.Date;
-import java.util.Map;
 
 public class AttributesBuilder {
 
@@ -12,43 +11,6 @@ public class AttributesBuilder {
 		super();
 	}
 
-	/**
-	 * Creates attributes builder.
-	 * @deprecated Use {@link Attributes#builder()} instead.
-	 * 
-	 * @return attributes builder.
-	 */
-	@Deprecated
-	public static AttributesBuilder attributes() {
-		return new AttributesBuilder();
-	}
-
-	/**
-     * Creates attributes builder.
-	 * @deprecated Use {@link Attributes#builder()} with {@link #arguments(String...)} instead.
-     * 
-     * @return attributes builder.
-     */
-	@Deprecated
-    public static AttributesBuilder attributes(String[] arguments) {
-        AttributesBuilder attributesBuilder = new AttributesBuilder();
-        attributesBuilder.arguments(arguments);
-        return attributesBuilder;
-    }
-
-    /**
-     * Creates attributes builder.
-	 * @deprecated Use {@link Attributes#builder()} with {@link #arguments(String)} instead.
-     * 
-     * @return attributes builder.
-     */
-    @Deprecated
-    public static AttributesBuilder attributes(String arguments) {
-        AttributesBuilder attributesBuilder = new AttributesBuilder();
-        attributesBuilder.arguments(arguments);
-        return attributesBuilder;
-    }
-	
     /**
      * Source language attribute.
      * @param sourceLanguage value.
@@ -146,18 +108,6 @@ public class AttributesBuilder {
      */
     public AttributesBuilder tableOfContents(Placement placement) {
         this.attributes.setTableOfContents(placement);
-        return this;
-    }
-    
-    /**
-     * Sets table of contents 2 attribute.
-     * @param placement where toc is rendered.
-     * @return this instance.
-	 * @deprecated Use {@link #tableOfContents(Placement)}
-     */
-    @Deprecated
-    public AttributesBuilder tableOfContents2(Placement placement) {
-        this.attributes.setTableOfContents2(placement);
         return this;
     }
     
@@ -559,28 +509,16 @@ public class AttributesBuilder {
 	}
 
 	/**
-	 * Adds all attributes.
-	 * 
-	 * @param attributes
-	 *            map.
-	 * @return this instance.
-	 */
-	public AttributesBuilder attributes(Map<String, Object> attributes) {
-		this.attributes.setAttributes(attributes);
-		return this;
-	}
-
-	/**
 	 * Sets attributes in string form. An example of a valid string would be:
-	 * 
+	 *
 	 * 'toc sectnums source-highlighter=coderay'
-	 * 
+	 *
 	 * where you are adding three attributes: toc, sectnums and
 	 * source-highlighter with value coderay.
-	 * 
+	 *
 	 * @param attributes
 	 *            in string format.
-	 * 
+	 *
 	 * @return this instance.
 	 */
 	public AttributesBuilder arguments(String attributes) {
@@ -590,38 +528,19 @@ public class AttributesBuilder {
 
 	/**
 	 * Sets attributes in array form. An example of a valid array would be:
-	 * 
+	 *
 	 * '['toc', 'sectnums']'
-	 * 
+	 *
 	 * where you are adding two attributes: toc and sectnums.
-	 * 
+	 *
 	 * @param attributes
 	 *            in array format.
-	 * 
+	 *
 	 * @return this instance.
 	 */
 	public AttributesBuilder arguments(String... attributes) {
 		this.attributes.setAttributes(attributes);
 		return this;
-	}
-
-	/**
-	 * Gets a map with configured options.
-	 * @deprecated Use {@link #build()} instead. 
-	 * 
-	 * @return map with all options. By default an empty map is returned.
-	 */
-	@Deprecated
-	public Map<String, Object> asMap() {
-		return this.attributes.map();
-	}
-
-	/**
-	 * @deprecated Use {@link #build()} instead.
-	 */
-	@Deprecated
-	public Attributes get() {
-		return this.attributes;
 	}
 
 	/**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -1,14 +1,11 @@
 package org.asciidoctor;
 
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
- * AsciidoctorJ conversion options. Each one maps to an option in Asciidoctor.
+ * AsciidoctorJ conversion options.
+ * <p>
  * See https://docs.asciidoctor.org/asciidoctor/latest/api/options/ for further
  * details.
  */
@@ -38,20 +35,7 @@ public class Options {
 
     private Map<String, Object> options = new HashMap<>();
 
-    /**
-     * @deprecated Use {@link Options#builder()} instead.
-     */
-    @Deprecated
-    public Options() {
-        super();
-    }
-
-    /**
-     * @deprecated Use {@link Options#builder()} instead.
-     */
-    @Deprecated
-    public Options(Map<String, Object> options) {
-        this.options = options;
+    Options() {
     }
 
     /**
@@ -60,7 +44,7 @@ public class Options {
     public static OptionsBuilder builder() {
         return new OptionsBuilder();
     }
-    
+
     public void setInPlace(boolean inPlace) {
         this.options.put(IN_PLACE, inPlace);
     }
@@ -117,7 +101,7 @@ public class Options {
     }
 
     /**
-     * Toogle writing output to a file.
+     * Toggle writing output to a file.
      *
      * @param toFile If <code>true</true>, write output to a file in the same directory
      *               as the input file, including header and footer into the output. If
@@ -140,7 +124,7 @@ public class Options {
 
     /**
      * Safe method calls safeMode.getLevel() to put the required level.
-     * 
+     *
      * @param safeMode
      *            enum.
      */
@@ -150,7 +134,7 @@ public class Options {
 
     /**
      * Keeps track of the file and line number for each parsed block. (Useful for tooling applications where the association between the converted output and the source file is important).
-     * 
+     *
      * @param sourcemap
      *            value.
      */
@@ -164,7 +148,7 @@ public class Options {
 
     /**
      * If true, tells the parser to capture images and links in the reference table. (Normally only IDs, footnotes and indexterms are included). The reference table is available via the references property on the document AST object. (Experimental).
-     * 
+     *
      * @param catalogAssets
      *            value.
      */
@@ -198,7 +182,7 @@ public class Options {
 
     /**
      * If true, the source is parsed eagerly (i.e., as soon as the source is passed to the load or load_file API). If false, parsing is deferred until the parse method is explicitly invoked.
-     * 
+     *
      * @param parse
      *            value.
      */

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
@@ -18,17 +18,6 @@ public class OptionsBuilder {
     }
 
     /**
-     * Creates options builder instance.
-     * @deprecated Use {@link Options#builder()} instead.
-     * 
-     * @return options builder instance.
-     */
-    @Deprecated
-    public static OptionsBuilder options() {
-        return new OptionsBuilder();
-    }
-
-    /**
      * Sets backend option.
      * 
      * @param backend
@@ -82,22 +71,6 @@ public class OptionsBuilder {
     }
 
     /**
-     * Sets template directory.
-     *
-     * @deprecated Use {@link #templateDirs(File...)} instead.
-     *
-     * @param templateDir
-     *            directory where templates are stored.
-     * @return this instance.
-     * @deprecated Use {@link #templateDirs(File...)} instead.
-     */
-    @Deprecated
-    public OptionsBuilder templateDir(File templateDir) {
-        this.options.setTemplateDirs(templateDir.getAbsolutePath());
-        return this;
-    }
-
-    /**
      * Sets template directories.
      * 
      * @param templateDirs
@@ -137,20 +110,6 @@ public class OptionsBuilder {
 
     /**
      * Sets attributes used for rendering input.
-     * @deprecated Use {@link #attributes(Attributes)} instead.
-     * 
-     * @param attributes
-     *            map.
-     * @return this instance.
-     */
-    @Deprecated
-    public OptionsBuilder attributes(Map<String, Object> attributes) {
-        this.options.setAttributes(attributes);
-        return this;
-    }
-
-    /**
-     * Sets attributes used for rendering input.
      * 
      * @param attributes
      *            map.
@@ -158,20 +117,6 @@ public class OptionsBuilder {
      */
     public OptionsBuilder attributes(Attributes attributes) {
         this.options.setAttributes(attributes);
-        return this;
-    }
-
-    /**
-     * Sets attributes used for rendering input.
-     * @deprecated Use {@link #attributes(Attributes)} instead. 
-     * 
-     * @param attributes
-     *            builder.
-     * @return this instance.
-     */
-    @Deprecated
-    public OptionsBuilder attributes(AttributesBuilder attributes) {
-        this.options.setAttributes(attributes.asMap());
         return this;
     }
 
@@ -358,25 +303,6 @@ public class OptionsBuilder {
     public OptionsBuilder baseDir(File baseDir) {
         this.options.setBaseDir(baseDir.getAbsolutePath());
         return this;
-    }
-
-    /**
-     * Gets a map with configured options.
-     * @deprecated Use {@link #build()} instead.
-     * 
-     * @return map with all options. By default, an empty map is returned.
-     */
-    @Deprecated
-    public Map<String, Object> asMap() {
-        return this.options.map();
-    }
-
-    /**
-     * @deprecated Use {@link #build()} instead.
-     */
-    @Deprecated
-    public Options get() {
-        return this.options;
     }
 
     /**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/syntaxhighlighter/SyntaxHighlighterAdapter.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/syntaxhighlighter/SyntaxHighlighterAdapter.java
@@ -35,9 +35,12 @@ import java.util.Map;
  *     Asciidoctor asciidoctor;
  *     asciidoctor.syntaxHighlighterRegistry().register(MySyntaxHighligher.class, "mysyntaxhighighter");
  *     asciidoctor.convert(doc,
- *         OptionsBuilder.options()
- *             .attributes(AttributesBuilder.attributes()
- *                 .sourceHighlighter("mysyntaxhighlighter")));</code></pre>
+ *         Options.builder()
+ *             .attributes(Attributes.builder()
+ *                 .sourceHighlighter("mysyntaxhighlighter")
+ *                 .build())
+ *             .build());
+ * </code></pre>
  * </p>
  * <p>A SyntaxHighlighterAdapter is expected to have a constructor with 3 parameters:
  * <dl>

--- a/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorAPICallIsCalled.java
+++ b/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorAPICallIsCalled.java
@@ -33,7 +33,7 @@ public class WhenAsciidoctorAPICallIsCalled {
         assertThat(asciidoctorCliOptions.getSafeMode()).isEqualTo(SafeMode.UNSAFE);
         assertThat(asciidoctorCliOptions.getBackend()).isEqualTo("docbook");
         assertThat(asciidoctorCliOptions.getParameters()).containsExactly("file.adoc");
-        assertThat(asciidoctorCliOptions.getAttributes())
+        assertThat(asciidoctorCliOptions.buildAttributes().map())
                 .containsEntry("myAttribute", "myValue")
                 .containsEntry("sectnums", "")
                 .containsEntry("copycss!", "");

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -337,7 +337,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     @Override
     public <T> T convert(String content, OptionsBuilder options, Class<T> expectedResult) {
-        return convert(content, options.asMap(), expectedResult);
+        return convert(content, options.build(), expectedResult);
     }
 
     @Override
@@ -354,7 +354,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     @Override
     public void convert(Reader contentReader, Writer rendererWriter, OptionsBuilder options) throws IOException {
-        this.convert(contentReader, rendererWriter, options.asMap());
+        this.convert(contentReader, rendererWriter, options.build());
     }
 
     @Override
@@ -421,12 +421,12 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     @Override
     public String convertFile(File file, OptionsBuilder options) {
-        return convertFile(file, options.asMap(), String.class);
+        return convertFile(file, options.build(), String.class);
     }
 
     @Override
     public <T> T convertFile(File file, OptionsBuilder options, Class<T> expectedResult) {
-        return convertFile(file, options.asMap(), expectedResult);
+        return convertFile(file, options.build(), expectedResult);
     }
 
     @Override
@@ -442,7 +442,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     @Override
     public String[] convertDirectory(Iterable<File> directoryWalker, OptionsBuilder options) {
-        return convertDirectory(directoryWalker, options.asMap());
+        return convertDirectory(directoryWalker, options.build());
     }
 
     @Override
@@ -458,7 +458,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     @Override
     public String[] convertFiles(Collection<File> files, OptionsBuilder options) {
-        return convertFiles(files, options.asMap());
+        return convertFiles(files, options.build());
     }
 
     @Override

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentContainsADefinitionList.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentContainsADefinitionList.groovy
@@ -28,7 +28,7 @@ Item C:: Another description
 '''
 
         when:
-        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().standalone(false).asMap())
+        Document documentNode = asciidoctor.load(document, Options.builder().standalone(false).build())
 
         then:
         DescriptionList list = documentNode.blocks[0]
@@ -107,7 +107,7 @@ Item A::
 
         when:
         asciidoctor.javaConverterRegistry().register(TestConverter, TestConverter.NAME)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().backend(TestConverter.NAME).standalone(false).asMap())
+        String result = asciidoctor.convert(document, Options.builder().backend(TestConverter.NAME).standalone(false).build())
 
         then:
         result == '''TEST DOCUMENT
@@ -129,7 +129,7 @@ Item B::
 
         when:
         asciidoctor.javaConverterRegistry().register(TestConverter, TestConverter.NAME)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().backend(TestConverter.NAME).standalone(false).asMap())
+        String result = asciidoctor.convert(document, Options.builder().backend(TestConverter.NAME).standalone(false).build())
 
         then:
         result == '''TEST DOCUMENT
@@ -160,7 +160,7 @@ Item A::
                 doc
             }
         })
-        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).asMap())
+        String result = asciidoctor.convert(document, Options.builder().standalone(false).build())
 
         then:
         org.jsoup.nodes.Document htmlDoc = Jsoup.parse(result)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentIsRenderedToStream.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenADocumentIsRenderedToStream.groovy
@@ -31,9 +31,10 @@ Hello World
 
         when:
         asciidoctor.convert(TEST_DOC,
-                OptionsBuilder.options()
+                Options.builder()
                         .backend(HTML5_BACKEND)
-                        .toStream(out))
+                        .toStream(out)
+                        .build())
 
         String result = new String(out.toByteArray())
 
@@ -50,13 +51,15 @@ Hello World
 
         when:
         asciidoctor.convert(TEST_DOC,
-                OptionsBuilder.options()
+                Options.builder()
                         .backend(HTML5_BACKEND)
-                        .toStream(out1))
+                        .toStream(out1)
+                        .build())
         asciidoctor.convert(TEST_DOC,
-                OptionsBuilder.options()
+                Options.builder()
                         .backend(HTML5_BACKEND)
-                        .toStream(out2))
+                        .toStream(out2)
+                        .build())
 
         String result1 = new String(out1.toByteArray())
         String result2 = new String(out2.toByteArray())
@@ -71,16 +74,17 @@ Hello World
         given:
         def out = new ByteArrayOutputStream()
         asciidoctor.javaConverterRegistry().register(TestConverter, TestConverter.TEST_BACKEND_NAME)
-        def testdoc = '''== Test
+        def testDoc = '''== Test
 
 Hello, World!
 '''
 
         when:
-        asciidoctor.convert(testdoc,
-                OptionsBuilder.options()
+        asciidoctor.convert(testDoc,
+                Options.builder()
                         .backend(TestConverter.TEST_BACKEND_NAME)
-                        .toStream(out))
+                        .toStream(out)
+                        .build())
 
         String result = new String(out.toByteArray())
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenATableIsLoaded.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenATableIsLoaded.groovy
@@ -22,7 +22,7 @@ class WhenATableIsLoaded extends Specification {
 '''
 
         when:
-        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().standalone(false).asMap())
+        Document documentNode = asciidoctor.load(document, Options.builder().standalone(false).build())
         Table tableNode = documentNode.blocks[0]
 
         then:
@@ -43,7 +43,7 @@ class WhenATableIsLoaded extends Specification {
 '''
 
         when:
-        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().standalone(false).asMap())
+        Document documentNode = asciidoctor.load(document, Options.builder().standalone(false).build())
         Table tableNode = documentNode.blocks[0]
 
         then:
@@ -71,7 +71,7 @@ The second content cell
 '''
 
         when:
-        Document documentNode = asciidoctor.load(document, OptionsBuilder.options().standalone(false).asMap())
+        Document documentNode = asciidoctor.load(document, Options.builder().standalone(false).build())
         Table tableNode = documentNode.blocks[0]
 
         then:

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenSubstitutionsAreUsed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenSubstitutionsAreUsed.groovy
@@ -33,7 +33,7 @@ System.out.println("Hello World");
 '''
 
         when:
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Document doc = asciidoctor.load(document, Map.of())
         Block paragraph = doc.blocks[0].blocks[0]
         Block source = doc.blocks[0].blocks[1]
 
@@ -58,11 +58,11 @@ Second test paragraph {foo}
 
         when:
         asciidoctor.javaExtensionRegistry().treeprocessor(TestTreeprocessor)
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Document doc = asciidoctor.load(document, Map.of())
         Block firstparagraph = doc.blocks[0].blocks[0]
         Block secondparagraph = doc.blocks[0].blocks[1]
 
-        String html = asciidoctor.convert(document, OptionsBuilder.options().asMap())
+        String html = asciidoctor.convert(document, Map.of())
 
         then:
         firstparagraph.substitutions == [SUBSTITUTION_SPECIAL_CHARACTERS, SUBSTITUTION_QUOTES, SUBSTITUTION_ATTRIBUTES, SUBSTITUTION_REPLACEMENTS, SUBSTITUTION_MACROS, SUBSTITUTION_POST_REPLACEMENTS]
@@ -93,11 +93,11 @@ System.out.println("{foo}");
 
         when:
         asciidoctor.javaExtensionRegistry().treeprocessor(TestTreeprocessor)
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Document doc = asciidoctor.load(document, Map.of())
         Block firstparagraph = doc.blocks[0].blocks[0]
         Block secondparagraph = doc.blocks[0].blocks[1]
 
-        String html = asciidoctor.convert(document, OptionsBuilder.options().asMap())
+        String html = asciidoctor.convert(document, Options.builder())
 
         then:
         firstparagraph.substitutions == [SUBSTITUTION_SPECIAL_CHARACTERS, SUBSTITUTION_QUOTES, SUBSTITUTION_ATTRIBUTES, SUBSTITUTION_REPLACEMENTS, SUBSTITUTION_MACROS, SUBSTITUTION_POST_REPLACEMENTS]
@@ -112,10 +112,10 @@ System.out.println("{foo}");
     static class TestTreeprocessor extends Treeprocessor {
         @Override
         Document process(Document document) {
-            if (document.blocks()[0].blocks[1].isSubstitutionEnabled(SUBSTITUTION_ATTRIBUTES)) {
-                document.blocks()[0].blocks[1].removeSubstitution(SUBSTITUTION_ATTRIBUTES)
+            if (document.blocks[0].blocks[1].isSubstitutionEnabled(SUBSTITUTION_ATTRIBUTES)) {
+                document.blocks[0].blocks[1].removeSubstitution(SUBSTITUTION_ATTRIBUTES)
             } else {
-                document.blocks()[0].blocks[1].addSubstitution(SUBSTITUTION_ATTRIBUTES)
+                document.blocks[0].blocks[1].addSubstitution(SUBSTITUTION_ATTRIBUTES)
             }
             document
         }
@@ -139,10 +139,10 @@ First test paragraph *{foo}
 
         when:
         asciidoctor.javaExtensionRegistry().treeprocessor(PrependSubstitutionTestTreeprocessor)
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
-        Block firstparagraph = doc.blocks()[0].blocks[0]
+        Document doc = asciidoctor.load(document, Map.of())
+        Block firstparagraph = doc.blocks[0].blocks[0]
 
-        String html = asciidoctor.convert(document, OptionsBuilder.options().asMap())
+        String html = asciidoctor.convert(document, Map.of())
 
         then:
         firstparagraph.substitutions == [SUBSTITUTION_ATTRIBUTES, SUBSTITUTION_SPECIAL_CHARACTERS, SUBSTITUTION_QUOTES, SUBSTITUTION_ATTRIBUTES, SUBSTITUTION_REPLACEMENTS, SUBSTITUTION_MACROS, SUBSTITUTION_POST_REPLACEMENTS]
@@ -154,7 +154,7 @@ First test paragraph *{foo}
     static class PrependSubstitutionTestTreeprocessor extends Treeprocessor {
         @Override
         Document process(Document document) {
-            document.blocks()[0].blocks[0].prependSubstitution(SUBSTITUTION_ATTRIBUTES)
+            document.blocks[0].blocks[0].prependSubstitution(SUBSTITUTION_ATTRIBUTES)
             document
         }
     }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheSourceShouldBeAccessed.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/WhenTheSourceShouldBeAccessed.groovy
@@ -37,7 +37,7 @@ This paragraph should show {foo}
 
 '''
         when:
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Document doc = asciidoctor.load(document, Map.of())
         Block block = doc.blocks[0].blocks[0]
 
         then:
@@ -60,7 +60,7 @@ This paragraph should show {foo}
 
 '''
         when:
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Document doc = asciidoctor.load(document, Map.of())
         List list = doc.blocks[0].blocks[0]
         ListItem listItem = list.items[0]
 
@@ -90,7 +90,7 @@ That::
 
 '''
         when:
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Document doc = asciidoctor.load(document, Map.of())
         DescriptionList list = doc.blocks[0].blocks[0]
         DescriptionListEntry listItem = list.items[0]
 
@@ -117,7 +117,7 @@ and should continue here'''
 
 '''
         when:
-        Document doc = asciidoctor.load(document, OptionsBuilder.options().asMap())
+        Document doc = asciidoctor.load(document, Map.of())
         Table table = doc.blocks[0].blocks[0]
         Cell cell = table.body[0].cells[0]
 
@@ -147,7 +147,7 @@ xxx
                 doc
             }
         })
-        String html = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).asMap())
+        String html = asciidoctor.convert(document,Options.builder().standalone(false).build())
         org.jsoup.nodes.Document doc = Jsoup.parse(html)
 
         then:
@@ -175,7 +175,7 @@ xxx
                 doc
             }
         })
-        String html = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).asMap())
+        String html = asciidoctor.convert(document, Options.builder().standalone(false).build())
         org.jsoup.nodes.Document doc = Jsoup.parse(html)
 
         then:
@@ -207,7 +207,7 @@ xxx
                 doc
             }
         })
-        String html = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).asMap())
+        String html = asciidoctor.convert(document, Options.builder().standalone(false).build())
         org.jsoup.nodes.Document doc = Jsoup.parse(html)
 
         then:

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/CatalogOfRefsAreAvailable.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/CatalogOfRefsAreAvailable.groovy
@@ -1,17 +1,15 @@
 package org.asciidoctor.converter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.Document
 import org.asciidoctor.ast.StructuralNode
 import org.hamcrest.BaseMatcher
 import spock.lang.Specification
 
-import static org.hamcrest.Matchers.contains
+import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.containsInAnyOrder
-import static org.hamcrest.Matchers.empty
-import static org.junit.Assert.assertThat
 
 /**
  * Tests that refs can be accessed from converter.
@@ -55,7 +53,7 @@ class CatalogOfRefsAreAvailable extends Specification {
     }
 
     def convert(String document) {
-        asciidoctor.convert(document, OptionsBuilder.options().backend(CONVERTER_BACKEND))
+        asciidoctor.convert(document, Options.builder().backend(CONVERTER_BACKEND).build())
     }
 
     def 'when there are no refs in source doc, refs should be empty'() {
@@ -66,7 +64,7 @@ class CatalogOfRefsAreAvailable extends Specification {
         convert(document)
 
         then:
-        assertThat(refs.entrySet(), empty())
+        refs.entrySet().empty
     }
 
     def 'when a ref is is in source doc, it should be accessible from converter'() {
@@ -78,7 +76,7 @@ class CatalogOfRefsAreAvailable extends Specification {
         convert(document)
 
         then:
-        assertThat(refs.keySet(), contains(idSectionA))
+        refs.keySet().contains(idSectionA)
         assertThat(refs, hasIdPointingToNodeNamed(idSectionA, NODE_NAME_SECTION))
     }
 
@@ -140,27 +138,27 @@ An [#${idInline}]*quoted text*
 
     private hasIdPointingToNodeNamed(final id, final expectedNodeName) {
         [
-            matches: { refs ->
-                if (refs.get(id)) {
-                    refs.get(id).nodeName == expectedNodeName
-                }
-            },
-            describeTo: { description ->
-                description.appendText('ref id ')
-                        .appendValue(id)
-                        .appendText(' pointing to node named ')
-                        .appendValue(expectedNodeName)
-            },
-            describeMismatch: { refs, description ->
-                if (!refs.get(id)) {
-                    description.appendText('did not find id ')
+                matches         : { refs ->
+                    if (refs.get(id)) {
+                        refs.get(id).nodeName == expectedNodeName
+                    }
+                },
+                describeTo      : { description ->
+                    description.appendText('ref id ')
                             .appendValue(id)
-                            .appendText(' in refs')
-                } else {
-                    description.appendText('instead found id pointing to ')
-                            .appendValue(refs.get(id).nodeName)
+                            .appendText(' pointing to node named ')
+                            .appendValue(expectedNodeName)
+                },
+                describeMismatch: { refs, description ->
+                    if (!refs.get(id)) {
+                        description.appendText('did not find id ')
+                                .appendValue(id)
+                                .appendText(' in refs')
+                    } else {
+                        description.appendText('instead found id pointing to ')
+                                .appendValue(refs.get(id).nodeName)
+                    }
                 }
-            }
         ] as BaseMatcher<Map<String, Object>>
     }
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableConverterTest.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/converter/TableConverterTest.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.converter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import spock.lang.Specification
 
 class TableConverterTest extends Specification {
@@ -31,7 +31,8 @@ class TableConverterTest extends Specification {
         asciidoctor.javaConverterRegistry().register(TableTestConverter, 'tabletestconverter')
 
         when:
-        String content = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).backend('tabletestconverter'))
+        def options = Options.builder().standalone(false).backend('tabletestconverter').build()
+        String content = asciidoctor.convert(document, options)
 
         then:
         content.readLines().collect { it - ~/\s+$/ } == '''HELLO TABLE
@@ -63,7 +64,8 @@ a|
         asciidoctor.javaConverterRegistry().register(TableTestConverter, 'tabletestconverter')
 
         when:
-        String content = asciidoctor.convert(document, OptionsBuilder.options().standalone(false).backend('tabletestconverter'))
+        def options = Options.builder().standalone(false).backend('tabletestconverter').build()
+        String content = asciidoctor.convert(document, options)
 
         then:
         content.readLines().collect { it - ~/\s+$/ } == '''HELLO ASCIIDOCTOR TABLE

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesAList.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesAList.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -31,7 +31,8 @@ list::HelloWorld[]
         asciidoctor.javaExtensionRegistry().blockMacro(LISTMACRO_NAME, new ListCreatorBlockMacro('olist'))
 
         when:
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(false))
+        def standalone = Options.builder().safe(SafeMode.SAFE).toFile(false).standalone(false).build()
+        String result = asciidoctor.convert(DOCUMENT, standalone)
 
         then:
         noExceptionThrown()
@@ -52,7 +53,8 @@ list::HelloWorld[]
         asciidoctor.javaExtensionRegistry().blockMacro(LISTMACRO_NAME, new ListCreatorBlockMacro('ulist'))
 
         when:
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(false))
+        def options = Options.builder().safe(SafeMode.SAFE).toFile(false).standalone(false).build()
+        String result = asciidoctor.convert(DOCUMENT, options)
 
         then:
         noExceptionThrown()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesASection.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesASection.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -30,14 +30,14 @@ section::HelloWorld[]
         asciidoctor.javaExtensionRegistry().blockMacro(BLOCKMACRO_NAME, SectionCreatorBlockMacro)
 
         when:
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(true))
+        def options = Options.builder().safe(SafeMode.SAFE).toFile(false).standalone(true).build()
+        String result = asciidoctor.convert(DOCUMENT, options)
 
         then:
         noExceptionThrown()
         Document htmlDocument = Jsoup.parse(result, UTF_8)
 
         htmlDocument.select(H2).text() == HELLO_WORLD
-
         htmlDocument.select(SECT1_SELECTOR).select(PARAGRAPH_SELECTOR).text() == SectionCreatorBlockMacro.CONTENT
     }
 
@@ -47,16 +47,14 @@ section::HelloWorld[]
         asciidoctor.createGroup().blockMacro(BLOCKMACRO_NAME, SectionCreatorBlockMacro).register()
 
         when:
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(true))
+        def options = Options.builder().safe(SafeMode.SAFE).toFile(false).standalone(true).build()
+        String result = asciidoctor.convert(DOCUMENT, options)
 
         then:
         noExceptionThrown()
         Document htmlDocument = Jsoup.parse(result, UTF_8)
 
         htmlDocument.select(H2).text() == HELLO_WORLD
-
         htmlDocument.select(SECT1_SELECTOR).select(PARAGRAPH_SELECTOR).text() == SectionCreatorBlockMacro.CONTENT
     }
-
-
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockProcessorCreatesABlockThatATreeProcessorVisits.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockProcessorCreatesABlockThatATreeProcessorVisits.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.Block
 import org.asciidoctor.ast.ContentModel
@@ -70,7 +70,8 @@ This will be ignored
         asciidoctor.javaExtensionRegistry().treeprocessor(BlockVisitor)
 
         when:
-        asciidoctor.convert(DOCUMENT, OptionsBuilder.options().safe(SafeMode.SAFE).toFile(false).standalone(true))
+        def options = Options.builder().safe(SafeMode.SAFE).toFile(false).standalone(true).build()
+        asciidoctor.convert(DOCUMENT, options)
 
         then:
         notThrown(ClassCastException)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockShouldBeDuplicated.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockShouldBeDuplicated.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.ContentModel
 import org.asciidoctor.ast.Document
@@ -28,7 +28,7 @@ class WhenABlockShouldBeDuplicated extends Specification {
     '''
 
         when:
-        Document document = asciidoctor.load(asciidoctorSource, OptionsBuilder.options().safe(SafeMode.SAFE).asMap())
+        Document document = asciidoctor.load(asciidoctorSource, Options.builder().safe(SafeMode.SAFE).build())
 
         then:
         document.blocks.size() == 2
@@ -52,7 +52,8 @@ This will be ignored
     '''
 
         when:
-        org.jsoup.nodes.Document html = Jsoup.parse(asciidoctor.convert(asciidoctorSource, OptionsBuilder.options().safe(SafeMode.SAFE).standalone(false).asMap()))
+        def options = Options.builder().safe(SafeMode.SAFE).standalone(false).build()
+        org.jsoup.nodes.Document html = Jsoup.parse(asciidoctor.convert(asciidoctorSource, options))
 
         then:
         html.select(CLASS_LISTINGBLOCK).get(0).text() == 'This will be ignored'

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionChecksAttributes.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionChecksAttributes.groovy
@@ -1,14 +1,13 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import spock.lang.Issue
 import spock.lang.Specification
 
 @Issue('https://github.com/asciidoctor/asciidoctorj/issues/450')
 class WhenAJavaExtensionChecksAttributes extends Specification {
-
 
     private static final String DOCUMENT = '''= Test document
 
@@ -22,7 +21,7 @@ Check me
     def "a BlockProcessor should only get String attribute keys"() {
         when:
         asciidoctor.javaExtensionRegistry().block(AttributeCheckingBlockProcessor)
-        asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         noExceptionThrown()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionGroupIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionGroupIsRegisteredWithAnnotations.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -86,7 +86,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor should be configurable via the Location annotation"() {
         when:
         asciidoctor.createGroup().docinfoProcessor(AnnotatedDocinfoProcessor).register()
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -97,7 +97,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance should be configurable via the Location annotation"() {
         when:
         asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor()).register()
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -109,7 +109,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance can override the annotation from footer to header"() {
         when:
         asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.HEADER)).register()
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -119,7 +119,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance can override the annotation from footer to footer"() {
         when:
         asciidoctor.createGroup().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.FOOTER)).register()
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -131,7 +131,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.createGroup().blockMacro(AnnotatedBlockMacroProcessor).register()
-        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         result.contains(AnnotatedBlockMacroProcessor.RESULT)
@@ -143,7 +143,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.createGroup().block(AnnotatedBlockProcessor).register()
-        String result = asciidoctor.convert(BLOCK_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         result.contains(DO_NOT_TOUCH_THIS)
@@ -157,7 +157,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.createGroup().block(new AnnotatedBlockProcessor('dummy', 'yell2')).register()
-        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, Options.builder().standalone(false).build())
 
         then:
         result.contains(DO_NOT_TOUCH_THIS)
@@ -168,7 +168,7 @@ And even more infos on manpage:git[7].
     def "when registering an InlineMacroProcessor class with long format it should be configurable via annotations"() {
         when:
         asciidoctor.createGroup().inlineMacro(AnnotatedLongInlineMacroProcessor).register()
-        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -179,7 +179,7 @@ And even more infos on manpage:git[7].
     def "when registering an InlineMacroProcessor class with regexp it should be configurable via annotations"() {
         when:
         asciidoctor.createGroup().inlineMacro(AnnotatedRegexpInlineMacroProcessor).register()
-        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionIsRegisteredWithAnnotations.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -86,7 +86,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor should be configurable via the Location annotation"() {
         when:
         asciidoctor.javaExtensionRegistry().docinfoProcessor(AnnotatedDocinfoProcessor)
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER))
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -97,7 +97,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance should be configurable via the Location annotation"() {
         when:
         asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor())
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -109,7 +109,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance can override the annotation from footer to header"() {
         when:
         asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.HEADER))
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -119,7 +119,7 @@ And even more infos on manpage:git[7].
     def "a docinfoprocessor instance can override the annotation from footer to footer"() {
         when:
         asciidoctor.javaExtensionRegistry().docinfoProcessor(new AnnotatedDocinfoProcessor(LocationType.FOOTER))
-        String result = asciidoctor.convert(DOCUMENT, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(DOCUMENT, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -131,7 +131,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.javaExtensionRegistry().blockMacro(AnnotatedBlockMacroProcessor)
-        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(BLOCK_MACRO_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         result.contains(AnnotatedBlockMacroProcessor.RESULT)
@@ -143,7 +143,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.javaExtensionRegistry().block(AnnotatedBlockProcessor)
-        String result = asciidoctor.convert(BLOCK_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         result.contains(DO_NOT_TOUCH_THIS)
@@ -157,7 +157,7 @@ And even more infos on manpage:git[7].
 
         when:
         asciidoctor.javaExtensionRegistry().block(new AnnotatedBlockProcessor('dummy', 'yell2'))
-        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(BLOCK_DOCUMENT_2, Options.builder().standalone(false).build())
 
         then:
         result.contains(DO_NOT_TOUCH_THIS)
@@ -168,7 +168,7 @@ And even more infos on manpage:git[7].
     def "when registering an InlineMacroProcessor class with long format it should be configurable via annotations"() {
         when:
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedLongInlineMacroProcessor)
-        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -179,7 +179,7 @@ And even more infos on manpage:git[7].
     def "when registering an InlineMacroProcessor class with regexp it should be configurable via annotations"() {
         when:
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedRegexpInlineMacroProcessor)
-        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(INLINE_MACRO_REGEXP_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionUsesCounters.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAJavaExtensionUsesCounters.groovy
@@ -2,7 +2,7 @@ package org.asciidoctor.extension
 
 import groovy.transform.CompileStatic
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.Block
 import org.asciidoctor.ast.ContentModel
@@ -46,7 +46,7 @@ The attribute for counterb: {counter:counterb}
 '''
         when:
         asciidoctor.javaExtensionRegistry().blockMacro(TestBlockMacroProcessor)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(document, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -78,7 +78,7 @@ The attribute for counterb: {counter:counterb}
 '''
         when:
         asciidoctor.javaExtensionRegistry().treeprocessor(TestTreeProcessor)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(document, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -104,7 +104,7 @@ testmacro::countera[]
 '''
         when:
         asciidoctor.javaExtensionRegistry().blockMacro(TestBlockMacroWithInitialCounterProcessor)
-        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(true).safe(SafeMode.SERVER))
+        String result = asciidoctor.convert(document, Options.builder().standalone(true).safe(SafeMode.SERVER).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.ast.Document
 import spock.lang.Specification
 
@@ -46,7 +46,7 @@ $secondLine"""
         })
 
         when:
-        asciidoctor.convert(document, OptionsBuilder.options())
+        asciidoctor.convert(document, Map.of())
 
         then:
         preprocessorCalled.get()
@@ -79,7 +79,7 @@ $secondLine"""
         })
 
         when:
-        asciidoctor.convert(document, OptionsBuilder.options())
+        asciidoctor.convert(document, Map.of())
 
         then:
         preprocessorCalled.get()
@@ -103,7 +103,7 @@ $secondLine"""
         })
 
         when:
-        asciidoctor.convert(document, OptionsBuilder.options())
+        asciidoctor.convert(document, Options.builder())
 
         then:
         preprocessorCalled.get()
@@ -134,7 +134,7 @@ $secondLine"""
         })
 
         when:
-        asciidoctor.convert(document, OptionsBuilder.options())
+        asciidoctor.convert(document, Options.builder())
 
         then:
         preprocessorCalled.get()
@@ -168,7 +168,7 @@ $secondLine"""
         })
 
         when:
-        asciidoctor.convert(document, OptionsBuilder.options())
+        asciidoctor.convert(document, Map.of())
 
         then:
         preprocessorCalled.get()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorSetsTheSourceMapOption.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorSetsTheSourceMapOption.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.ast.Document
 import spock.lang.Specification
 
@@ -46,7 +46,7 @@ Some text
         asciidoctor.javaExtensionRegistry()
                 .preprocessor(new SourceMapOptionPreprocessor())
                 .treeprocessor(treeprocessor)
-        def doc = asciidoctor.load(DOCUMENT, OptionsBuilder.options().asMap())
+        def doc = asciidoctor.load(DOCUMENT, Options.builder().build())
 
         then:
         treeprocessor.lineNoFirstSection == 3
@@ -61,7 +61,7 @@ Some text
         when:
         asciidoctor.javaExtensionRegistry()
                 .treeprocessor(treeprocessor)
-        def doc = asciidoctor.load(DOCUMENT, OptionsBuilder.options().asMap())
+        def doc = asciidoctor.load(DOCUMENT, Options.builder().build())
 
         then:
         treeprocessor.lineNoFirstSection == NOT_SET

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorCreatesNodes.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorCreatesNodes.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.ast.Document
 import org.asciidoctor.ast.StructuralNode
 import org.jsoup.Jsoup
@@ -46,7 +46,7 @@ puts "Hello"
         asciidoctor.javaExtensionRegistry().treeprocessor(tp)
 
         when: 'The document is converted'
-        String html = asciidoctor.convert(document, OptionsBuilder.options().standalone(true))
+        String html = asciidoctor.convert(document, Options.builder().standalone(true).build())
 
         then: 'The second source block uses the same value of the language attribute and highlight as Ruby'
         org.jsoup.nodes.Document htmlDocument = Jsoup.parse(html)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorWorksOnTables.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenATreeProcessorWorksOnTables.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.jsoup.Jsoup
 import spock.lang.Specification
 
@@ -27,7 +27,7 @@ class WhenATreeProcessorWorksOnTables extends Specification {
         asciidoctor.javaExtensionRegistry().treeprocessor(TableCreatorTreeProcessor)
 
         when: 'the document is rendered'
-        String content = asciidoctor.convert(EMPTY_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String content = asciidoctor.convert(EMPTY_DOCUMENT, Options.builder().standalone(false).build())
 
         then: 'the resulting document has a table'
         org.jsoup.nodes.Document document = Jsoup.parse(content)
@@ -67,7 +67,7 @@ class WhenATreeProcessorWorksOnTables extends Specification {
 | World | Hello 
 |===
 
-''', OptionsBuilder.options().standalone(false))
+''', Options.builder().standalone(false))
 
         def htmlDocument = Jsoup.parse(content)
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnExtensionAppendsChildBlocks.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnExtensionAppendsChildBlocks.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.ast.Block
 import org.asciidoctor.ast.Document
 import org.asciidoctor.ast.Section
@@ -47,7 +47,7 @@ more text
         })
 
         when:
-        String result = asciidoctor.convert(this.document, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(this.document, Options.builder().standalone(false).build())
 
         then:
         org.jsoup.nodes.Document htmlDocument = Jsoup.parse(result)
@@ -81,7 +81,7 @@ And this as well
         })
 
         when:
-        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(document, Options.builder().standalone(false).build())
 
         then:
         org.jsoup.nodes.Document htmlDocument = Jsoup.parse(result)
@@ -124,7 +124,7 @@ testmacro::target[]
         })
 
         when:
-        String result = asciidoctor.convert(document, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(document, Options.builder().standalone(false).build())
 
         then:
         result.contains(expectedContent)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnInlineMacroProcessorProcessesATable.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAnInlineMacroProcessorProcessesATable.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -38,7 +38,7 @@ a| You can find infos on man:gittutorial[7] or man:git[8, 1].
     def "a InlineMacroProcessor should be able to process table cells"() {
         when:
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedLongInlineMacroProcessor)
-        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT, Options.builder().standalone(false).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)
@@ -49,7 +49,7 @@ a| You can find infos on man:gittutorial[7] or man:git[8, 1].
     def "a InlineMacroProcessor should be able to process table cells with asciidoc style"() {
         when:
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedLongInlineMacroProcessor)
-        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT_ASCIIDOC_STYLE, OptionsBuilder.options().standalone(false))
+        String result = asciidoctor.convert(INLINE_MACRO_DOCUMENT_ASCIIDOC_STYLE, Options.builder().standalone(false).build())
 
         then:
         Document doc = Jsoup.parse(result, UTF8)

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenTheConfigIsSetOfAJavaExtension.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenTheConfigIsSetOfAJavaExtension.groovy
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Options
 import org.asciidoctor.ast.ContentModel
 import org.asciidoctor.jruby.internal.AsciidoctorCoreException
 import spock.lang.Specification
@@ -39,7 +39,7 @@ Parsing will crash when processing this block
         asciidoctor.javaExtensionRegistry().block(blockProcessor)
 
         when:
-        asciidoctor.convert(document, OptionsBuilder.options().toFile(false))
+        asciidoctor.convert(document, Options.builder().toFile(false).build())
 
         then:
         Exception e = thrown()
@@ -54,7 +54,7 @@ Parsing will crash when processing this block
         asciidoctor.javaExtensionRegistry().block('modify', ConfigModifyingBlockProcessor)
 
         when:
-        asciidoctor.convert(document, OptionsBuilder.options().toFile(false))
+        asciidoctor.convert(document, Options.builder().toFile(false).build())
 
         then:
         Exception e = thrown()

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenACoderayAdapterIsImplementedInGroovy.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenACoderayAdapterIsImplementedInGroovy.groovy
@@ -1,8 +1,8 @@
 package org.asciidoctor.syntaxhighlighter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.AttributesBuilder
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Attributes
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import spock.lang.Ignore
 import spock.lang.Specification
@@ -38,19 +38,23 @@ func main() {
     asciidoctor.syntaxHighlighterRegistry().register(CoderayHighlighter, NAME_SYNTAXHIGHLIGHTER)
 
     when:
-    String htmlJava = asciidoctor.convert(doc, OptionsBuilder.options()
+    String htmlJava = asciidoctor.convert(doc, Options.builder()
             .safe(SafeMode.UNSAFE)
             .standalone(true)
-            .attributes(AttributesBuilder.attributes()
+            .attributes(Attributes.builder()
                 .sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)
-                .linkCss(true)))
+                .linkCss(true)
+                .build())
+            .build())
 
-    String htmlRuby = asciidoctor.convert(doc, OptionsBuilder.options()
+    String htmlRuby = asciidoctor.convert(doc, Options.builder()
             .safe(SafeMode.UNSAFE)
             .standalone(true)
-            .attributes(AttributesBuilder.attributes()
+            .attributes(Attributes.builder()
                 .sourceHighlighter('coderay')
-                .linkCss(true)))
+                .linkCss(true)
+                .build())
+            .build())
 
     then:
     // Cannot use `htmlRuby == htmlJava` because it fails with OOM

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAHighlightjsAdapterIsImplementedInGroovy.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAHighlightjsAdapterIsImplementedInGroovy.groovy
@@ -1,8 +1,8 @@
 package org.asciidoctor.syntaxhighlighter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.AttributesBuilder
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Attributes
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -42,10 +42,11 @@ func main() {
         asciidoctor.syntaxHighlighterRegistry().register(HighlightJsHighlighter, NAME_SYNTAXHIGHLIGHTER)
 
         when:
-        String html = asciidoctor.convert(doc, OptionsBuilder.options()
+        String html = asciidoctor.convert(doc, Options.builder()
                 .safe(SafeMode.UNSAFE)
                 .standalone(true)
-                .attributes(AttributesBuilder.attributes().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)))
+                .attributes(Attributes.builder().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER).build())
+                .build())
 
         then:
         Document document = Jsoup.parse(html)
@@ -61,10 +62,11 @@ func main() {
     def 'should autoregister from extension'() {
 
         when:
-        asciidoctor.convert(doc, OptionsBuilder.options()
+        asciidoctor.convert(doc, Options.builder()
                 .safe(SafeMode.UNSAFE)
                 .standalone(true)
-                .attributes(AttributesBuilder.attributes().sourceHighlighter(HighlightJsExtension.NAME_HIGHLIGHTER)))
+                .attributes(Attributes.builder().sourceHighlighter(HighlightJsExtension.NAME_HIGHLIGHTER).build())
+                .build())
 
         then:
         assertThat(ObservableHighlightJsHighlighter.called, is(equalTo(2)))

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenALayoutingSyntaxHighlighterIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenALayoutingSyntaxHighlighterIsRegistered.groovy
@@ -1,8 +1,8 @@
 package org.asciidoctor.syntaxhighlighter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.AttributesBuilder
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Attributes
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.Block
 import org.asciidoctor.ast.Document
@@ -50,10 +50,11 @@ System.out.println("Hello World");
     asciidoctor.syntaxHighlighterRegistry().register(AllGoHighlighter, NAME_SYNTAXHIGHLIGHTER)
 
     when:
-    String html = asciidoctor.convert(doc, OptionsBuilder.options()
+    String html = asciidoctor.convert(doc, Options.builder()
             .safe(SafeMode.UNSAFE)
             .standalone(false)
-            .attributes(AttributesBuilder.attributes().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)))
+            .attributes(Attributes.builder().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER).build())
+            .build())
 
     org.jsoup.nodes.Document document = Jsoup.parse(html)
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAServerSideSyntaxHighlighterIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/syntaxhighlighter/WhenAServerSideSyntaxHighlighterIsRegistered.groovy
@@ -1,8 +1,8 @@
 package org.asciidoctor.syntaxhighlighter
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.AttributesBuilder
-import org.asciidoctor.OptionsBuilder
+import org.asciidoctor.Attributes
+import org.asciidoctor.Options
 import org.asciidoctor.SafeMode
 import org.asciidoctor.ast.Block
 import org.asciidoctor.ast.Document
@@ -54,10 +54,11 @@ System.out.println("Hello World");
     asciidoctor.syntaxHighlighterRegistry().register(TestHighlighter, NAME_SYNTAXHIGHLIGHTER)
 
     when:
-    String html = asciidoctor.convert(doc, OptionsBuilder.options()
+    String html = asciidoctor.convert(doc, Options.builder()
             .safe(SafeMode.UNSAFE)
             .standalone(false)
-            .attributes(AttributesBuilder.attributes().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER)))
+            .attributes(Attributes.builder().sourceHighlighter(NAME_SYNTAXHIGHLIGHTER).build())
+            .build())
 
     org.jsoup.nodes.Document document = Jsoup.parse(html)
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiated.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorClassIsInstantiated.java
@@ -1,6 +1,5 @@
 package org.asciidoctor;
 
-import com.google.common.io.CharStreams;
 import org.asciidoctor.jruby.AsciiDocDirectoryWalker;
 import org.asciidoctor.jruby.internal.AsciidoctorCoreException;
 import org.asciidoctor.test.AsciidoctorInstance;
@@ -24,8 +23,6 @@ import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import static org.asciidoctor.AttributesBuilder.attributes;
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.isEmptyString;
@@ -97,7 +94,7 @@ public class WhenAnAsciidoctorClassIsInstantiated {
 
         FileReader inputAsciidoctorFile = new FileReader(renderSampleDocument);
         StringWriter rendererWriter = new StringWriter();
-        asciidoctor.convert(inputAsciidoctorFile, rendererWriter, options().asMap());
+        asciidoctor.convert(inputAsciidoctorFile, rendererWriter, options().build().map());
 
         StringBuffer renderedContent = rendererWriter.getBuffer();
         assertRenderedFile(renderedContent.toString());
@@ -116,7 +113,7 @@ public class WhenAnAsciidoctorClassIsInstantiated {
     @Test
     public void file_document_should_be_rendered_into_current_directory_using_options_class() {
 
-        Options options = options().inPlace(true).get();
+        Options options = options().inPlace(true).build();
         String renderContent = asciidoctor.convertFile(renderSampleDocument, options);
 
         File expectedFile = new File(renderSampleDocument.getParent(), "rendersample.html");
@@ -131,7 +128,7 @@ public class WhenAnAsciidoctorClassIsInstantiated {
     public void file_document_should_be_rendered_into_current_directory() {
 
         String renderContent = asciidoctor.convertFile(renderSampleDocument, options()
-                .inPlace(true).asMap());
+                .inPlace(true).build().map());
 
         File expectedFile = new File(renderSampleDocument.getParent(), "rendersample.html");
 
@@ -180,7 +177,7 @@ public class WhenAnAsciidoctorClassIsInstantiated {
     @Test
     public void file_document_should_be_rendered_into_foreign_directory_using_options_class() {
 
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE).toDir(tempFolder).get();
+        Options options = options().inPlace(false).safe(SafeMode.UNSAFE).toDir(tempFolder).build();
 
         String renderContent = asciidoctor.convertFile(renderSampleDocument, options);
 
@@ -193,8 +190,8 @@ public class WhenAnAsciidoctorClassIsInstantiated {
     @Test
     public void docbook_document_should_be_rendered_into_current_directory() {
 
-        Map<String, Object> attributes = attributes().backend("docbook").asMap();
-        Map<String, Object> options = options().inPlace(true).attributes(attributes).asMap();
+        Attributes attributes = Attributes.builder().backend("docbook").build();
+        Map<String, Object> options = options().inPlace(true).attributes(attributes).build().map();
 
         String renderContent = asciidoctor.convertFile(renderSampleDocument, options);
 
@@ -209,8 +206,8 @@ public class WhenAnAsciidoctorClassIsInstantiated {
     @Test
     public void docbook_document_should_be_rendered_into_current_directory_using_options_class() {
 
-        Attributes attributes = attributes().backend("docbook").get();
-        Options options = options().inPlace(true).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().backend("docbook").build();
+        Options options = options().inPlace(true).attributes(attributes).build();
 
         String renderContent = asciidoctor.convertFile(renderSampleDocument, options);
 
@@ -225,7 +222,7 @@ public class WhenAnAsciidoctorClassIsInstantiated {
     @Test
     public void docbook_document_should_be_rendered_into_current_directory_using_options_backend_attribute() {
 
-        Options options = options().inPlace(true).backend("docbook").get();
+        Options options = options().inPlace(true).backend("docbook").build();
 
         String renderContent = asciidoctor.convertFile(renderSampleDocument, options);
 
@@ -247,8 +244,8 @@ public class WhenAnAsciidoctorClassIsInstantiated {
         customDate.set(Calendar.MONTH, 11);
         customDate.set(Calendar.DATE, 5);
 
-        Map<String, Object> attributes = attributes().localDate(customDate.getTime()).asMap();
-        Map<String, Object> options = options().attributes(attributes).asMap();
+        Attributes attributes = Attributes.builder().localDate(customDate.getTime()).build();
+        Map<String, Object> options = options().attributes(attributes).build().map();
 
         String render_file = asciidoctor.convert(Files.readString(documentWithDate), options);
         assertRenderedLocalDateContent(render_file, "2012-12-05.");
@@ -265,8 +262,8 @@ public class WhenAnAsciidoctorClassIsInstantiated {
         customTime.set(Calendar.MINUTE, 15);
         customTime.set(Calendar.SECOND, 0);
 
-        Map<String, Object> attributes = attributes().localTime(customTime.getTime()).asMap();
-        Map<String, Object> options = options().attributes(attributes).asMap();
+        Attributes attributes = Attributes.builder().localTime(customTime.getTime()).build();
+        Map<String, Object> options = options().attributes(attributes).build().map();
 
         String render_file = asciidoctor.convert(Files.readString(documentWithDate), options);
 
@@ -289,7 +286,7 @@ public class WhenAnAsciidoctorClassIsInstantiated {
     public void all_files_from_a_collection_should_be_rendered_into_an_array() {
 
         String[] allRenderedFiles = asciidoctor.convertFiles(
-                List.of(renderSampleDocument), options().toFile(false).get());
+                List.of(renderSampleDocument), options().toFile(false).build());
         assertThat(allRenderedFiles, is(arrayWithSize(1)));
     }
 
@@ -362,10 +359,6 @@ public class WhenAnAsciidoctorClassIsInstantiated {
         assertThat(renderFileSource, hasXPath("/div/div[@class='sectionbody']"));
     }
 
-    private static String toString(InputStream inputStream) throws IOException {
-        return CharStreams.toString(new InputStreamReader(inputStream));
-    }
-
     private static org.w3c.dom.Document inputStream2Document(InputStream inputStream) throws IOException, SAXException,
             ParserConfigurationException {
         DocumentBuilderFactory newInstance = DocumentBuilderFactory.newInstance();
@@ -374,4 +367,7 @@ public class WhenAnAsciidoctorClassIsInstantiated {
         return parse;
     }
 
+    private OptionsBuilder options() {
+        return Options.builder();
+    }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorJInstanceIsRequired.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAnAsciidoctorJInstanceIsRequired.java
@@ -15,7 +15,7 @@ public class WhenAnAsciidoctorJInstanceIsRequired {
         AsciidoctorJRuby asciidoctorj = Asciidoctor.Factory.create().unwrap(AsciidoctorJRuby.class);
         asciidoctorj.rubyExtensionRegistry().loadClass(getClass().getResourceAsStream("/ruby-extensions/YellRubyBlock.rb")).block("yell", "YellRubyBlock");
 
-        String html = asciidoctorj.convert(DOC, OptionsBuilder.options().standalone(false));
+        String html = asciidoctorj.convert(DOC, Options.builder().standalone(false));
 
         assertThat(html, containsString("HELLO WORLD"));
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsLoadedToDocument.java
@@ -141,7 +141,7 @@ public class WhenAsciiDocIsLoadedToDocument {
 
     @Test
     public void should_return_options_from_parsed_string_when_passed_as_map() {
-        Map<String, Object> options = OptionsBuilder.options().compact(true).asMap();
+        Map<String, Object> options = Options.builder().compact(true).build().map();
         Document document = asciidoctor.load(DOCUMENT, options);
 
         Map<Object, Object> documentOptions = document.getOptions();
@@ -195,9 +195,11 @@ public class WhenAsciiDocIsLoadedToDocument {
 
     @Test
     public void should_be_able_to_manipulate_attributes() {
-        Map<String, Object> options = OptionsBuilder.options()
-                .attributes(AttributesBuilder.attributes().dataUri(true))
-                .compact(true).asMap();
+        Map<String, Object> options = Options.builder()
+                .attributes(Attributes.builder().dataUri(true).build())
+                .compact(true)
+                .build()
+                .map();
         Document document = asciidoctor.load(DOCUMENT, options);
         assertThat(document.getAttributes(), hasKey("toc-placement"));
         assertThat(document.hasAttribute("toc-placement"), is(true));
@@ -245,18 +247,22 @@ public class WhenAsciiDocIsLoadedToDocument {
 
     @Test
     public void should_be_able_to_get_icon_uri_string_reference() {
-        Map<String, Object> options = OptionsBuilder.options()
-                .attributes(AttributesBuilder.attributes().dataUri(false))
-                .compact(true).asMap();
+        Map<String, Object> options = Options.builder()
+                .attributes(Attributes.builder().dataUri(false).build())
+                .compact(true)
+                .build()
+                .map();
         Document document = asciidoctor.load(DOCUMENT, options);
         assertThat(document.iconUri("note"), is("./images/icons/note.png"));
     }
 
     @Test
     public void should_be_able_to_get_icon_uri() {
-        Map<String, Object> options = OptionsBuilder.options().safe(SafeMode.SAFE)
-                .attributes(AttributesBuilder.attributes().dataUri(true).icons("font"))
-                .compact(true).asMap();
+        Map<String, Object> options = Options.builder().safe(SafeMode.SAFE)
+                .attributes(Attributes.builder().dataUri(true).icons("font").build())
+                .compact(true)
+                .build()
+                .map();
         Document document = asciidoctor.load(DOCUMENT, options);
         assertThat(document.iconUri("note"),
                 either(
@@ -273,9 +279,11 @@ public class WhenAsciiDocIsLoadedToDocument {
 
     @Test
     public void should_be_able_to_get_image_uri() {
-        Map<String, Object> options = OptionsBuilder.options().safe(SafeMode.SAFE)
-                .attributes(AttributesBuilder.attributes().dataUri(false))
-                .compact(true).asMap();
+        Map<String, Object> options = Options.builder().safe(SafeMode.SAFE)
+                .attributes(Attributes.builder().dataUri(false).build())
+                .compact(true)
+                .build()
+                .map();
         Document document = asciidoctor.load(DOCUMENT, options);
         assertThat(document.imageUri("target.jpg"), is("target.jpg"));
         assertThat(document.imageUri("target.jpg", "imagesdir"), is("target.jpg"));
@@ -291,10 +299,11 @@ public class WhenAsciiDocIsLoadedToDocument {
     public void should_be_able_to_read_asset(
             @ClasspathResource("rendersample.asciidoc") File inputFile) throws IOException {
 
-        Map<String, Object> options = OptionsBuilder.options().safe(SafeMode.SAFE)
-                .attributes(AttributesBuilder.attributes().dataUri(false))
+        Map<String, Object> options = Options.builder().safe(SafeMode.SAFE)
+                .attributes(Attributes.builder().dataUri(false).build())
                 .compact(true)
-                .asMap();
+                .build()
+                .map();
         Document document = asciidoctor.load(DOCUMENT, options);
 
         String content = document.readAsset(inputFile.getAbsolutePath(), new HashMap<>());
@@ -326,7 +335,7 @@ public class WhenAsciiDocIsLoadedToDocument {
             @ClasspathResource("sourcelocation.adoc") File file) {
 
         // When
-        Document document = asciidoctor.loadFile(file, OptionsBuilder.options().sourcemap(true).docType("book").asMap());
+        Document document = asciidoctor.loadFile(file, Options.builder().sourcemap(true).docType("book").build().map());
         Map<Object, Object> selector = new HashMap<>();
         selector.put("context", ":paragraph");
         List<StructuralNode> findBy = document.findBy(selector);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -29,7 +29,6 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.asciidoctor.test.AsciidoctorInstance.InstanceScope.PER_METHOD;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -68,13 +67,11 @@ public class WhenAsciidoctorLogsToConsole {
         final MemoryLogHandler memoryLogHandler = registerMemoryLogHandler();
 
         File inputFile = documentWithNotExistingFile;
-        String renderContent = asciidoctor.convertFile(inputFile,
-                options()
+        asciidoctor.convertFile(inputFile,
+                Options.builder()
                         .inPlace(true)
                         .safe(SafeMode.SERVER)
-                        .attributes(
-                                AttributesBuilder.attributes().allowUriRead(true))
-                        .asMap());
+                        .attributes(Attributes.builder().allowUriRead(true).build()));
 
         File expectedFile = new File(inputFile.getParent(), "documentwithnotexistingfile.html");
         expectedFile.delete();
@@ -100,13 +97,11 @@ public class WhenAsciidoctorLogsToConsole {
         asciidoctor.registerLogHandler(logRecords::add);
 
         File inputFile = documentWithNotExistingFile;
-        String renderContent = asciidoctor.convertFile(inputFile,
-                options()
+        asciidoctor.convertFile(inputFile,
+                Options.builder()
                         .inPlace(true)
                         .safe(SafeMode.SERVER)
-                        .attributes(
-                                AttributesBuilder.attributes().allowUriRead(true))
-                        .asMap());
+                        .attributes(Attributes.builder().allowUriRead(true).build()));
 
         File expectedFile = new File(inputFile.getParent(), "documentwithnotexistingfile.html");
         expectedFile.delete();
@@ -134,14 +129,12 @@ public class WhenAsciidoctorLogsToConsole {
         asciidoctor.registerLogHandler(logRecords::add);
 
         File inputFile = documentWithInvalidRefs;
-        String renderContent = asciidoctor.convertFile(inputFile,
-                options()
+        asciidoctor.convertFile(inputFile,
+                Options.builder()
                         .inPlace(true)
                         .safe(SafeMode.SERVER)
                         .toFile(false)
-                        .attributes(
-                                AttributesBuilder.attributes().allowUriRead(true))
-                        .asMap());
+                        .attributes(Attributes.builder().allowUriRead(true).build()));
 
         assertThat(logRecords, hasSize(1));
         assertThat(logRecords.get(0).getMessage(), containsString("invalid reference: invalidref"));
@@ -160,13 +153,11 @@ public class WhenAsciidoctorLogsToConsole {
 
         // Now render via second instance and check that there is no notification
         File inputFile = documentWithNotExistingFile;
-        String renderContent1 = secondInstance.convertFile(inputFile,
-                options()
+        secondInstance.convertFile(inputFile,
+                Options.builder()
                         .inPlace(true)
                         .safe(SafeMode.SERVER)
-                        .attributes(
-                                AttributesBuilder.attributes().allowUriRead(true))
-                        .asMap());
+                        .attributes(Attributes.builder().allowUriRead(true).build()));
 
         File expectedFile1 = new File(inputFile.getParent(), "documentwithnotexistingfile.html");
         expectedFile1.delete();
@@ -174,20 +165,18 @@ public class WhenAsciidoctorLogsToConsole {
         assertEquals(0, logRecords.size());
 
         // Now render via first instance and check that notifications appeared.
-        String renderContent = asciidoctor.convertFile(inputFile,
-                options()
+        asciidoctor.convertFile(inputFile,
+                Options.builder()
                         .inPlace(true)
                         .safe(SafeMode.SERVER)
-                        .attributes(
-                                AttributesBuilder.attributes().allowUriRead(true))
-                        .asMap());
+                        .attributes(Attributes.builder().allowUriRead(true).build()));
 
         File expectedFile2 = new File(inputFile.getParent(), "documentwithnotexistingfile.html");
         expectedFile2.delete();
 
         assertEquals(4, logRecords.size());
         assertThat(logRecords.get(0).getMessage(), containsString("include file not found"));
-        final Cursor cursor = (Cursor) logRecords.get(0).getCursor();
+        final Cursor cursor = logRecords.get(0).getCursor();
         assertThat(cursor.getDir().replace('\\', '/'), is(inputFile.getParent().replace('\\', '/')));
         assertThat(cursor.getFile(), is(inputFile.getName()));
         assertThat(cursor.getLineNumber(), is(3));
@@ -202,13 +191,11 @@ public class WhenAsciidoctorLogsToConsole {
         asciidoctor.registerLogHandler(logHandler);
 
         File inputFile = documentWithNotExistingFile;
-        String renderContent = asciidoctor.convertFile(inputFile,
-                options()
+        asciidoctor.convertFile(inputFile,
+                Options.builder()
                         .inPlace(true)
                         .safe(SafeMode.SERVER)
-                        .attributes(
-                                AttributesBuilder.attributes().allowUriRead(true))
-                        .asMap());
+                        .attributes(Attributes.builder().allowUriRead(true).build()));
 
         File expectedFile = new File(inputFile.getParent(), "documentwithnotexistingfile.html");
         expectedFile.delete();
@@ -219,12 +206,10 @@ public class WhenAsciidoctorLogsToConsole {
         asciidoctor.unregisterLogHandler(logHandler);
 
         asciidoctor.convertFile(inputFile,
-                options()
+                Options.builder()
                         .inPlace(true)
                         .safe(SafeMode.SERVER)
-                        .attributes(
-                                AttributesBuilder.attributes().allowUriRead(true))
-                        .asMap());
+                        .attributes(Attributes.builder().allowUriRead(true).build()));
 
         File expectedFile2 = new File(inputFile.getParent(), "documentwithnotexistingfile.html");
         expectedFile2.delete();
@@ -236,13 +221,11 @@ public class WhenAsciidoctorLogsToConsole {
     public void shouldNotifyLogHandlerService() {
 
         File inputFile = documentWithNotExistingFile;
-        String renderContent = asciidoctor.convertFile(inputFile,
-                options()
+        asciidoctor.convertFile(inputFile,
+                Options.builder()
                         .inPlace(true)
                         .safe(SafeMode.SERVER)
-                        .attributes(
-                                AttributesBuilder.attributes().allowUriRead(true))
-                        .asMap());
+                        .attributes(Attributes.builder().allowUriRead(true).build()));
 
         File expectedFile = new File(inputFile.getParent(), "documentwithnotexistingfile.html");
         expectedFile.delete();
@@ -288,7 +271,7 @@ public class WhenAsciidoctorLogsToConsole {
         asciidoctor.javaExtensionRegistry().block(LoggingProcessor.class);
 
         String renderContent = asciidoctor.convert("= Test\n\n== Something different\n\n[big]\nHello World",
-                options().option("sourcemap", "true").asMap());
+                Options.builder().option("sourcemap", "true").build().map());
 
         assertEquals(1, logRecords.size());
         assertThat(logRecords.get(0).getMessage(), is("Hello Log"));
@@ -309,7 +292,7 @@ public class WhenAsciidoctorLogsToConsole {
         try {
             asciidoctor.convert(
                     "= Test\n\n== Something different\n\n[big]\nHello World",
-                    options().option("sourcemap", "true").asMap());
+                    Options.builder().option("sourcemap", "true").build().map());
         } catch (Throwable t) {
             // then
             assertThat(t.getMessage(), containsString("Failed to load AsciiDoc document"));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -24,8 +24,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Map;
 
-import static org.asciidoctor.AttributesBuilder.attributes;
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
@@ -57,9 +55,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void qualified_http_url_inline_with_hide_uri_scheme_set() {
 
-        Attributes attributes = attributes().hiddenUriScheme(true).get();
+        Attributes attributes = Attributes.builder()
+                .hiddenUriScheme(true)
+                .build();
 
-        String content = asciidoctor.convert("The AsciiDoc project is located at https://asciidoc.org.", OptionsBuilder.options().attributes(attributes));
+        String content = asciidoctor.convert("The AsciiDoc project is located at https://asciidoc.org.", Options.builder().attributes(attributes));
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Element link = doc.getElementsByTag("a").first();
@@ -70,9 +70,12 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void compat_mode_should_change_how_document_is_rendered_to_legacy_system() {
 
-        Attributes attributes = attributes().attribute("version", "1.0.0").compatMode(CompatMode.LEGACY).get();
+        Attributes attributes = Attributes.builder()
+                .attribute("version", "1.0.0")
+                .compatMode(CompatMode.LEGACY)
+                .build();
 
-        String content = asciidoctor.convert("The `AsciiDoc {version}` project.", OptionsBuilder.options().attributes(attributes));
+        String content = asciidoctor.convert("The `AsciiDoc {version}` project.", Options.builder().attributes(attributes));
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Element code = doc.getElementsByTag("code").first();
@@ -83,9 +86,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void no_compat_mode_should_change_how_document_is_rendered_to_new_system() {
 
-        Attributes attributes = attributes().attribute("version", "1.0.0").get();
+        Attributes attributes = Attributes.builder()
+                .attribute("version", "1.0.0")
+                .build();
 
-        String content = asciidoctor.convert("The `AsciiDoc {version}` project.", OptionsBuilder.options().attributes(attributes));
+        String content = asciidoctor.convert("The `AsciiDoc {version}` project.", Options.builder().attributes(attributes));
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Element code = doc.getElementsByTag("code").first();
@@ -96,9 +101,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void should_preload_open_cache_uri_gem() {
 
-        Attributes attributes = attributes().cacheUri(true).get();
+        Attributes attributes = Attributes.builder()
+                .cacheUri(true)
+                .build();
 
-        String content = asciidoctor.convert("read my lips", OptionsBuilder.options().attributes(attributes));
+        String content = asciidoctor.convert("read my lips", Options.builder().attributes(attributes));
 
         assertThat(content, is(notNullValue()));
 
@@ -108,10 +115,14 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void should_add_AsciiMath_delimiters_around_math_block_content_if_math_attribute_not_latexmath(
             @ClasspathResource("math.asciidoc") File sourceDocument) throws IOException {
 
-        Attributes attributes = attributes().math("asciimath").get();
+        Attributes attributes = Attributes.builder().math("asciimath").build();
 
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(sourceDocument, options);
 
@@ -124,10 +135,14 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void should_use_custom_appendix_caption_if_specified(
             @ClasspathResource("appendix.asciidoc") File appendixDocument) throws IOException {
 
-        Attributes attributes = attributes().appendixCaption("App").get();
+        Attributes attributes = Attributes.builder().appendixCaption("App").build();
 
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(appendixDocument, options);
 
@@ -141,9 +156,9 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void should_add_a_hardbreak_at_end_of_each_line_when_hardbreaks_option_is_set() {
 
-        Attributes attributes = attributes().hardbreaks(true).get();
+        Attributes attributes = Attributes.builder().hardbreaks(true).build();
 
-        String content = asciidoctor.convert("read\nmy\nlips", OptionsBuilder.options().attributes(attributes));
+        String content = asciidoctor.convert("read\nmy\nlips", Options.builder().attributes(attributes));
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Element paragraph = doc.getElementsByAttributeValue("class", "paragraph").first();
@@ -155,13 +170,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void sect_num_levels_attribute_should_only_number_levels_up_to_value_defined_by_sectnumlevels_attribute(
             @ClasspathResource("multiple_levels.asciidoc") File multiLevelDocument) throws IOException {
 
-        Attributes attributes = attributes().sectionNumbers(true).sectNumLevels(2).get();
+        Attributes attributes = Attributes.builder().sectionNumbers(true).sectNumLevels(2).build();
 
-        Options options = options()
+        Options options = Options.builder()
                 .inPlace(false)
                 .safe(SafeMode.UNSAFE)
                 .toDir(tempFolder).attributes(attributes)
-                .get();
+                .build();
 
         asciidoctor.convertFile(multiLevelDocument, options);
 
@@ -176,10 +191,14 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void no_footer_attribute_should_not_show_footer_info() throws IOException {
 
-        Attributes attributes = attributes().noFooter(true).get();
+        Attributes attributes = Attributes.builder().noFooter(true).build();
 
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -192,11 +211,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
     @Test
     public void show_title_true_attribute_should_show_title_on_embedded_document() {
-        final Options options = options()
-                .attributes(attributes().showTitle(true).get())
+        final Options options = Options.builder()
+                .attributes(Attributes.builder().showTitle(true).build())
                 .toFile(false)
                 .standalone(false)
-                .get();
+                .build();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(renderSample, options));
 
@@ -206,11 +225,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
     @Test
     public void show_title_false_then_true_attribute_should_show_title_on_embedded_document() {
-        final Options options = options()
-                .attributes(attributes().showTitle(false).showTitle(true).get())
+        final Options options = Options.builder()
+                .attributes(Attributes.builder().showTitle(false).showTitle(true).build())
                 .toFile(false)
                 .standalone(false)
-                .get();
+                .build();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(renderSample, options));
 
@@ -220,11 +239,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
     @Test
     public void show_title_false_attribute_should_hide_title_on_embedded_document() {
-        final Options options = options()
-                .attributes(attributes().showTitle(false).get())
+        final Options options = Options.builder()
+                .attributes(Attributes.builder().showTitle(false).build())
                 .toFile(false)
                 .standalone(false)
-                .get();
+                .build();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(renderSample, options));
 
@@ -233,11 +252,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
     @Test
     public void show_title_true_then_false_attribute_should_hide_title_on_embedded_document() {
-        final Options options = options()
-                .attributes(attributes().showTitle(true).showTitle(false).get())
+        final Options options = Options.builder()
+                .attributes(Attributes.builder().showTitle(true).showTitle(false).build())
                 .toFile(false)
                 .standalone(false)
-                .get();
+                .build();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(renderSample, options));
 
@@ -247,11 +266,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void show_title_true_attribute_should_show_title_on_standalone_document() {
 
-        final Options options = options()
-                .attributes(attributes().showTitle(true).get())
+        final Options options = Options.builder()
+                .attributes(Attributes.builder().showTitle(true).build())
                 .toFile(false)
                 .standalone(true)
-                .get();
+                .build();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(renderSample, options));
 
@@ -262,11 +281,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void show_title_false_attribute_should_hide_title_on_standalone_document() {
 
-        final Options options = options()
-                .attributes(attributes().showTitle(false).get())
+        final Options options = Options.builder()
+                .attributes(Attributes.builder().showTitle(false).build())
                 .toFile(false)
                 .standalone(true)
-                .get();
+                .build();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(renderSample, options));
 
@@ -276,11 +295,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void show_title_true_then_false_attribute_should_hide_title_on_standalone_document() {
 
-        final Options options = options()
-                .attributes(attributes().showTitle(false).get())
+        final Options options = Options.builder()
+                .attributes(Attributes.builder().showTitle(false).build())
                 .toFile(false)
                 .standalone(true)
-                .get();
+                .build();
 
         final Document doc = Jsoup.parse(asciidoctor.convertFile(renderSample, options));
 
@@ -291,10 +310,14 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void source_highlighter_attribute_should_add_required_javascript_libraries_as_highlighter() throws IOException {
 
-        Attributes attributes = attributes().sourceHighlighter("prettify").get();
+        Attributes attributes = Attributes.builder().sourceHighlighter("prettify").build();
 
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -307,11 +330,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void render_content_without_attributes_should_embed_css_by_default() throws IOException {
 
-        Options options = options()
+        Options options = Options.builder()
                 .inPlace(false)
                 .safe(SafeMode.UNSAFE)
                 .toDir(tempFolder)
-                .get();
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -328,8 +351,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void should_skip_front_matter_if_specified_by_skip_front_matter_attribute(
             @ClasspathResource("renderwithfrontmatter.adoc") File renderWithFrontMatter) {
 
-        Attributes attributes = attributes().skipFrontMatter(true).get();
-        Options options = options().toFile(false).inPlace(false).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().skipFrontMatter(true).build();
+        Options options = Options.builder().toFile(false).inPlace(false).attributes(attributes).build();
 
         String content = asciidoctor.convertFile(renderWithFrontMatter, options);
         Document doc = Jsoup.parse(content, "UTF-8");
@@ -342,8 +365,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void set_anchors_attribute_should_add_anchor_to_sections() {
 
-        Attributes attributes = attributes().setAnchors(true).get();
-        Options options = options().inPlace(false).toFile(false).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().setAnchors(true).build();
+        Options options = Options.builder().inPlace(false).toFile(false).attributes(attributes).build();
 
         String content = asciidoctor.convertFile(renderSample, options);
 
@@ -358,8 +381,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void ignore_undefined_attributes_should_keep_lines_with_undefined_attributes(
             @ClasspathResource("documentwithundefinedattribute.asciidoc") File sourceDocument) {
 
-        Attributes attributes = attributes().ignoreUndefinedAttributes(true).get();
-        Options options = options().toFile(false).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().ignoreUndefinedAttributes(true).build();
+        Options options = Options.builder().toFile(false).attributes(attributes).build();
 
         String renderContent = asciidoctor.convertFile(
                 sourceDocument,
@@ -454,8 +477,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void attribute_missing_should_drop_line_should_drop_line_with_reference_to_missing_attribute_if_attribute_missing_attribute_is_drop_line() {
 
-        Attributes attributes = attributes().attributeMissing("drop-line").get();
-        Options options = options().attributes(attributes).get();
+        Attributes attributes = Attributes.builder().attributeMissing("drop-line").build();
+        Options options = Options.builder().attributes(attributes).build();
 
         String renderContent = asciidoctor.convert("This is\n"
                 + "blah blah {foobarbaz}\n" + "all there is.", options);
@@ -467,8 +490,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void attribute_undefined_should_not_drop_line_with_attribute_unassignment_if_attribute_undefined_is_drop() {
 
-        Attributes attributes = attributes().attributeUndefined("drop").get();
-        Options options = options().attributes(attributes).get();
+        Attributes attributes = Attributes.builder().attributeUndefined("drop").build();
+        Options options = Options.builder().attributes(attributes).build();
 
         String renderContent = asciidoctor.convert(":foo:\n\n{set:foo!}\n{foo}yes", options);
 
@@ -480,31 +503,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void table_of_content_should_be_placeable() throws IOException {
 
-        Attributes attributes = attributes().tableOfContents(Placement.RIGHT).get();
-        Options options = options().inPlace(false)
+        Attributes attributes = Attributes.builder().tableOfContents(Placement.RIGHT).build();
+        Options options = Options.builder()
+                .inPlace(false)
                 .toFile(new File(tempFolder, "toc2sample.html"))
-                .safe(SafeMode.UNSAFE).attributes(attributes).get();
-
-        asciidoctor.convertFile(toc2Sample, options);
-
-        File renderedFile = new File(tempFolder, "toc2sample.html");
-        Document doc = Jsoup.parse(renderedFile, "UTF-8");
-        Elements body = doc.select("body");
-        String classAttribute = body.attr("class");
-        String[] classAttributes = classAttribute.split(" ");
-        assertThat(classAttributes, hasItemInArray("toc2"));
-        assertThat(classAttributes, hasItemInArray("toc-right"));
-
-        renderedFile.delete();
-    }
-
-    @Test
-    public void table_of_content_2_should_be_placeable() throws IOException {
-
-        Attributes attributes = attributes().tableOfContents2(Placement.RIGHT).get();
-        Options options = options().inPlace(false)
-                .toFile(new File(tempFolder, "toc2sample.html"))
-                .safe(SafeMode.UNSAFE).attributes(attributes).get();
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(toc2Sample, options);
 
@@ -522,9 +527,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void setting_linkcss_as_false_in_string_should_embed_css_file() throws IOException {
 
-        Attributes attributes = attributes("linkcss!").get();
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().attribute("linkcss!").build();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -543,8 +552,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void setting_toc_attribute_and_numbered_in_string_form_table_of_contents_should_be_generated() throws IOException {
 
-        Attributes attributes = attributes("toc sectnums").get();
-        Options options = options().inPlace(false).toDir(tempFolder).safe(SafeMode.UNSAFE).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().arguments("toc sectnums").build();
+        Options options = Options.builder()
+                .inPlace(false)
+                .toDir(tempFolder)
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(tocSample, options);
 
@@ -559,8 +573,17 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void setting_toc_attribute_and_numbered_in_array_form_table_of_contents_should_be_generated() throws IOException {
 
-        Attributes attributes = attributes(new String[]{"toc", "sectnums"}).get();
-        Options options = options().inPlace(false).toDir(tempFolder).safe(SafeMode.UNSAFE).attributes(attributes).get();
+        Attributes attributes = Attributes.builder()
+                .attribute("toc")
+                .attribute("sectnums")
+                .build();
+
+        Options options = Options.builder()
+                .inPlace(false)
+                .toDir(tempFolder)
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(tocSample, options);
 
@@ -575,8 +598,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void unsetting_toc_attribute_table_of_contents_should_not_be_generated() {
 
-        Attributes attributes = attributes().tableOfContents(false).get();
-        Options options = options().toFile(false).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().tableOfContents(false).build();
+        Options options = Options.builder().toFile(false).attributes(attributes).build();
 
         String renderContent = asciidoctor.convertFile(tocSample, options);
 
@@ -590,10 +613,14 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void styleSheetName_is_set_custom_stylesheet_should_be_used_()
             throws IOException {
 
-        Attributes attributes = attributes().linkCss(true)
-                .styleSheetName("mycustom.css").get();
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().linkCss(true)
+                .styleSheetName("mycustom.css").build();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -608,9 +635,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void unsetting_styleSheetName_should_leave_document_without_style()
             throws IOException {
 
-        Attributes attributes = attributes().unsetStyleSheet().get();
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().unsetStyleSheet().build();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -624,12 +655,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void styles_dir_is_set_css_routes_should_use_it() throws IOException {
 
-        Attributes attributes = attributes().stylesDir("./styles")
-                .linkCss(true).styleSheetName("mycustom.css").get();
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
+        Attributes attributes = Attributes.builder().stylesDir("./styles")
+                .linkCss(true).styleSheetName("mycustom.css").build();
+        Options options = Options.builder().inPlace(false).safe(SafeMode.UNSAFE)
                 .toDir(tempFolder)
                 .mkDirs(true)
-                .attributes(attributes).get();
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -643,9 +675,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void unsetting_linkcss_should_embed_css_file() throws IOException {
 
-        Attributes attributes = attributes().linkCss(false).get();
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().linkCss(false).build();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -664,9 +700,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void linkcss_should_not_embed_css_file() throws IOException {
 
-        Attributes attributes = attributes().linkCss(true).get();
-        Options options = options().inPlace(false).safe(SafeMode.UNSAFE)
-                .toDir(tempFolder).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().linkCss(true).build();
+        Options options = Options.builder()
+                .inPlace(false)
+                .safe(SafeMode.UNSAFE)
+                .toDir(tempFolder)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -679,9 +719,12 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
     @Test
     public void copycss_with_in_place_should_copy_css_to_rendered_directory() {
-        Attributes attributes = attributes().linkCss(true).copyCss(true).get();
-        Options options = options().inPlace(true).safe(SafeMode.UNSAFE)
-                .attributes(attributes).get();
+        Attributes attributes = Attributes.builder().linkCss(true).copyCss(true).build();
+        Options options = Options.builder()
+                .inPlace(true)
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -693,9 +736,12 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
     @Test
     public void copycss_negated_with_in_place_should_not_copy_css_to_rendered_directory() {
-        Attributes attributes = attributes().copyCss(false).get();
-        Options options = options().inPlace(true).safe(SafeMode.UNSAFE)
-                .attributes(attributes).get();
+        Attributes attributes = Attributes.builder().copyCss(false).build();
+        Options options = Options.builder()
+                .inPlace(true)
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -711,9 +757,12 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void copycss_and_linkcss_negated_should_not_copy_css_to_rendered_file() {
 
-        Attributes attributes = attributes().copyCss(true).linkCss(false).get();
-        Options options = options().inPlace(true).safe(SafeMode.UNSAFE)
-                .attributes(attributes).get();
+        Attributes attributes = Attributes.builder().copyCss(true).linkCss(false).build();
+        Options options = Options.builder()
+                .inPlace(true)
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -729,10 +778,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void copycss_with_to_file_should_copy_css_to_to_file_directory() {
 
-        Attributes attributes = attributes().linkCss(true).copyCss(true).get();
-        Options options = options().inPlace(false)
+        Attributes attributes = Attributes.builder().linkCss(true).copyCss(true).build();
+        Options options = Options.builder()
+                .inPlace(false)
                 .toFile(new File(tempFolder, "output.html"))
-                .safe(SafeMode.UNSAFE).attributes(attributes).get();
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -744,9 +796,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void copycss_with_to_dir_should_copy_css_to_to_dir_directory() {
 
-        Attributes attributes = attributes().linkCss(true).copyCss(true).get();
-        Options options = options().inPlace(false).toDir(tempFolder)
-                .safe(SafeMode.UNSAFE).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().linkCss(true).copyCss(true).build();
+        Options options = Options.builder()
+                .inPlace(false)
+                .toDir(tempFolder)
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -758,10 +814,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void copycss_with_render_to_file_should_copy_css_to_to_file_directory() {
 
-        Attributes attributes = attributes().linkCss(true).copyCss(true).get();
-        Options options = options().inPlace(false)
+        Attributes attributes = Attributes.builder().linkCss(true).copyCss(true).build();
+        Options options = Options.builder()
+                .inPlace(false)
                 .toFile(new File(tempFolder, "output.html"))
-                .safe(SafeMode.UNSAFE).attributes(attributes).get();
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convert("This is Asciidoctor", options);
 
@@ -773,9 +832,13 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void copycss_with_render_to_dir_should_copy_css_to_to_dir_directory() {
 
-        Attributes attributes = attributes().linkCss(true).copyCss(true).get();
-        Options options = options().inPlace(false).toDir(tempFolder)
-                .safe(SafeMode.UNSAFE).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().linkCss(true).copyCss(true).build();
+        Options options = Options.builder()
+                .inPlace(false)
+                .toDir(tempFolder)
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes)
+                .build();
 
         asciidoctor.convert("This is Asciidoctor", options);
 
@@ -788,9 +851,10 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void string_content_with_icons_enabled_should_be_rendered()
             throws IOException, SAXException, ParserConfigurationException {
 
-        Map<String, Object> attributes = attributes().icons(
-                Attributes.IMAGE_ICONS).asMap();
-        Map<String, Object> options = options().attributes(attributes).asMap();
+        Attributes attributes = Attributes.builder()
+                .icons(Attributes.IMAGE_ICONS)
+                .build();
+        Map<String, Object> options = Options.builder().attributes(attributes).build().map();
 
         String result = asciidoctor.convert(Files.readString(documentWithNote.toPath()), options);
         result = result.replaceAll("<img(.*?)>", "<img$1/>");
@@ -804,9 +868,10 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
         InputStream content = new FileInputStream(documentWithNote);
 
-        Map<String, Object> attributes = attributes().icons(
-                Attributes.FONT_ICONS).asMap();
-        Map<String, Object> options = options().attributes(attributes).asMap();
+        Attributes attributes = Attributes.builder()
+                .icons(Attributes.FONT_ICONS)
+                .build();
+        Map<String, Object> options = Options.builder().attributes(attributes).build().map();
 
         String result = asciidoctor.convert(toString(content), options);
         assertRenderedFontAwesomeAdmonitionIcon(result);
@@ -819,9 +884,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
 
         InputStream content = new FileInputStream(documentWithNote);
 
-        Map<String, Object> attributes = attributes()
-                .icons(Attributes.IMAGE_ICONS).iconsDir("icons").asMap();
-        Map<String, Object> options = options().attributes(attributes).asMap();
+        Attributes attributes = Attributes.builder()
+                .icons(Attributes.IMAGE_ICONS)
+                .iconsDir("icons")
+                .build();
+        Map<String, Object> options = Options.builder().attributes(attributes).build().map();
 
         String renderContent = asciidoctor.convert(toString(content), options);
 
@@ -835,11 +902,11 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void linkattrs_should_make_asciidoctor_render_link_macro_attributes() {
 
-        Attributes attributes = attributes().linkAttrs(true).get();
-        Options options = options().attributes(attributes).get();
+        Attributes attributes = Attributes.builder().linkAttrs(true).build();
+        Options options = Options.builder().attributes(attributes).build();
 
         String content = asciidoctor.convert(
-                "http://google.com[Google, window=\"_blank\"]", options);
+                "https://google.com[Google, window=\"_blank\"]", options);
 
         Document doc = Jsoup.parse(content);
         Elements image = doc.select("a[target]");
@@ -852,8 +919,8 @@ public class WhenAttributesAreUsedInAsciidoctor {
     @Test
     public void experimental_flag_should_enable_experimental_features_like_keyboard_shortcuts() {
 
-        Attributes attributes = attributes().experimental(true).get();
-        Options options = options().attributes(attributes).get();
+        Attributes attributes = Attributes.builder().experimental(true).build();
+        Options options = Options.builder().attributes(attributes).build();
 
         String content = asciidoctor.convert("kbd:[F11]", options);
 
@@ -867,9 +934,9 @@ public class WhenAttributesAreUsedInAsciidoctor {
     public void iconfont_attributes_should_be_used_for_using_custom_font_css_icons()
             throws URISyntaxException, IOException {
 
-        Attributes attributes = attributes().icons(Attributes.FONT_ICONS)
-                .iconFontRemote(true).iconFontCdn(new URI("http://mycdn/css/font-awesome.min.css")).get();
-        Options options = options().inPlace(true).attributes(attributes).get();
+        Attributes attributes = Attributes.builder().icons(Attributes.FONT_ICONS)
+                .iconFontRemote(true).iconFontCdn(new URI("http://mycdn/css/font-awesome.min.css")).build();
+        Options options = Options.builder().inPlace(true).attributes(attributes).build();
 
         asciidoctor.convertFile(documentWithNote, options);
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenCustomTemplatesAreUsed.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenCustomTemplatesAreUsed.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.asciidoctor.test.AsciidoctorInstance.InstanceScope.PER_METHOD;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,7 +30,7 @@ public class WhenCustomTemplatesAreUsed {
     @Test
     public void document_should_be_rendered_using_given_template_dir() {
 
-        Options options = options().templateDir(html5TweaksDir).toFile(false).get();
+        Options options = Options.builder().templateDirs(html5TweaksDir).toFile(false).build();
         String renderContent = asciidoctor.convertFile(renderSample, options);
 
         Document doc = Jsoup.parse(renderContent, "UTF-8");

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenSourceHighlightingIsUsed.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenSourceHighlightingIsUsed.java
@@ -30,12 +30,13 @@ public class WhenSourceHighlightingIsUsed {
     @Test
     public void should_render_with_rouge() {
         String html = asciidoctor.convert(DOCUMENT,
-                OptionsBuilder.options()
+                Options.builder()
                         .standalone(true)
                         .safe(SafeMode.UNSAFE)
                         .attributes(
-                                AttributesBuilder.attributes()
-                                        .sourceHighlighter("rouge")));
+                                Attributes.builder()
+                                        .sourceHighlighter("rouge")
+                                        .build()));
 
         Document doc = Jsoup.parse(html);
 
@@ -46,12 +47,13 @@ public class WhenSourceHighlightingIsUsed {
     @Test
     public void should_render_with_coderay() {
         String html = asciidoctor.convert(DOCUMENT,
-                OptionsBuilder.options()
+                Options.builder()
                         .standalone(true)
                         .safe(SafeMode.UNSAFE)
                         .attributes(
-                                AttributesBuilder.attributes()
-                                        .sourceHighlighter("coderay")));
+                                Attributes.builder()
+                                        .sourceHighlighter("coderay")
+                                        .build()));
 
 
         Document doc = Jsoup.parse(html);

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/WhenConverterIsRegistered.java
@@ -2,7 +2,7 @@ package org.asciidoctor.converter;
 
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.MemoryLogHandler;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.Section;
@@ -56,7 +56,7 @@ public class WhenConverterIsRegistered {
     public void shouldRegisterAndExecuteGivenConverter() {
         asciidoctor.javaConverterRegistry().register(TextConverter.class, "test");
 
-        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options().backend("test"));
+        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", Options.builder().backend("test"));
 
         assertThat(result, is("== Hello ==\n\nWorld!\n\n-> a\n-> b\n"));
     }
@@ -67,7 +67,7 @@ public class WhenConverterIsRegistered {
         asciidoctor.javaConverterRegistry().register(TextConverter.class);
         asciidoctor.javaConverterRegistry().register(DummyConverter.class);
 
-        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options().backend(TextConverter.DEFAULT_FORMAT));
+        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", Options.builder().backend(TextConverter.DEFAULT_FORMAT));
 
         assertThat(result, is("== Hello ==\n\nWorld!\n\n-> a\n-> b\n"));
     }
@@ -77,7 +77,7 @@ public class WhenConverterIsRegistered {
         // Register as default converter
         asciidoctor.javaConverterRegistry().register(DummyConverter.class);
 
-        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options().backend("Undefined"));
+        String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", Options.builder().backend("Undefined"));
 
         assertThat(result, is("Dummy"));
     }
@@ -95,7 +95,7 @@ public class WhenConverterIsRegistered {
         try {
             asciidoctor.javaConverterRegistry().register(TextConverter.class);
 
-            String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options().backend(TextConverter.DEFAULT_FORMAT));
+            String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", Options.builder().backend(TextConverter.DEFAULT_FORMAT));
 
             assertThat(handler.getLogRecords(), hasSize(1));
             assertThat(handler.getLogRecords().get(0).getMessage(), is("Now we're logging"));
@@ -142,7 +142,7 @@ public class WhenConverterIsRegistered {
                 "\n" +
                 "== Test" +
                 "\n" +
-                "== Test2\n", OptionsBuilder.options().backend("test3").standalone(false));
+                "== Test2\n", Options.builder().backend("test3").standalone(false));
 
         assertEquals("== 1 Test ==\n" +
                 "== 42 Test2 ==", result);
@@ -157,7 +157,7 @@ public class WhenConverterIsRegistered {
         try {
             Thread.currentThread().setContextClassLoader(new URLClassLoader(new URL[]{serviceLoader.toURI().toURL()}));
             asciidoctor = JRubyAsciidoctor.create();
-            String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", OptionsBuilder.options().backend("extensiontext"));
+            String result = asciidoctor.convert("== Hello\n\nWorld!\n\n- a\n- b", Options.builder().backend("extensiontext"));
 
             assertThat(result, is("== Hello ==\n\nWorld!\n\n-> a\n-> b\n"));
         } finally {
@@ -167,12 +167,12 @@ public class WhenConverterIsRegistered {
 
 
     @Test
-    public void shouldWriteFileWithSuffixFromConverterWithAnnotation(@TempDir File tempDir) throws Exception {
+    public void shouldWriteFileWithSuffixFromConverterWithAnnotation(@TempDir File tempDir) {
 
         asciidoctor.javaConverterRegistry().register(TextConverter.class);
 
         File todir = tempDir;
-        asciidoctor.convertFile(simpleDocument, OptionsBuilder.options().backend(TextConverter.DEFAULT_FORMAT).toDir(todir).safe(SafeMode.UNSAFE));
+        asciidoctor.convertFile(simpleDocument, Options.builder().backend(TextConverter.DEFAULT_FORMAT).toDir(todir).safe(SafeMode.UNSAFE));
 
         assertThat(new File(todir, "simple.html").exists(), is(false));
         assertThat(new File(todir, "simple.txt").exists(), is(true));
@@ -184,7 +184,7 @@ public class WhenConverterIsRegistered {
         asciidoctor.javaConverterRegistry().register(TextConverterWithSuffix.class);
 
         File todir = tempDir;
-        asciidoctor.convertFile(simpleDocument, OptionsBuilder.options().backend(TextConverterWithSuffix.DEFAULT_FORMAT).toDir(todir).safe(SafeMode.UNSAFE));
+        asciidoctor.convertFile(simpleDocument, Options.builder().backend(TextConverterWithSuffix.DEFAULT_FORMAT).toDir(todir).safe(SafeMode.UNSAFE));
 
         assertThat(new File(todir, "simple.html").exists(), is(false));
         assertThat(new File(todir, "simple.text").exists(), is(true));

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockMacroRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockMacroRegistrationTest.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.jruby.internal.AsciidoctorCoreException;
 import org.asciidoctor.test.AsciidoctorInstance;
@@ -83,23 +83,23 @@ public class BlockMacroRegistrationTest {
     @Test
     public void testRegisterNamedClassAsClass() {
         asciidoctor.javaExtensionRegistry().blockMacro(AnnotatedTestProcessor.class);
-        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Hello World"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Hello World"), Options.builder());
         check("HELLO WORLD", result);
     }
 
     @Test
     public void testRegisterClassWithMetaNameAnnotation() {
         asciidoctor.javaExtensionRegistry().blockMacro(AnnotatedTestProcessorWithMetaNameAnnotation.class);
-        final String result = asciidoctor.convert(document(MetaNameAnnotation.NAME, "Hello World"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(MetaNameAnnotation.NAME, "Hello World"), Options.builder());
         check("HELLO WORLD", result);
     }
 
     @Test
     public void testRegisterClassWithMultipleNameAnnotations() {
         asciidoctor.javaExtensionRegistry().blockMacro(AnnotatedTestProcessorWithMultipleNameAnnotations.class);
-        String result = asciidoctor.convert(document(MetaNameAnnotation.NAME, "Hello World"), OptionsBuilder.options());
+        String result = asciidoctor.convert(document(MetaNameAnnotation.NAME, "Hello World"), Options.builder());
         check("HELLO WORLD", result);
-        result = asciidoctor.convert(document(AnnotatedTestProcessorWithMultipleNameAnnotations.NAME, "Hello World"), OptionsBuilder.options());
+        result = asciidoctor.convert(document(AnnotatedTestProcessorWithMultipleNameAnnotations.NAME, "Hello World"), Options.builder());
         check("HELLO WORLD", result);
     }
 
@@ -107,14 +107,14 @@ public class BlockMacroRegistrationTest {
     public void testRegisterNamedClassAsClassWithExplicitName() {
         final String explicitblockname = "explicitblockname";
         asciidoctor.javaExtensionRegistry().blockMacro(explicitblockname, AnnotatedTestProcessor.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), Options.builder());
         check("HELLO EXPLICIT", result);
     }
 
     @Test
     public void testRegisterNamedClassAsInstance() {
         asciidoctor.javaExtensionRegistry().blockMacro(new AnnotatedTestProcessor());
-        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Another Test"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Another Test"), Options.builder());
         check("ANOTHER TEST", result);
     }
 
@@ -122,7 +122,7 @@ public class BlockMacroRegistrationTest {
     public void testRegisterNamedClassAsInstanceWithExplicitName() {
         final String blockName = "somename";
         asciidoctor.javaExtensionRegistry().blockMacro(blockName, new AnnotatedTestProcessor());
-        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), Options.builder());
         check("YET ANOTHER TEST", result);
     }
 
@@ -135,7 +135,7 @@ public class BlockMacroRegistrationTest {
     public void testRegisterClassAsClassWithExplicitName() {
         final String explicitblockname = "anotherexplicitname";
         asciidoctor.javaExtensionRegistry().blockMacro(explicitblockname, AbstractTestProcessor.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Class"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Class"), Options.builder());
         check("HELLO EXPLICIT CLASS", result);
     }
 
@@ -143,7 +143,7 @@ public class BlockMacroRegistrationTest {
     public void testRegisterClassAsInstance() {
         assertThrows(AsciidoctorCoreException.class, () -> {
             asciidoctor.javaExtensionRegistry().blockMacro(new AbstractTestProcessor());
-            asciidoctor.convert(document("foo", "Hello Explicit Instance"), OptionsBuilder.options());
+            asciidoctor.convert(document("foo", "Hello Explicit Instance"), Options.builder());
         });
     }
 
@@ -151,7 +151,7 @@ public class BlockMacroRegistrationTest {
     public void testRegisterClassAsInstanceWithExplicitName() {
         final String explicitblockname = "aname";
         asciidoctor.javaExtensionRegistry().blockMacro(explicitblockname, new AbstractTestProcessor());
-        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Instance"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Instance"), Options.builder());
         check("HELLO EXPLICIT INSTANCE", result);
     }
 
@@ -165,14 +165,14 @@ public class BlockMacroRegistrationTest {
     public void testRegisterClassWithNameAsClassWithExplicitName() {
         final String explicitblockname = "explicitblockname";
         asciidoctor.javaExtensionRegistry().blockMacro(explicitblockname, TestProcessorWithName.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), Options.builder());
         check("HELLO EXPLICIT", result);
     }
 
     @Test
     public void testRegisterClassWithNameAsInstance() {
         asciidoctor.javaExtensionRegistry().blockMacro(new TestProcessorWithName());
-        final String result = asciidoctor.convert(document(TestProcessorWithName.NAME, "Another Test"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(TestProcessorWithName.NAME, "Another Test"), Options.builder());
         check("ANOTHER TEST", result);
     }
 
@@ -180,7 +180,7 @@ public class BlockMacroRegistrationTest {
     public void testRegisterClassWithNameAsInstanceWithExplicitName() {
         final String blockName = "somename";
         asciidoctor.javaExtensionRegistry().blockMacro(blockName, new TestProcessorWithName());
-        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), Options.builder());
         check("YET ANOTHER TEST", result);
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockProcessorRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/BlockProcessorRegistrationTest.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.jruby.internal.AsciidoctorCoreException;
 import org.asciidoctor.test.AsciidoctorInstance;
@@ -75,7 +75,7 @@ public class BlockProcessorRegistrationTest {
     @Test
     public void testRegisterNamedClassAsClass() {
         asciidoctor.javaExtensionRegistry().block(AnnotatedTestProcessor.class);
-        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Hello World"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Hello World"), Options.builder());
         check("H e l l o W o r l d", result);
     }
 
@@ -83,14 +83,14 @@ public class BlockProcessorRegistrationTest {
     public void testRegisterNamedClassAsClassWithExplicitName() {
         final String explicitblockname = "explicitblockname";
         asciidoctor.javaExtensionRegistry().block(explicitblockname, AnnotatedTestProcessor.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), Options.builder());
         check("H e l l o E x p l i c i t", result);
     }
 
     @Test
     public void testRegisterNamedClassAsInstance() {
         asciidoctor.javaExtensionRegistry().block(new AnnotatedTestProcessor());
-        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Another Test"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "Another Test"), Options.builder());
         check("A n o t h e r T e s t", result);
     }
 
@@ -98,7 +98,7 @@ public class BlockProcessorRegistrationTest {
     public void testRegisterNamedClassAsInstanceWithExplicitName() {
         final String blockName = "somename";
         asciidoctor.javaExtensionRegistry().block(blockName, new AnnotatedTestProcessor());
-        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), Options.builder());
         check("Y e t A n o t h e r T e s t", result);
     }
 
@@ -117,7 +117,7 @@ public class BlockProcessorRegistrationTest {
     public void testRegisterClassAsClassWithExplicitName() {
         final String explicitblockname = "anotherexplicitname";
         asciidoctor.javaExtensionRegistry().block(explicitblockname, AbstractTestProcessor.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Class"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Class"), Options.builder());
         check("H e l l o E x p l i c i t C l a s s", result);
     }
 
@@ -125,7 +125,7 @@ public class BlockProcessorRegistrationTest {
     public void testRegisterClassAsInstance() {
         assertThrows(AsciidoctorCoreException.class, () -> {
             asciidoctor.javaExtensionRegistry().block(new AbstractTestProcessor());
-            asciidoctor.convert(document("foo", "Hello Explicit Instance"), OptionsBuilder.options());
+            asciidoctor.convert(document("foo", "Hello Explicit Instance"), Options.builder());
         });
     }
 
@@ -133,7 +133,7 @@ public class BlockProcessorRegistrationTest {
     public void testRegisterClassAsInstanceWithExplicitName() {
         final String explicitblockname = "aname";
         asciidoctor.javaExtensionRegistry().block(explicitblockname, new AbstractTestProcessor());
-        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Instance"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit Instance"), Options.builder());
         check("H e l l o E x p l i c i t I n s t a n c e", result);
     }
 
@@ -147,14 +147,14 @@ public class BlockProcessorRegistrationTest {
     public void testRegisterClassWithNameAsClassWithExplicitName() {
         final String explicitblockname = "explicitblockname";
         asciidoctor.javaExtensionRegistry().block(explicitblockname, TestProcessorWithName.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Hello Explicit"), Options.builder());
         check("H e l l o E x p l i c i t", result);
     }
 
     @Test
     public void testRegisterClassWithNameAsInstance() {
         asciidoctor.javaExtensionRegistry().block(new TestProcessorWithName());
-        final String result = asciidoctor.convert(document(TestProcessorWithName.NAME, "Another Test"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(TestProcessorWithName.NAME, "Another Test"), Options.builder());
         check("A n o t h e r T e s t", result);
     }
 
@@ -162,7 +162,7 @@ public class BlockProcessorRegistrationTest {
     public void testRegisterClassWithNameAsInstanceWithExplicitName() {
         final String blockName = "somename";
         asciidoctor.javaExtensionRegistry().block(blockName, new TestProcessorWithName());
-        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(blockName, "Yet Another Test"), Options.builder());
         check("Y e t A n o t h e r T e s t", result);
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/InlineMacroRegistrationTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/InlineMacroRegistrationTest.java
@@ -1,7 +1,7 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.jruby.internal.AsciidoctorCoreException;
@@ -70,7 +70,7 @@ public class InlineMacroRegistrationTest {
     @Test
     public void testRegisterNamedClassAsClass() {
         asciidoctor.javaExtensionRegistry().inlineMacro(AnnotatedTestProcessor.class);
-        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "World"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "World"), Options.builder());
         check("Hello WORLD", result);
     }
 
@@ -78,14 +78,14 @@ public class InlineMacroRegistrationTest {
     public void testRegisterNamedClassAsClassWithExplicitName() {
         final String explicitblockname = "explicitblockname";
         asciidoctor.javaExtensionRegistry().inlineMacro(explicitblockname, AnnotatedTestProcessor.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "Explicit"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Explicit"), Options.builder());
         check("Hello EXPLICIT", result);
     }
 
     @Test
     public void testRegisterNamedClassAsInstance() {
         asciidoctor.javaExtensionRegistry().inlineMacro(new AnnotatedTestProcessor());
-        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "AnotherTest"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(AnnotatedTestProcessor.NAME, "AnotherTest"), Options.builder());
         check("Hello ANOTHER TEST", result);
     }
 
@@ -93,7 +93,7 @@ public class InlineMacroRegistrationTest {
     public void testRegisterNamedClassAsInstanceWithExplicitName() {
         final String blockName = "somename";
         asciidoctor.javaExtensionRegistry().inlineMacro(blockName, new AnnotatedTestProcessor());
-        final String result = asciidoctor.convert(document(blockName, "YetAnotherTest"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(blockName, "YetAnotherTest"), Options.builder());
         check("Hello YET ANOTHER TEST", result);
     }
 
@@ -107,7 +107,7 @@ public class InlineMacroRegistrationTest {
     public void testRegisterClassAsClassWithExplicitName() {
         final String explicitblockname = "anotherexplicitname";
         asciidoctor.javaExtensionRegistry().inlineMacro(explicitblockname, AbstractTestProcessor.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "ExplicitClass"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "ExplicitClass"), Options.builder());
         check("Hello EXPLICIT CLASS", result);
     }
 
@@ -115,7 +115,7 @@ public class InlineMacroRegistrationTest {
     public void testRegisterClassAsInstance() {
         assertThrows(AsciidoctorCoreException.class, () -> {
             asciidoctor.javaExtensionRegistry().inlineMacro(new AbstractTestProcessor());
-            asciidoctor.convert(document("foo", "HelloExplicitInstance"), OptionsBuilder.options());
+            asciidoctor.convert(document("foo", "HelloExplicitInstance"), Options.builder());
         });
     }
 
@@ -123,7 +123,7 @@ public class InlineMacroRegistrationTest {
     public void testRegisterClassAsInstanceWithExplicitName() {
         final String explicitblockname = "someexplicitname";
         asciidoctor.javaExtensionRegistry().inlineMacro(explicitblockname, new AbstractTestProcessor());
-        final String result = asciidoctor.convert(document(explicitblockname, "ExplicitInstance"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "ExplicitInstance"), Options.builder());
         check("Hello EXPLICIT INSTANCE", result);
     }
 
@@ -137,14 +137,14 @@ public class InlineMacroRegistrationTest {
     public void testRegisterClassWithNameAsClassWithExplicitName() {
         final String explicitblockname = "explicitblockname";
         asciidoctor.javaExtensionRegistry().inlineMacro(explicitblockname, TestProcessorWithName.class);
-        final String result = asciidoctor.convert(document(explicitblockname, "Explicit"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(explicitblockname, "Explicit"), Options.builder());
         check("Hello EXPLICIT", result);
     }
 
     @Test
     public void testRegisterClassWithNameAsInstance() {
         asciidoctor.javaExtensionRegistry().inlineMacro(new TestProcessorWithName());
-        final String result = asciidoctor.convert(document(TestProcessorWithName.NAME, "AnotherTest"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(TestProcessorWithName.NAME, "AnotherTest"), Options.builder());
         check("Hello ANOTHER TEST", result);
     }
 
@@ -152,7 +152,7 @@ public class InlineMacroRegistrationTest {
     public void testRegisterClassWithNameAsInstanceWithExplicitName() {
         final String blockName = "somename";
         asciidoctor.javaExtensionRegistry().inlineMacro(blockName, new TestProcessorWithName());
-        final String result = asciidoctor.convert(document(blockName, "YetAnotherTest"), OptionsBuilder.options());
+        final String result = asciidoctor.convert(document(blockName, "YetAnotherTest"), Options.builder());
         check("Hello YET ANOTHER TEST", result);
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -2,6 +2,7 @@ package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
+import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.ast.ContentModel;
 import org.asciidoctor.ast.Document;
@@ -33,7 +34,6 @@ import java.util.*;
 import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.asciidoctor.test.AsciidoctorInstance.InstanceScope.PER_METHOD;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -151,7 +151,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithUriInclude,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -209,7 +209,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithUriInclude,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -227,7 +227,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 simpleDocument,
-                options().standalone(true).safe(SafeMode.SERVER).toFile(false).get());
+                options().standalone(true).safe(SafeMode.SERVER).toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -247,7 +247,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 simpleDocument,
-                options().standalone(true).safe(SafeMode.SERVER).toFile(false).get());
+                options().standalone(true).safe(SafeMode.SERVER).toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -265,7 +265,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 changeAttribute,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -282,7 +282,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 changeAttribute,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -299,7 +299,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 changeAttribute,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -362,7 +362,7 @@ public class WhenJavaExtensionIsRegistered {
         Options options = Options.builder()
                 .inPlace(false)
                 .toFile(renderedFile)
-                .safe(SafeMode.UNSAFE).get();
+                .safe(SafeMode.UNSAFE).build();
 
         asciidoctor.convertFile(renderSample, options);
 
@@ -383,7 +383,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithUriInclude,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -404,7 +404,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithUriInclude,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -425,7 +425,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithUriInclude,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -463,7 +463,7 @@ public class WhenJavaExtensionIsRegistered {
         javaExtensionRegistry.includeProcessor(PositionalAttrsIncludeProcessor.class);
 
         String content = asciidoctor.convertFile(sampleWithIncludePosAttrs,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -482,7 +482,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithTerminalCommand,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -504,7 +504,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithTerminalCommand,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -527,7 +527,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithTerminalCommand,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -548,7 +548,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithTerminalCommand,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -600,7 +600,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithGistMacro,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element script = doc.getElementsByTag("script").first();
@@ -617,7 +617,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithGistMacro,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element script = doc.getElementsByTag("script").first();
@@ -634,7 +634,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithGistMacro,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element script = doc.getElementsByTag("script").first();
@@ -654,7 +654,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithGistMacro,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element script = doc.getElementsByTag("script").first();
@@ -671,7 +671,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithManLink,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element link = doc.getElementsByTag("a").first();
@@ -690,7 +690,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithManLink,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element link = doc.getElementsByTag("a").first();
@@ -713,7 +713,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithManLink,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element link = doc.getElementsByTag("a").first();
@@ -737,7 +737,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithManLink,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element link = doc.getElementsByTag("a").first();
@@ -759,7 +759,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 sampleWithManLink,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element link = doc.getElementsByTag("a").first();
@@ -803,7 +803,7 @@ public class WhenJavaExtensionIsRegistered {
         Options options = Options.builder()
                 .inPlace(false)
                 .toFile(renderedFile)
-                .safe(SafeMode.UNSAFE).get();
+                .safe(SafeMode.UNSAFE).build();
 
         asciidoctor.unregisterAllExtensions();
         asciidoctor.convertFile(renderSample, options);
@@ -822,7 +822,7 @@ public class WhenJavaExtensionIsRegistered {
         javaExtensionRegistry.block("yell", "org.asciidoctor.extension.YellStaticBlock");
         String content = asciidoctor.convertFile(
                 sampleWithYellBlock,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
@@ -839,7 +839,7 @@ public class WhenJavaExtensionIsRegistered {
         javaExtensionRegistry.block("yell", YellStaticBlock.class);
         String content = asciidoctor.convertFile(
                 sampleWithYellBlock,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
@@ -857,7 +857,7 @@ public class WhenJavaExtensionIsRegistered {
         for (int i = 0; i < 2; i++) {
             String content = asciidoctor.convertFile(
                     sampleWithYellBlock,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
 
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
             Elements elements = doc.getElementsByClass("paragraph");
@@ -878,7 +878,7 @@ public class WhenJavaExtensionIsRegistered {
         javaExtensionRegistry.block(yellBlock);
         String content = asciidoctor.convertFile(
                 sampleWithYellBlock,
-                options().toFile(false).get());
+                options().toFile(false).build());
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
         assertThat(elements.size(), is(1));
@@ -900,7 +900,7 @@ public class WhenJavaExtensionIsRegistered {
         for (int i = 0; i < 2; i++) {
             String content = asciidoctor.convertFile(
                     sampleWithYellBlock,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
             Elements elements = doc.getElementsByClass("paragraph");
             assertThat(elements.size(), is(1));
@@ -920,7 +920,7 @@ public class WhenJavaExtensionIsRegistered {
         for (int i = 0; i < 2; i++) {
             String content = asciidoctor.convertFile(
                     sampleWithUriInclude,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
 
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -942,7 +942,7 @@ public class WhenJavaExtensionIsRegistered {
         for (int i = 0; i < 2; i++) {
             String content = asciidoctor.convertFile(
                     sampleWithUriInclude,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
 
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
 
@@ -960,7 +960,7 @@ public class WhenJavaExtensionIsRegistered {
         javaExtensionRegistry.block("yell", YellStaticListingBlock.class);
         String content = asciidoctor.convertFile(
                 sampleWithYellListingBlock,
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
@@ -981,7 +981,7 @@ public class WhenJavaExtensionIsRegistered {
         javaExtensionRegistry.block(yellBlock);
         String content = asciidoctor.convertFile(
                 sampleWithYellListingBlock,
-                options().toFile(false).get());
+                options().toFile(false).build());
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
         assertThat(elements.size(), is(1));
@@ -1009,7 +1009,7 @@ public class WhenJavaExtensionIsRegistered {
 
         String content = asciidoctor.convertFile(
                 documentWithToc,
-                options().standalone(true).toFile(false).safe(SafeMode.UNSAFE).get());
+                options().standalone(true).toFile(false).safe(SafeMode.UNSAFE).build());
 
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Element toc = doc.getElementById("toc");
@@ -1090,7 +1090,7 @@ public class WhenJavaExtensionIsRegistered {
         {
             String contentWithoutBlock = asciidoctor.convertFile(
                     sampleWithYellBlock,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
             org.jsoup.nodes.Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
             Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
             assertThat(elementsWithoutBlock.size(), is(1));
@@ -1101,7 +1101,7 @@ public class WhenJavaExtensionIsRegistered {
             extensionGroup.register();
             String content = asciidoctor.convertFile(
                     sampleWithYellBlock,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
             org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
             Elements elements = doc.getElementsByClass("paragraph");
             assertThat(elements.size(), is(1));
@@ -1111,7 +1111,7 @@ public class WhenJavaExtensionIsRegistered {
             extensionGroup.unregister();
             String contentWithoutBlock = asciidoctor.convertFile(
                     sampleWithYellBlock,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
             org.jsoup.nodes.Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
             Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
             assertThat(elementsWithoutBlock.size(), is(1));
@@ -1151,7 +1151,7 @@ public class WhenJavaExtensionIsRegistered {
         javaExtensionRegistry.block("quiet", TestBlock.class);
         String content = asciidoctor.convert(
                 "[quiet]\nHello World",
-                options().toFile(false).get());
+                options().toFile(false).build());
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
         assertThat(elements.size(), is(1));
@@ -1172,13 +1172,17 @@ public class WhenJavaExtensionIsRegistered {
         javaExtensionRegistry.block(new TestBlock());
         String content = asciidoctor.convert(
                 "[quiet]\nHello Again",
-                options().toFile(false).get());
+                options().toFile(false).build());
         org.jsoup.nodes.Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
         assertThat(elements.size(), is(1));
         assertThat(elements.get(0).text(), is("hello again"));
 
         TestBlock.asciidoctor = null;
+    }
+
+    private OptionsBuilder options() {
+        return Options.builder();
     }
 
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionGroupIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionGroupIsRegistered.java
@@ -1,6 +1,8 @@
 package org.asciidoctor.extension;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.jruby.internal.JRubyAsciidoctor;
 import org.asciidoctor.test.AsciidoctorInstance;
@@ -19,7 +21,6 @@ import java.io.File;
 import java.util.Iterator;
 
 import static java.util.Collections.singletonList;
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.asciidoctor.test.AsciidoctorInstance.InstanceScope.PER_METHOD;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
@@ -52,7 +53,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                         "\n" +
                         "[rubyyell]\n" +
                         "The time is now. Get a move on.",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
@@ -75,7 +76,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                         "\n" +
                         "[yell]\n" +
                         "The time is now. Get a move on.",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
@@ -93,7 +94,7 @@ public class WhenRubyExtensionGroupIsRegistered {
         {
             String contentWithoutBlock = asciidoctor.convertFile(
                     sampleWithRubyYellBlock,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
 
             Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
             Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
@@ -104,7 +105,7 @@ public class WhenRubyExtensionGroupIsRegistered {
             extensionGroup.register();
             String content = asciidoctor.convertFile(
                     sampleWithRubyYellBlock,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
 
             Document doc = Jsoup.parse(content, "UTF-8");
             Elements elements = doc.getElementsByClass("paragraph");
@@ -116,7 +117,7 @@ public class WhenRubyExtensionGroupIsRegistered {
 
             String contentWithoutBlock = asciidoctor.convertFile(
                     sampleWithRubyYellBlock,
-                    options().toFile(false).get());
+                    options().toFile(false).build());
 
             Document docWithoutBlock = Jsoup.parse(contentWithoutBlock, "UTF-8");
             Elements elementsWithoutBlock = docWithoutBlock.getElementsByClass("paragraph");
@@ -137,7 +138,7 @@ public class WhenRubyExtensionGroupIsRegistered {
         String content = asciidoctor.convert(
                 ".My Gist\n" +
                         "mygist::123456[]",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByTag("script");
@@ -157,7 +158,7 @@ public class WhenRubyExtensionGroupIsRegistered {
         String content = asciidoctor.convert(
                 ".My Gist\n" +
                         "gist::42[]",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByTag("script");
@@ -178,7 +179,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                 "= Man Inline Macro Extension\n" +
                         "\n" +
                         "See myman:gittutorial[7] to get started.",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByTag("a");
@@ -199,7 +200,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                 "= Man Inline Macro Extension\n" +
                         "\n" +
                         "See man:dockertutorial[7] to get started.",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByTag("a");
@@ -221,7 +222,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                         " > Hello, World!\n" +
                         "\n" +
                         " $ gem install asciidoctor",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         final Document document = Jsoup.parse(content);
         final TextNode commandElement = document.getElementsByClass("command").get(0).textNodes().get(0);
@@ -242,7 +243,7 @@ public class WhenRubyExtensionGroupIsRegistered {
 
         String content = asciidoctor.convert(
                 "Read &sect;2 and it&apos;ll all be clear.",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         System.out.println(content);
         assertThat(content, containsString("Read &#167;2 and it&#39;ll all be clear."));
@@ -260,7 +261,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                         "\n" +
                         "include::response[]" +
                         "",
-                options().toFile(false).safe(SafeMode.SAFE).get());
+                options().toFile(false).safe(SafeMode.SAFE).build());
 
         final Document document = Jsoup.parse(content);
         assertThat(
@@ -292,7 +293,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                         "{front-matter}\n" +
                         "---\n" +
                         "....",
-                options().toFile(false).get());
+                options().toFile(false).build());
 
         final Document document = Jsoup.parse(content);
         final Element contentElement = document.getElementsByClass("content").get(0);
@@ -327,7 +328,7 @@ public class WhenRubyExtensionGroupIsRegistered {
                         "* hidden till clicked            \n" +
                         "* hidden till clicked 2          \n" +
                         "====                             ",
-                options().toFile(false).safe(SafeMode.SAFE).standalone(true).get());
+                options().toFile(false).safe(SafeMode.SAFE).standalone(true).build());
 
         final Document document = Jsoup.parse(content);
         final Iterator<Element> elems = document.getElementsByTag("style").iterator();
@@ -341,4 +342,7 @@ public class WhenRubyExtensionGroupIsRegistered {
         assertTrue("Could not find style element that should have been added by docinfo processor:\n" + document, found);
     }
 
+    private OptionsBuilder options() {
+        return Options.builder();
+    }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenRubyExtensionIsRegistered.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.extension;
 
+import org.asciidoctor.Options;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.jruby.AsciidoctorJRuby;
 import org.asciidoctor.test.AsciidoctorInstance;
@@ -18,7 +19,6 @@ import java.io.File;
 import java.util.Iterator;
 
 import static java.util.Collections.singletonList;
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.asciidoctor.test.AsciidoctorInstance.InstanceScope.PER_METHOD;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -49,7 +49,7 @@ public class WhenRubyExtensionIsRegistered {
                         "\n" +
                         "[rubyyell]\n" +
                         "The time is now. Get a move on.",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
@@ -72,7 +72,7 @@ public class WhenRubyExtensionIsRegistered {
                         "\n" +
                         "[yell]\n" +
                         "The time is now. Get a move on.",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByClass("paragraph");
@@ -91,7 +91,7 @@ public class WhenRubyExtensionIsRegistered {
         String content = asciidoctor.convert(
                 ".My Gist\n" +
                         "mygist::123456[]",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByTag("script");
@@ -110,7 +110,7 @@ public class WhenRubyExtensionIsRegistered {
         String content = asciidoctor.convert(
                 ".My Gist\n" +
                         "gist::42[]",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByTag("script");
@@ -130,7 +130,7 @@ public class WhenRubyExtensionIsRegistered {
                 "= Man Inline Macro Extension\n" +
                         "\n" +
                         "See myman:gittutorial[7] to get started.",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByTag("a");
@@ -150,7 +150,7 @@ public class WhenRubyExtensionIsRegistered {
                 "= Man Inline Macro Extension\n" +
                         "\n" +
                         "See man:dockertutorial[7] to get started.",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         Document doc = Jsoup.parse(content, "UTF-8");
         Elements elements = doc.getElementsByTag("a");
@@ -173,7 +173,7 @@ public class WhenRubyExtensionIsRegistered {
                         " > Hello, World!\n" +
                         "\n" +
                         " $ gem install asciidoctor",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         final Document document = Jsoup.parse(content);
         final TextNode commandElement = document.getElementsByClass("command").get(0).textNodes().get(0);
@@ -193,7 +193,7 @@ public class WhenRubyExtensionIsRegistered {
                         "\n" +
                         "include::response[]" +
                         "",
-                options().toFile(false).safe(SafeMode.SAFE).get());
+                Options.builder().toFile(false).safe(SafeMode.SAFE).build());
 
         final Document document = Jsoup.parse(content);
         assertThat(
@@ -212,7 +212,7 @@ public class WhenRubyExtensionIsRegistered {
 
         String content = asciidoctor.convert(
                 "Read &sect;2 and it&apos;ll all be clear.",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         assertThat(content, containsString("Read &#167;2 and it&#39;ll all be clear."));
     }
@@ -241,7 +241,7 @@ public class WhenRubyExtensionIsRegistered {
                         "{front-matter}\n" +
                         "---\n" +
                         "....",
-                options().toFile(false).get());
+                Options.builder().toFile(false).build());
 
         final Document document = Jsoup.parse(content);
         final Element contentElement = document.getElementsByClass("content").get(0);
@@ -275,7 +275,7 @@ public class WhenRubyExtensionIsRegistered {
                         "* hidden till clicked            \n" +
                         "* hidden till clicked 2          \n" +
                         "====                             ",
-                options().toFile(false).safe(SafeMode.SAFE).standalone(true).get());
+                Options.builder().toFile(false).safe(SafeMode.SAFE).standalone(true).build());
 
         final Document document = Jsoup.parse(content);
         final Iterator<Element> elems = document.getElementsByTag("style").iterator();

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/internal/WhenDocumentIsRenderedWithPreloading.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/internal/WhenDocumentIsRenderedWithPreloading.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.jruby.internal;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.AttributesBuilder;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
 import org.asciidoctor.test.AsciidoctorInstance;
 import org.asciidoctor.test.extension.AsciidoctorExtension;
 import org.jruby.RubyBoolean;
@@ -25,8 +25,10 @@ public class WhenDocumentIsRenderedWithPreloading {
     @Test
     public void coderay_gem_should_be_preloaded() {
 
-        Map<String, Object> options = OptionsBuilder.options()
-                .attributes(AttributesBuilder.attributes().sourceHighlighter("coderay").get()).asMap();
+        Map<String, Object> options = Options.builder()
+                .attributes(Attributes.builder().sourceHighlighter("coderay").build())
+                .build()
+                .map();
 
         ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
         RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'coderay'");
@@ -36,8 +38,10 @@ public class WhenDocumentIsRenderedWithPreloading {
     @Test
     public void not_coderay_gem_should_not_be_preloaded() {
 
-        Map<String, Object> options = OptionsBuilder.options()
-                .attributes(AttributesBuilder.attributes().sourceHighlighter("pygments").get()).asMap();
+        Map<String, Object> options = Options.builder()
+                .attributes(Attributes.builder().sourceHighlighter("pygments").build())
+                .build()
+                .map();
 
         ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
         RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'coderay'");
@@ -47,7 +51,10 @@ public class WhenDocumentIsRenderedWithPreloading {
     @Test
     public void erubis_gem_should_be_preloaded() {
 
-        Map<String, Object> options = OptionsBuilder.options().eruby("erubis").asMap();
+        Map<String, Object> options = Options.builder()
+                .eruby("erubis")
+                .build()
+                .map();
 
         ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
         RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'erubis'");
@@ -57,7 +64,10 @@ public class WhenDocumentIsRenderedWithPreloading {
     @Test
     public void not_erubis_gem_should_be_preloaded() {
 
-        Map<String, Object> options = OptionsBuilder.options().eruby("erb").asMap();
+        Map<String, Object> options = Options.builder()
+                .eruby("erb")
+                .build()
+                .map();
 
         ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
         RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'erubis'");
@@ -67,7 +77,10 @@ public class WhenDocumentIsRenderedWithPreloading {
     @Test
     public void template_dir_should_preload_tilt() {
 
-        Map<String, Object> options = OptionsBuilder.options().templateDir(new File(".")).asMap();
+        Map<String, Object> options = Options.builder()
+                .templateDirs(new File("."))
+                .build()
+                .map();
 
         ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
         RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'tilt'");
@@ -77,8 +90,10 @@ public class WhenDocumentIsRenderedWithPreloading {
     @Test
     public void data_uri_gem_should_be_preloaded() {
 
-        Map<String, Object> options = OptionsBuilder.options()
-                .attributes(AttributesBuilder.attributes().dataUri(true).get()).asMap();
+        Map<String, Object> options = Options.builder()
+                .attributes(Attributes.builder().dataUri(true).build())
+                .build()
+                .map();
 
         ((JRubyAsciidoctor) asciidoctor).rubyGemsPreloader.preloadRequiredLibraries(options);
         RubyBoolean evalScriptlet = (RubyBoolean) ((JRubyAsciidoctor) asciidoctor).rubyRuntime.evalScriptlet("require 'base64'");

--- a/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
+++ b/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenBackendIsPdf.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.asciidoctor.OptionsBuilder.options;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith({AsciidoctorExtension.class, ClasspathExtension.class})
@@ -34,14 +33,14 @@ public class WhenBackendIsPdf {
         // The asciidoctor-pdf backend returns the converter itself on convert.
         // If the result should be written to a file the write method will convert to a PDF stream
         // Therefore, if the result should not be written to a file the PDF converter should be returned.
-        IRubyObject o = asciidoctor.convert(DOCUMENT, options().backend("pdf").get(), IRubyObject.class);
+        IRubyObject o = asciidoctor.convert(DOCUMENT, options().backend("pdf").build(), IRubyObject.class);
         assertThat(o.getMetaClass().getRealClass().getName()).isEqualTo("Asciidoctor::PDF::Converter");
     }
 
     @Test
     void pdf_should_include_images(@ClasspathResource("image-sample.adoc") File inputFile) throws IOException {
 
-        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).get());
+        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).build());
 
         File outputFile = new File(inputFile.getParentFile(), "image-sample.pdf");
         assertThat(outputFile).exists();
@@ -56,7 +55,7 @@ public class WhenBackendIsPdf {
     @Test
     void pdf_source_code_should_be_highlighted(@ClasspathResource("code-sample.adoc") File inputFile) throws IOException {
 
-        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).get());
+        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.UNSAFE).build());
 
         File outputFile = new File(inputFile.getParentFile(), "code-sample.pdf");
         assertThat(outputFile).exists();
@@ -78,9 +77,13 @@ public class WhenBackendIsPdf {
 
     @Test
     void pdf_should_not_fail_with_empty_tables(@ClasspathResource("empty-table.adoc") File inputFile) {
-        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.SAFE).get());
+        asciidoctor.convertFile(inputFile, options().backend("pdf").safe(SafeMode.SAFE).build());
 
         File outputFile = new File(inputFile.getParentFile(), "empty-table.pdf");
         assertThat(outputFile).exists();
+    }
+
+    private static OptionsBuilder options() {
+        return Options.builder();
     }
 }

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/AsciidoctorInterface.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/AsciidoctorInterface.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.integrationguide;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ public class AsciidoctorInterface {
     public void autocloseAsciidoctorInstance() {
 //tag::autoclose[]
         try (Asciidoctor asciidoctor = Asciidoctor.Factory.create()) {
-            asciidoctor.convert("Hello World", OptionsBuilder.options());
+            asciidoctor.convert("Hello World", Options.builder());
         }
 //end::autoclose[]
     }

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/SimpleAsciidoctorRendering.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/SimpleAsciidoctorRendering.java
@@ -3,6 +3,7 @@ package org.asciidoctor.integrationguide;
 import java.io.File;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 
@@ -12,7 +13,7 @@ public class SimpleAsciidoctorRendering {
         Asciidoctor asciidoctor = Asciidoctor.Factory.create(); // <1>
         asciidoctor.convertFile(                                // <2>
                 new File(args[0]),
-                OptionsBuilder.options()                        // <3>
+                Options.builder()                               // <3>
                         .toFile(true)
                         .safe(SafeMode.UNSAFE));
     }

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/converter/TextConverterTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/converter/TextConverterTest.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.integrationguide.converter;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.test.AsciidoctorInstance;
 import org.asciidoctor.test.ClasspathResource;
@@ -39,9 +40,10 @@ public class TextConverterTest {
 
         String result = asciidoctor.convertFile(
                 test_adoc,
-                OptionsBuilder.options()
+                Options.builder()
                         .backend("text")                                   // <2>
-                        .toFile(false));
+                        .toFile(false)
+                        .build());
 
 //end::include[]
 
@@ -65,9 +67,10 @@ public class TextConverterTest {
 
             String result = asciidoctor.convertFile(
                     test_adoc,
-                    OptionsBuilder.options()
+                    Options.builder()
                             .backend("text")
-                            .toFile(false));
+                            .toFile(false)
+                            .build());
 
             verifyResult(result);
         } finally {

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ASTShowcase.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/ASTShowcase.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.integrationguide.extension;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.test.AsciidoctorInstance;
 import org.asciidoctor.test.ClasspathResource;
@@ -34,7 +35,7 @@ public class ASTShowcase {
 
         asciidoctor.javaExtensionRegistry().treeprocessor(ASTExtractorTreeprocessor.class);
 
-        asciidoctor.loadFile(astDemo, OptionsBuilder.options().asMap());
+        asciidoctor.loadFile(astDemo, Options.builder().build());
 
         assertThat(
                 ASTExtractorTreeprocessor.result.toString(),

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/TerminalCommandTreeprocessorTest.java
@@ -36,9 +36,10 @@ public class TerminalCommandTreeprocessorTest {
 
         String referenceResult = asciidoctor.convertFile(
                 referenceDocument,
-                OptionsBuilder.options()
+                Options.builder()
                         .standalone(false)
-                        .toFile(false));
+                        .toFile(false)
+                        .build());
 
 //tag::include[]
         File src = //...
@@ -50,9 +51,10 @@ public class TerminalCommandTreeprocessorTest {
                 .treeprocessor(TerminalCommandTreeprocessor.class); // <1>
         String result = asciidoctor.convertFile(
                 src,
-                OptionsBuilder.options()
+                Options.builder()
                         .standalone(false)
-                        .toFile(false));
+                        .toFile(false)
+                        .build());
 //end::include[]
 
         assertThat(result, is(referenceResult));
@@ -64,9 +66,10 @@ public class TerminalCommandTreeprocessorTest {
 
         String referenceResult = asciidoctor.convertFile(
                 referenceDocument,
-                OptionsBuilder.options()
+                Options.builder()
                         .standalone(false)
-                        .toFile(false));
+                        .toFile(false)
+                        .build());
 
 //tag::include-extension-registry[]
         File src = //...

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/YellBlockProcessorTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/extension/YellBlockProcessorTest.java
@@ -33,7 +33,7 @@ public class YellBlockProcessorTest {
 
         asciidoctor.javaExtensionRegistry().block(YellBlockProcessor.class); // <1>
 
-        String result = asciidoctor.convertFile(yellblock_adoc, OptionsBuilder.options().toFile(false));
+        String result = asciidoctor.convertFile(yellblock_adoc, Options.builder().toFile(false));
 
         assertThat(result, containsString("I REALLY MEAN IT"));              // <2>
 //end::include[]

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/HighlightJsHighlighterTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/HighlightJsHighlighterTest.java
@@ -42,10 +42,11 @@ public class HighlightJsHighlighterTest {
             .register(HighlightJsHighlighter.class, "myhighlightjs"); // <1>
 
         String result = asciidoctor.convertFile(sources_adoc,
-            OptionsBuilder.options()
+            Options.builder()
                 .standalone(true) // <2>
                 .toFile(false)
-                .attributes(Attributes.builder().sourceHighlighter("myhighlightjs").build())); // <3>
+                .attributes(Attributes.builder().sourceHighlighter("myhighlightjs").build()) // <3>
+                .build());
 
         assertThat(result,
             containsString("<script>hljs.initHighlighting()</script>"));
@@ -60,10 +61,12 @@ public class HighlightJsHighlighterTest {
             .register(org.asciidoctor.integrationguide.syntaxhighlighter.threeparams.HighlightJsHighlighter.class, "myhighlightjs");
 
         String result = asciidoctor.convertFile(sources_adoc,
-            OptionsBuilder.options()
+            Options.builder()
                 .standalone(true)
                 .toFile(false)
-                .attributes(AttributesBuilder.attributes().sourceHighlighter("myhighlightjs")));
+                .attributes(Attributes.builder()
+                        .sourceHighlighter("myhighlightjs")
+                        .build()));
 
         assertThat(result,
             containsString("<script>hljs.initHighlighting()</script>"));
@@ -79,10 +82,12 @@ public class HighlightJsHighlighterTest {
             .register(HighlightJsWithLanguageHighlighter.class, "myhighlightjs");
 
         String result = asciidoctor.convertFile(sources_adoc,
-            OptionsBuilder.options()
+            Options.builder()
                 .standalone(true)
                 .toFile(false)
-                .attributes(Attributes.builder().sourceHighlighter("myhighlightjs").build()));
+                .attributes(Attributes.builder()
+                        .sourceHighlighter("myhighlightjs")
+                        .build()));
 
         assertThat(result,
             containsString("<script>hljs.initHighlighting()</script>"));
@@ -105,14 +110,16 @@ public class HighlightJsHighlighterTest {
             .register(HighlightJsWithOfflineStylesHighlighter.class, "myhighlightjs");
 
         asciidoctor.convertFile(sources_adoc,
-            OptionsBuilder.options()
+            Options.builder()
                 .standalone(true)
                 .toDir(toDir)              // <1>
                 .safe(SafeMode.UNSAFE)
-                .attributes(AttributesBuilder.attributes()
+                .attributes(Attributes.builder()
                     .sourceHighlighter("myhighlightjs")
                     .copyCss(true)         // <1>
-                    .linkCss(true)));
+                    .linkCss(true)
+                    .build())
+                .build());
 
         File docFile = new File(toDir, "sources.html");
         assertTrue(docFile.exists());

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/PrismJsHighlighterTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/integrationguide/syntaxhighlighter/PrismJsHighlighterTest.java
@@ -1,9 +1,6 @@
 package org.asciidoctor.integrationguide.syntaxhighlighter;
 
-import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.AttributesBuilder;
-import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.SafeMode;
+import org.asciidoctor.*;
 import org.asciidoctor.test.AsciidoctorInstance;
 import org.asciidoctor.test.ClasspathResource;
 import org.asciidoctor.test.extension.AsciidoctorExtension;
@@ -51,14 +48,16 @@ public class PrismJsHighlighterTest {
             .register(PrismJsHighlighter.class, "prismjs"); // <1>
 
         asciidoctor.convertFile(sources_adoc,
-            OptionsBuilder.options()
+            Options.builder()
                 .standalone(true)
                 .toDir(toDir)
                 .safe(SafeMode.UNSAFE)
-                .attributes(AttributesBuilder.attributes()
+                .attributes(Attributes.builder()
                     .sourceHighlighter("prismjs")           // <1>
                     .copyCss(true)
-                    .linkCss(true)));
+                    .linkCss(true)
+                        .build())
+                    .build());
 
         File docFile = new File(toDir, "sources.html");
 

--- a/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/AsciidoctorServlet.java
+++ b/asciidoctorj-wildfly-integration-test/src/test/java/org/asciidoctor/AsciidoctorServlet.java
@@ -23,7 +23,7 @@ public class AsciidoctorServlet extends HttpServlet {
         resp.setStatus(200);
         try (InputStreamReader reader = new InputStreamReader(req.getInputStream());
              OutputStreamWriter writer = new OutputStreamWriter(resp.getOutputStream())) {
-            asciidoctor.convert(reader, writer, OptionsBuilder.options().get());
+            asciidoctor.convert(reader, writer, Options.builder());
         }
     }
 }

--- a/docs/modules/ROOT/pages/read-document-tree.adoc
+++ b/docs/modules/ROOT/pages/read-document-tree.adoc
@@ -30,7 +30,7 @@ import org.asciidoctor.ast.Section;
 
 //...
 Document document = asciidoctor.load(DOCUMENT, Options.builder().build()); // <1>
-Section section = (Section) document.blocks().get(1); // <2>
+Section section = (Section) document.getBlocks().get(1); // <2>
 
 assertThat(section.index(), is(0)); // <3>
 assertThat(section.sectname(), is("sect1"));

--- a/docs/modules/guides/nav.adoc
+++ b/docs/modules/guides/nav.adoc
@@ -1,5 +1,6 @@
 * Help & Guides
 ** Updating to New Releases
+***xref:api-migration-guide-v25x-to-v30.adoc[]
 *** xref:extension-migration-guide-16-to-20.adoc[]
 *** xref:extension-migration-guide-15-to-16.adoc[]
 ** Running in Frameworks

--- a/docs/modules/guides/pages/api-migration-guide-v25x-to-v30.adoc
+++ b/docs/modules/guides/pages/api-migration-guide-v25x-to-v30.adoc
@@ -1,0 +1,59 @@
+= AsciidoctorJ v3.0.x migration guide
+:navtitle: v3.0.x migration guide
+
+AsciidoctorJ v3.0.0 introduces breaking changes.
+This guide will provide the steps required to update a project currently using 2.5.x version.
+
+include::partial$removal-of-deprecated-methods-in-options.adoc[]
+
+include::partial$removal-of-deprecated-methods-in-attributes.adoc[]
+
+== Removal of `asMap` from OptionsBuilder and AttributesBuilder
+
+In v2.5.x it is possible to obtain the backing `Map<String,Object>` for both options and attributes.
+
+[,java]
+.Obtaining backing Map for OptionsBuilder
+----
+Map<String, Object> optionsMap = Options.builder()
+    .backend("html5")
+    .mkDirs(true)
+    .safe(SafeMode.UNSAFE)
+    .asMap();
+----
+
+[,java]
+.Obtaining backing Map for AttributesBuilder
+----
+Map<String, Object> attributesMap = Attributes.builder()
+    .icons("font")
+    .sectionNumbers(true)
+    .asMap();
+----
+
+To remove feature duplication and avoid confusion between values in the actual `org.asciidoctor.Attributes` and `org.asciidoctor.Options` and their respective builders, `asMap` it's no longer available in both builders.
+
+To obtain the backing up, use the `map()` method from the actual `org.asciidoctor.Attributes` and `org.asciidoctor.Options` instances.
+
+IMPORTANT: `Options::map()` and `Attributes::map()` are marked as deprecated and subject to change at some point, but are still maintained and safe to use in v3.0.x.
+
+[,java]
+.Obtaining backing Map for Options
+----
+Options options = Options.builder()
+    .backend("html5")
+    .mkDirs(true)
+    .safe(SafeMode.UNSAFE)
+    .build();
+Map<String, Object> optionsMap = options.map();
+----
+
+[,java]
+.Obtaining backing Map for Attributes
+----
+Attributes attributes = Attributes.builder()
+    .icons("font")
+    .sectionNumbers(true)
+    .build();
+Map<String, Object> attributesMap = attributes.map();
+----

--- a/docs/modules/guides/partials/removal-of-deprecated-methods-in-attributes.adoc
+++ b/docs/modules/guides/partials/removal-of-deprecated-methods-in-attributes.adoc
@@ -1,0 +1,73 @@
+== Removal of deprecated methods in `org.asciidoctor.Attributes`
+
+Several methods in `org.asciidoctor.Attributes` class that were marked as `@Deprecated` have been removed.
+This has been done to remove duplicated features and simplify the API interaction.
+
+=== Simplification of Attributes initialization
+
+In v2.5.x the following alternatives to initialize `Attributes` where possible:
+
+[,java]
+.Using Java Constructor and setters
+----
+Attributes attributes = new Attributes();
+attributes.setIcons("font");
+attributes.setNoFooter(true);
+----
+
+[,java]
+.Using Map constructor
+----
+Map<String, Object> attributesMap = new HashMap<>();
+attributesMap.put("toclevels", 2);
+attributesMap.put("icons", "font");
+Attributes attributes = new Attributes(attributesMap);
+----
+
+[,java]
+.Using AttributesBuilder.attributes() and get() methods
+----
+Attributes attributes = AttributesBuilder.attributes()
+    .icons("dont")
+    .noFooter(true)
+    .get();
+----
+
+The new API streamlines the process with a more standard builder approach, in which
+
+* Only interaction with `org.asciidoctor.Attributes` is required.
+* Nested methods offer IDE completion and creation of immutable instances.
+* Improved code readability through indentation.
+
+From v3.0.x, use the new `builder()` and `build()` methods from `org.asciidoctor.Attributes`.
+
+[,java]
+.Using Attributes builder
+----
+Attributes attributes = Attributes.builder()
+    .icons("dont")
+    .noFooter(true)
+    .build();
+----
+
+Note that `Attributes` setter methods are still available, that means that `Attributes` instances can still be modified as in this example.
+
+[,java]
+.Using setters on an instance
+----
+Attributes attributes = Attributes.builder().build();
+attributes.setIcons("font");
+attributes.setNoFooter(true);
+----
+
+[NOTE]
+====
+Free key-value insertion is still possible using:
+
+* `AttributesBuilder::attribute(String attributeName)`
+* `AttributesBuilder::attribute(String attributeName, Object attributeValue)`
+* `Attributes::setAttribute(String attributeName, Object attributeValue)`
+* `Attributes::setAttributes(String attributes)`
+* `Attributes::setAttributes(String... attributes)`
+* `Attributes::setAttributes(Map<String, Object> attributes)`
+====

--- a/docs/modules/guides/partials/removal-of-deprecated-methods-in-options.adoc
+++ b/docs/modules/guides/partials/removal-of-deprecated-methods-in-options.adoc
@@ -1,0 +1,170 @@
+== Removal of deprecated methods in `org.asciidoctor.Options`
+
+Several methods in `org.asciidoctor.Options` class that were marked as `@Deprecated` have been removed.
+This has been done to remove duplicated features and simplify the API interaction.
+
+=== Simplification of Options initialization
+
+In v2.5.x the following alternatives to initialize `Options` where possible:
+
+[,java]
+.Using Java Constructor and setters
+----
+Options options = new Options();
+options.setBackend("html5");
+options.setSafe(SafeMode.UNSAFE);
+options.setMkDirs(true);
+----
+
+[,java]
+.Using Map constructor
+----
+Map<String, Object> optionsMap = new HashMap<>();
+optionsMap.put("backend", "html5");
+optionsMap.put("sage", SafeMode.UNSAFE);
+optionsMap.put("mkdirs", true);
+Options options = new Options(optionsMap);
+----
+
+[,java]
+.Using OptionsBuilder.options() and get() methods
+----
+Options options = OptionsBuilder.options()
+    .backend("html5")
+    .mkDirs(true)
+    .safe(SafeMode.UNSAFE)
+    .get();
+----
+
+The new API streamlines the process with a more standard builder approach, in which
+
+* Only interaction with `org.asciidoctor.Options` is required.
+* Nested methods offer IDE completion and creation of immutable instances.
+* Improved code readability through indentation.
+
+From v3.0.x, use the new `builder()` and `build()` methods from `org.asciidoctor.Options`.
+
+[,java]
+.Using Options builder
+----
+Options options = Options.builder()
+    .backend("html5")
+    .mkDirs(true)
+    .safe(SafeMode.UNSAFE)
+    .build();
+----
+
+Note that `Options` setter methods are still available, that means that `Options` instances can still be modified as in this example.
+
+[,java]
+.Using setters on an instance
+----
+Options options = Options.builder().build();
+options.setBackend("html5");
+options.setSafe(SafeMode.UNSAFE);
+options.setMkDirs(true)
+----
+
+[NOTE]
+====
+Free key-value insertion is still possible using:
+
+* `OptionsBuilder::option(String option, Object value)`
+* `Options::setOption(String option, Object value)`
+====
+
+=== Simplification of Attributes injection in Options
+
+The previous API offered the following ways to inject attributes to an `Options` instance.
+
+[,java]
+.Using Attributes instance setter
+----
+Attributes attributes = new Attributes();
+options.setAttributes(attributes);
+----
+
+[,java]
+.Using Map setter
+----
+Map<String, Object> attributesMap = new HashMap<>();
+attributesMap.put("toclevels", 2);
+attributesMap.put("icons", "font");
+options.setAttributes(attributesMap);
+----
+
+Also, in v2.5.x it is possible to pass attributes to an `OptionsBuilder`.
+
+[,java]
+.Using OptionsBuilder's Attributes instance setter
+----
+Attributes attributes = new Attributes();
+Options options = OptionsBuilder.options()
+    .attributes(attributes)
+    .get();
+----
+
+[,java]
+.Using OptionsBuilder's Map setter
+----
+Map<String, Object> attributesMap = new HashMap<>();
+attributesMap.put("toclevels", 2);
+attributesMap.put("icons", "font");
+Options options = OptionsBuilder.options()
+    .attributes(attributesMap)
+    .get();
+----
+
+[,java]
+.Using OptionsBuilder's AttributesBuilder setter
+----
+AttributesBuilder attributesBuilder = AttributesBuilder.attributes();
+Options options = OptionsBuilder.options()
+    .attributes(attributesBuilder)
+    .get();
+----
+
+All these alternatives have been unified in two methods for `Options` and one for `OptionsBuilder`.
+
+[,java]
+.Using Attributes setter in Options
+----
+Attributes attributes = Attributes.builder()
+    .icons("font")
+    .build();
+
+Options options = Options.builder().build();
+options.setAttributes(attributes);
+----
+
+[,java]
+.Using attributes Map setter in Options
+----
+Map<String, Object> attributesMap = new HashMap<>();
+attributesMap.put("toclevels", 2);
+attributesMap.put("icons", "font");
+
+Options options = Options.builder().build();
+options.setAttributes(attributesMap);
+----
+
+[,java]
+.Using Attributes instance setter in OptionsBuilder
+----
+Attributes attributes = Attributes.builder()
+    .icons("font")
+    .build();
+Options options = Options.builder()
+    .attributes(attributes)
+    .build();
+----
+
+[NOTE]
+====
+Free key-value or string insertion is still possible using:
+
+* `AttributesBuilder::attribute(String attributeName)`
+* `AttributesBuilder::attribute(String attributeName, Object attributeValue)`
+* `Attributes::setAttributes(String attributes)`
+* `Attributes::setAttributes(String... attributes)`
+====


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*

See https://github.com/asciidoctor/asciidoctorj/issues/1199

*How does it achieve that?*

Simply remove methods already marked as deprecated and fix where necessary (mostly tests).
* Some extra work removing deprecated use (not the method) of `Document::blocks`, using now `Document::getBlocks`

*Are there any alternative ways to implement this?*

No :thinking: 
Docs feed from test code, so it will be updated. Still pending a manual review though.

*Are there any implications of this pull request? Anything a user must know?*

It's a  breaking change for v3.0.0, nothing to do for v2.5.x branch.

## Issue

Fixes #1199 
