### PR TITLE
Remove deprecated from ast package

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,7 @@ Improvement::
 * BREAKING: Remove deprecated methods from Asciidoctor interface (#1201) (@abelsromero)
 * BREAKING: Remove deprecated methods from Document interface (#1202) (@abelsromero)
 * BREAKING: Remove deprecated methods and constants from extension package (#1203) (@abelsromero)
+* BREAKING: Remove deprecated methods from ast package (#1204) (@abelsromero)
 
 Bug Fixes::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Block.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Block.java
@@ -3,12 +3,6 @@ package org.asciidoctor.ast;
 import java.util.List;
 
 public interface Block extends StructuralNode {
-    /**
-     * @deprecated Please use {@link #getLines}
-     * @return The original content of this block
-     */
-    @Deprecated
-    List<String> lines();
 
     /**
      * @return The original content of this block
@@ -17,24 +11,19 @@ public interface Block extends StructuralNode {
 
     /**
      * Sets the source lines of the Block.
+     *
      * @param lines The source of this Block, substitutions will still be applied.
      */
     void setLines(List<String> lines);
 
     /**
-     * @deprecated Please use {@link #getSource}
-     * @return the String containing the lines joined together or null if there are no lines
-     */
-    @Deprecated
-    String source();
-
-    /**
-     * @return the String containing the lines joined together or null if there are no lines
+     * @return The String containing the lines joined together or null if there are no lines
      */
     String getSource();
 
     /**
      * Sets the source of the Block.
+     *
      * @param source The source of this Block, substitutions will still be applied.
      */
     void setSource(String source);

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentNode.java
@@ -6,13 +6,6 @@ import java.util.Map;
 public interface ContentNode {
 
     /**
-     * @deprecated Please use {@link #getId()}
-     * @return A unique ID for this node
-     */
-    @Deprecated
-    String id();
-
-    /**
      * @return A unique ID for this node
      */
     String getId();
@@ -20,56 +13,18 @@ public interface ContentNode {
     void setId(String id);
 
     String getNodeName();
-    /**
-     * @deprecated Use {@linkplain #getParent()}  instead.
-     */
-    @Deprecated
-    ContentNode parent();
+
     ContentNode getParent();
-    /**
-     * @deprecated Use {@linkplain #getContext()}  instead.
-     */
-    @Deprecated
-    String context();
+
     String getContext();
-    /**
-     * @deprecated Use {@linkplain #getDocument()}  instead.
-     */
-    @Deprecated
-    Document document();
+
     Document getDocument();
+
     boolean isInline();
+
     boolean isBlock();
+
     Map<String, Object> getAttributes();
-
-    /**
-     *
-     * @param name
-     * @param defaultValue
-     * @param inherit
-     * @return
-     * @deprecated Use {@link #getAttribute(Object, Object, boolean)} instead
-     */
-    @Deprecated
-    Object getAttr(Object name, Object defaultValue, boolean inherit);
-
-    /**
-     *
-     * @param name
-     * @param defaultValue
-     * @return
-     * @deprecated Use {@link #getAttribute(Object, Object)} instead
-     */
-    @Deprecated
-    Object getAttr(Object name, Object defaultValue);
-
-    /**
-     * @param name
-     * @return
-     * @deprecated Use {@link #getAttribute(Object)} instead
-     */
-    @Deprecated
-    Object getAttr(Object name);
 
     Object getAttribute(Object name, Object defaultValue, boolean inherit);
 
@@ -80,29 +35,10 @@ public interface ContentNode {
     /**
      * @param name
      * @return {@code true} if this node or the document has an attribute with the given name
-     * @deprecated Use {@link #hasAttribute(Object)} instead
-     */
-    @Deprecated
-    boolean hasAttr(Object name);
-
-    /**
-     *
-     * @param name
-     * @param inherited
-     * @return {@code true} if the current node or depending on the inherited parameter the document has an attribute with the given name.
-     * @deprecated Use {@link #hasAttribute(Object, boolean)} instead
-     */
-    @Deprecated
-    boolean hasAttr(Object name, boolean inherited);
-
-    /**
-     * @param name
-     * @return {@code true} if this node or the document has an attribute with the given name
      */
     boolean hasAttribute(Object name);
 
     /**
-     *
      * @param name
      * @param inherited
      * @return {@code true} if the current node or depending on the inherited parameter the document has an attribute with the given name.
@@ -110,28 +46,6 @@ public interface ContentNode {
     boolean hasAttribute(Object name, boolean inherited);
 
     /**
-     *
-     * @param name
-     * @param expected
-     * @return
-     * @deprecated Use {@link #isAttribute(Object, Object)} instead.
-     */
-    @Deprecated
-    boolean isAttr(Object name, Object expected);
-
-    /**
-     *
-     * @param name
-     * @param expected
-     * @param inherit
-     * @return
-     * @deprecated Use {@link #isAttribute(Object, Object, boolean)} instead.
-     */
-    @Deprecated
-    boolean isAttr(Object name, Object expected, boolean inherit);
-
-    /**
-     *
      * @param name
      * @param expected
      * @return
@@ -139,7 +53,6 @@ public interface ContentNode {
     boolean isAttribute(Object name, Object expected);
 
     /**
-     *
      * @param name
      * @param expected
      * @param inherit
@@ -148,30 +61,23 @@ public interface ContentNode {
     boolean isAttribute(Object name, Object expected, boolean inherit);
 
     /**
-     *
      * @param name
      * @param value
      * @param overwrite
      * @return
-     * @deprecated Use {@link #setAttribute(Object, Object, boolean)} instead.
      */
-    @Deprecated
-    boolean setAttr(Object name, Object value, boolean overwrite);
-
     boolean setAttribute(Object name, Object value, boolean overwrite);
 
 
-
     boolean isOption(Object name);
+
     //boolean isRole(String expect); cannot be implemented because it tries to use the non argument isRole.
     boolean isRole();
+
     boolean hasRole(String role);
+
     String getRole();
-    /**
-     * @deprecated Use {@linkplain #getRole()}  instead.
-     */
-    @Deprecated
-    String role();
+
     List<String> getRoles();
 
     void addRole(String role);
@@ -179,12 +85,19 @@ public interface ContentNode {
     void removeRole(String role);
 
     boolean isReftext();
+
     String getReftext();
+
     String iconUri(String name);
+
     String mediaUri(String target);
+
     String imageUri(String targetImage);
+
     String imageUri(String targetImage, String assetDirKey);
+
     String readAsset(String path, Map<Object, Object> opts);
+
     String normalizeWebPath(String path, String start, boolean preserveUriTarget);
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/DescriptionList.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/DescriptionList.java
@@ -6,13 +6,6 @@ public interface DescriptionList extends StructuralNode {
 
     boolean hasItems();
 
-    /**
-     * @deprecated Please use {@link #convert()}
-     * @return
-     */
-    @Deprecated
-    String render();
-
     String convert();
 
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/DescriptionListEntry.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/DescriptionListEntry.java
@@ -20,6 +20,7 @@ public interface DescriptionListEntry {
      *     return doc;
      *   }
      * }</pre></code>
+     *
      * @param description The new description for this description list entry,
      */
     void setDescription(final ListItem description);

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/List.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/List.java
@@ -6,13 +6,4 @@ public interface List extends StructuralNode {
 
     boolean hasItems();
 
-    /**
-     * @deprecated Please use {@link #convert()}
-     * @return
-     */
-    @Deprecated
-    String render();
-
-    String convert();
-
 }

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/PhraseNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/PhraseNode.java
@@ -2,12 +2,6 @@ package org.asciidoctor.ast;
 
 public interface PhraseNode extends ContentNode {
 
-    /**
-     * @deprecated Please use {@link #convert()}
-     */
-    @Deprecated
-    String render();
-    
     String convert();
 
     String getType();

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Section.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Section.java
@@ -3,34 +3,13 @@ package org.asciidoctor.ast;
 public interface Section extends StructuralNode {
 
     /**
-     * @deprecated Please use {@link #getIndex()}
-     * @return the 0-based index order of this section within the parent block
-     */
-    @Deprecated
-    int index();
-
-    /**
      * @return the 0-based index order of this section within the parent block
      */
     int getIndex();
 
     /**
-     * @deprecated Please use {@link #getNumber()}
-     * @return the number of this section within the parent block
-     */
-    @Deprecated
-    int number();
-
-    /**
-     * @deprecated Please use {@link #getNumeral()}
-     * @return the number of this section within the parent block
-     */
-    @Deprecated
-    int getNumber();
-
-    /**
      * Section numeral.
-     *
+     * <p>
      * This is a roman numeral for book parts, arabic numeral for regular sections,
      * and a letter for special sections.
      *
@@ -39,35 +18,14 @@ public interface Section extends StructuralNode {
     String getNumeral();
 
     /**
-     * @deprecated Please use {@link #getSectionName()}
-     * @return the section name of this section
-     */
-    @Deprecated
-    String sectname();
-
-    /**
      * @return the section name of this section
      */
     String getSectionName();
 
     /**
-     * @deprecated Please use {@link #isSpecial()}
-     * @return Get the flag to indicate whether this is a special section or a child of one
-     */
-    @Deprecated
-    boolean special();
-
-    /**
      * @return Get the flag to indicate whether this is a special section or a child of one
      */
     boolean isSpecial();
-
-    /**
-     * @deprecated Please use {@link #isNumbered()}
-     * @return the state of the numbered attribute at this section (need to preserve for creating TOC)
-     */
-    @Deprecated
-    boolean numbered();
 
     /**
      * @return the state of the numbered attribute at this section (need to preserve for creating TOC)

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/StructuralNode.java
@@ -41,32 +41,15 @@ public interface StructuralNode extends ContentNode {
      */
     String SUBSTITUTION_POST_REPLACEMENTS  = "post_replacements";
 
-    /**
-     * @deprecated Please use {@linkplain #getTitle()} instead
-     */
-    @Deprecated
-    String title();
     String getTitle();
     void setTitle(String title);
 
     String getCaption();
     void setCaption(String caption);
 
-    /**
-     * @deprecated Please use {@linkplain #getStyle()} instead
-     */
-    @Deprecated
-    String style();
     String getStyle();
 
     void setStyle(String style);
-
-    /**
-     * @return The list of child blocks of this block
-     * @deprecated Please use {@linkplain #getBlocks()} instead
-     */
-    @Deprecated
-    List<StructuralNode> blocks();
 
     /**
      * @return The list of child blocks of this block
@@ -79,11 +62,6 @@ public interface StructuralNode extends ContentNode {
      */
     void append(StructuralNode block);
 
-    /**
-     * @deprecated Please use {@linkplain #getContent()} instead
-     */
-    @Deprecated
-    Object content();
     Object getContent();
     String convert();
     List<StructuralNode> findBy(Map<Object, Object> selector);

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Table.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Table.java
@@ -26,30 +26,34 @@ public interface Table extends StructuralNode {
      * Returns the frame attribute of the table that defines what frame to render around the table.
      * By default, the frame attribute is assigned the {@code all} value, which draws a border on each side of the table.
      * If you set the frame attribute, you can override the default value with {@code topbot}, {@code sides} or {@code none}.
+     *
      * @return the frame attribute
      */
     String getFrame();
 
     /**
      * Sets the frame attribute.
-     * @see #getFrame()
+     *
      * @param frame {@code all}, {@code topbot}, {@code sides} or {@code none}
+     * @see #getFrame()
      */
     void setFrame(String frame);
 
     /**
      * Returns the grid attribute that defines what boundary lines to draw between rows and columns.
-     * By default the grid attribute is assigned the {@code all} value, which draws lines around each cell.
+     * By default, the grid attribute is assigned the {@code all} value, which draws lines around each cell.
      * Alternative values are {@code cols} to draw lines between columns, {@code rows} to draw boundary lines
      * between rows and {@code none} to draw no boundary lines
+     *
      * @return the value of the {@code grid} attribute, usually either {@code all}, {@code cols}, {@code rows} or {@code none}
      */
     String getGrid();
 
     /**
      * Sets the value of the {@grid} attribute.
-     * @see #getGrid()
+     *
      * @param grid usually either {@code all}, {@code cols}, {@code rows} or {@code none}
+     * @see #getGrid()
      */
     void setGrid(String grid);
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/AuthorImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/AuthorImpl.java
@@ -32,7 +32,7 @@ public class AuthorImpl implements Author {
     }
 
     private static String aref(RubyStruct s, String key) {
-        return (String) JavaEmbedUtils.rubyToJava(s.aref(s.getRuntime().newString(key)));
+        return JavaEmbedUtils.rubyToJava(s.aref(s.getRuntime().newString(key)));
     }
 
     public String getFullName() {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/BlockImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/BlockImpl.java
@@ -1,22 +1,16 @@
 package org.asciidoctor.jruby.ast.impl;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.asciidoctor.ast.Block;
 import org.jruby.RubyArray;
 import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class BlockImpl extends StructuralNodeImpl implements Block {
 
     public BlockImpl(IRubyObject blockDelegate) {
         super(blockDelegate);
-    }
-
-    @Override
-    @Deprecated
-    public List<String> lines() {
-        return getLines();
     }
 
     @Override
@@ -27,16 +21,10 @@ public class BlockImpl extends StructuralNodeImpl implements Block {
     @Override
     public void setLines(List<String> lines) {
         RubyArray newLines = getRuntime().newArray(lines.size());
-        for (String s: lines) {
-            newLines.add(getRuntime().newString(s));
+        for (String line : lines) {
+            newLines.add(getRuntime().newString(line));
         }
         setRubyProperty("lines", newLines);
-    }
-
-    @Override
-    @Deprecated
-    public String source() {
-        return getSource();
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ContentNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ContentNodeImpl.java
@@ -20,12 +20,6 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
-    @Deprecated
-    public String id() {
-        return getId();
-    }
-
-    @Override
     public String getId() {
         return getString("id");
     }
@@ -36,31 +30,14 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
-    @Deprecated
-    public String context() {
-        return getContext();
-    }
-
-    @Override
     public String getContext() {
         return getString("context");
     }
 
-    @Override
-    @Deprecated
-    public ContentNode parent() {
-        return getParent();
-    }
 
     @Override
     public ContentNode getParent() {
         return NodeConverter.createASTNode(getRubyProperty("parent"));
-    }
-
-    @Override
-    @Deprecated
-    public Document document() {
-        return getDocument();
     }
 
     @Override
@@ -89,24 +66,6 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
-    @Deprecated
-    public Object getAttr(Object name, Object defaultValue, boolean inherit) {
-        return getAttribute(name, defaultValue, inherit);
-    }
-
-    @Override
-    @Deprecated
-    public Object getAttr(Object name, Object defaultValue) {
-        return getAttribute(name, defaultValue);
-    }
-
-    @Override
-    @Deprecated
-    public Object getAttr(Object name) {
-        return getAttribute(name);
-    }
-
-    @Override
     public Object getAttribute(Object name, Object defaultValue, boolean inherit) {
         return JavaEmbedUtils.rubyToJava(getRubyProperty("attr", name, defaultValue, inherit));
     }
@@ -122,18 +81,6 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
-    @Deprecated
-    public boolean isAttr(Object name, Object expected, boolean inherit) {
-        return isAttribute(name, expected, inherit);
-    }
-
-    @Override
-    @Deprecated
-    public boolean isAttr(Object name, Object expected) {
-        return isAttribute(name, expected);
-    }
-
-    @Override
     public boolean isAttribute(Object name, Object expected, boolean inherit) {
         return getBoolean("attr?", name, expected, inherit);
     }
@@ -144,18 +91,6 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
-    @Deprecated
-    public boolean hasAttr(Object name) {
-        return hasAttribute(name);
-    }
-
-    @Override
-    @Deprecated
-    public boolean hasAttr(Object name, boolean inherited) {
-        return hasAttribute(name, inherited);
-    }
-
-    @Override
     public boolean hasAttribute(Object name) {
         return getBoolean("attr?", name);
     }
@@ -163,12 +98,6 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     @Override
     public boolean hasAttribute(Object name, boolean inherited) {
         return getBoolean("attr?", name, null, inherited);
-    }
-
-    @Override
-    @Deprecated
-    public boolean setAttr(Object name, Object value, boolean overwrite) {
-        return setAttribute(name, value, overwrite);
     }
 
     @Override
@@ -189,12 +118,6 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     @Override
     public String getRole() {
         return getString("role");
-    }
-
-    @Override
-    @Deprecated
-    public String role() {
-        return getRole();
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DescriptionListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/DescriptionListImpl.java
@@ -29,12 +29,6 @@ public class DescriptionListImpl extends StructuralNodeImpl implements Descripti
     }
 
     @Override
-    @Deprecated
-    public String render() {
-        return getString("render");
-    }
-
-    @Override
     public String convert() {
         return getString("convert");
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ListImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ListImpl.java
@@ -24,12 +24,6 @@ public class ListImpl extends StructuralNodeImpl implements List {
     }
 
     @Override
-    @Deprecated
-    public String render() {
-        return getString("render");
-    }
-
-    @Override
     public String convert() {
         return getString("convert");
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/PhraseNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/PhraseNodeImpl.java
@@ -10,12 +10,6 @@ public class PhraseNodeImpl extends ContentNodeImpl implements PhraseNode {
     }
 
     @Override
-    @Deprecated
-    public String render() {
-        return getString("render");
-    }
-
-    @Override
     public String convert() {
         return getString("convert");
     }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/RowImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/RowImpl.java
@@ -17,7 +17,7 @@ public class RowImpl extends RubyObjectWrapper implements Row {
 
     @Override
     public List<Cell> getCells() {
-        return new RubyBlockListDecorator<Cell>((RubyArray) getRubyObject());
+        return new RubyBlockListDecorator<>((RubyArray) getRubyObject());
     }
 
     public RubyArray getRubyCells() {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/SectionImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/SectionImpl.java
@@ -10,26 +10,8 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
     }
 
     @Override
-    @Deprecated
-    public int index() {
-        return getIndex();
-    }
-
-    @Override
     public int getIndex() {
         return getInt("index");
-    }
-
-    @Override
-    @Deprecated
-    public int number() {
-        return getNumber();
-    }
-
-    @Override
-    @Deprecated
-    public int getNumber() {
-        return getInt("number");
     }
 
     @Override
@@ -38,31 +20,13 @@ public class SectionImpl extends StructuralNodeImpl implements Section {
     }
 
     @Override
-    @Deprecated
-    public String sectname() {
-        return getSectionName();
-    }
-
-    @Override
     public String getSectionName() {
         return getString("sectname");
     }
 
     @Override
-    @Deprecated
-    public boolean special() {
-        return isSpecial();
-    }
-
-    @Override
     public boolean isSpecial() {
         return getBoolean("special");
-    }
-
-    @Override
-    @Deprecated
-    public boolean numbered() {
-        return isNumbered();
     }
 
     @Override

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/StructuralNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/StructuralNodeImpl.java
@@ -18,12 +18,6 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     }
 
     @Override
-    @Deprecated
-    public String title() {
-        return getTitle();
-    }
-
-    @Override
     public String getTitle() {
         return getString("title");
     }
@@ -44,12 +38,6 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     }
 
     @Override
-    @Deprecated
-    public String style() {
-        return getStyle();
-    }
-
-    @Override
     public String getStyle() {
         return getString("style");
     }
@@ -57,12 +45,6 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     @Override
     public void setStyle(String style) {
         setString("style", style);
-    }
-
-    @Override
-    @Deprecated
-    public List<StructuralNode> blocks() {
-        return getBlocks();
     }
 
     @Override
@@ -74,12 +56,6 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
     @Override
     public void append(StructuralNode block) {
         getRubyObject().callMethod(runtime.getCurrentContext(), "<<", ((StructuralNodeImpl) block).getRubyObject());
-    }
-
-    @Override
-    @Deprecated
-    public Object content() {
-        return getContent();
     }
 
     @Override
@@ -113,7 +89,7 @@ public class StructuralNodeImpl extends ContentNodeImpl implements StructuralNod
 
     @Override
     public String getContentModel() {
-    	return getString("content_model");
+        return getString("content_model");
     }
 
     @Override

--- a/docs/modules/guides/pages/api-migration-guide-v25x-to-v30.adoc
+++ b/docs/modules/guides/pages/api-migration-guide-v25x-to-v30.adoc
@@ -21,3 +21,5 @@ include::partial$removal-of-deprecated-methods-in-document.adoc[]
 include::partial$removal-of-deprecated-constants-in-BlockProcessor.adoc[]
 
 include::partial$removal-of-deprecated-methods-in-extension-package.adoc[]
+
+include::partial$removal-of-deprecated-methods-in-ast-package.adoc[]

--- a/docs/modules/guides/partials/removal-of-deprecated-methods-in-ast-package.adoc
+++ b/docs/modules/guides/partials/removal-of-deprecated-methods-in-ast-package.adoc
@@ -1,0 +1,131 @@
+== Removal of deprecated methods in `org.asciidoctor.ast` package
+
+Several methods under `org.asciidoctor.ast` that were marked as `@Deprecated` have been removed.
+The new methods align better with Java naming patterns and are easily identifiable.
+
+Here follows the list of affected interfaces, describing for each one the removed methods and the substitutions.
+
+=== Block
+
+[,java]
+.Removed deprecated methods
+----
+List<String> lines()
+String source()
+----
+
+[,java]
+.Final methods
+----
+List<String> getLines()
+String getSource()
+----
+
+=== DescriptionList, PhraseNode and List
+
+[,java]
+.Removed deprecated method
+----
+String render()
+----
+
+[,java]
+.Final method
+----
+String convert()
+----
+
+=== ContentNode
+
+[,java]
+.Removed deprecated methods
+----
+String id()
+ContentNode parent()
+String context()
+Document document()
+String role()
+
+Object getAttr(Object name, Object defaultValue, boolean inherit)
+Object getAttr(Object name, Object defaultValue)
+Object getAttr(Object name)
+
+boolean hasAttr(Object name)
+boolean hasAttr(Object name, boolean inherited)
+
+boolean isAttr(Object name, Object expected)
+boolean isAttr(Object name, Object expected, boolean inherit)
+
+boolean setAttr(Object name, Object value, boolean overwrite)
+----
+
+[,java]
+.Final methods
+----
+String getId()
+ContentNode getParent()
+String getContext()
+Document getDocument()
+String getRole()
+
+Object getAttribute(Object name, Object defaultValue, boolean inherit)
+Object getAttribute(Object name, Object defaultValue)
+Object getAttribute(Object name)
+
+boolean hasAttribute(Object name)
+boolean hasAttribute(Object name, boolean inherited)
+
+boolean isAttribute(Object name, Object expected)
+boolean isAttribute(Object name, Object expected, boolean inherit)
+
+boolean setAttribute(Object name, Object value, boolean overwrite)
+----
+
+=== Section
+
+On top of the methods replaced by Java getters, both `number` and `getNumber` are replaced by `getNumeral`.
+This is done to support non-number numerals.
+
+[,java]
+.Removed deprecated methods
+----
+int index()
+int number()
+int getNumber()
+
+String sectname()
+boolean special()
+
+boolean numbered()
+----
+
+[,java]
+.Final methods
+----
+int getIndex()
+String getNumeral()
+
+String getSectionName()
+boolean isSpecial()
+
+boolean isNumbered()
+----
+
+=== StructuralNode
+
+[,java]
+.Removed deprecated methods
+----
+Object content()
+String style()
+String title()
+List<StructuralNode> blocks()
+----
+
+.Final methods
+----
+Object getContent()
+String getStyle()
+String getTitle()
+List<StructuralNode> getBlocks()
+----

--- a/docs/modules/guides/partials/removal-of-deprecated-methods-in-extension-package.adoc
+++ b/docs/modules/guides/partials/removal-of-deprecated-methods-in-extension-package.adoc
@@ -1,6 +1,6 @@
 == Removal of deprecated methods in `org.asciidoctor.extension` package
 
-Several methods under `org.asciidoctor.extension that were marked as `@Deprecated` have been removed.
+Several methods under `org.asciidoctor.extension` that were marked as `@Deprecated` have been removed.
 The new methods align better with Java naming patterns and are easily identifiable.
 
 [,java]


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*

Remove deprecated methods in `ast` package.

*How does it achieve that?*

Simply remove the code marked as deprecated and adding migration docs.

*Are there any alternative ways to implement this?*

no

*Are there any implications of this pull request? Anything a user must know?*

Users will need to update their code if they use some of the removed methods.
The PR includes a migration guide.

## Issue

Fixes #1204 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc