### PR TITLE
(main) Bump Spring Boot in IT to latest v3.1.0

### DIFF
--- a/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
+++ b/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-	id 'org.springframework.boot' version '3.0.4'
+	id 'org.springframework.boot' version '3.1.0'
 	id 'java'
 }
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Test compatibility with the atest Boot version v3.1.0 in main branch.

How does it achieve that?

Bump Boot version in IT.

Are there any alternative ways to implement this?

No.

Are there any implications of this pull request? Anything a user must know?

No.

## Issue
## Release notes

Just a chore, not worth documenting imho