### PR TITLE
V2.5.x bump jruby to 9.4.2.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 == Unreleased
 
+Improvement::
+
+* Upgrade to JRuby 9.4.2.0 (#1215) (@abelsromero)
+
 == 2.5.9 (2023-06-01)
 
 Improvement::

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.82'
-  jrubyVersion = '9.3.10.0'
+  jrubyVersion = '9.4.2.0'
   jsoupVersion = '1.14.3'
   junitVersion = '4.13.2'
   assertjVersion = '3.19.0'


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

*What is the goal of this pull request?*

Simply bump JRuby to latest.
JRuby has fixed some CVEs and while we are unaffected, bumping avoids warnings in users scans.

*How does it achieve that?*

Bump the `jrubyVersion` property.

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

Closes #1215 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc