### PR TITLE
(v2.5.x) Bump Spring Boot in IT to latest v2.7.12

### DIFF
--- a/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
+++ b/asciidoctorj-springboot-integration-test/springboot-app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-	id 'org.springframework.boot' version '2.6.5'
-	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	id 'org.springframework.boot' version '2.7.12'
+	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'java'
 }
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Test compatibility with the latest Boot version v2.7.12 in main v2.5.x.
We use Boot branch 2.x which is still Java 8 compatible.

How does it achieve that?

Bump Boot version in IT.

Are there any alternative ways to implement this?

No.

Are there any implications of this pull request? Anything a user must know?

No.

## Issue
## Release notes

Just a chore, not worth documenting imho