### PR TITLE
Fixes #1221. 'UnsupportedOperationException' when passing immutable Map as options to 'createPhraseNode'

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* 'UnsupportedOperationException' when passing immutable Map as options to 'createPhraseNode' (#1221) (@abelsromero)
+
 Improvement::
 
 * BREAKING: Fix Macro APIs to take StructuralNodes and return Phrase- or StructuralNodes. (#1084)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/internal/JRubyProcessor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/internal/JRubyProcessor.java
@@ -159,19 +159,21 @@ public class JRubyProcessor implements Processor {
     public Block createBlock(StructuralNode parent, String context, String content, Map<String, Object> attributes,
                              Map<Object, Object> options) {
 
-        options.put(Options.SOURCE, content);
-        options.put(Options.ATTRIBUTES, attributes);
+        Map<Object, Object> optionsCopy = new HashMap<>(options);
+        optionsCopy.put(Options.SOURCE, content);
+        optionsCopy.put(Options.ATTRIBUTES, attributes);
 
-        return createBlock(parent, context, options);
+        return createBlock(parent, context, optionsCopy);
     }
 
     @Override
     public Block createBlock(StructuralNode parent, String context, List<String> content, Map<String, Object> attributes,
                              Map<Object, Object> options) {
 
-        options.put(Options.SOURCE, content);
-        options.put(Options.ATTRIBUTES, new HashMap<>(attributes));
-        return createBlock(parent, context, options);
+        Map<Object, Object> optionsCopy = new HashMap<>(options);
+        optionsCopy.put(Options.SOURCE, content);
+        optionsCopy.put(Options.ATTRIBUTES, new HashMap<>(attributes));
+        return createBlock(parent, context, optionsCopy);
     }
 
     @Override
@@ -179,10 +181,11 @@ public class JRubyProcessor implements Processor {
 
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
 
-        options.put(Options.ATTRIBUTES, attributes);
+        Map<Object, Object> optionsCopy = new HashMap<>(options);
+        optionsCopy.put(Options.ATTRIBUTES, attributes);
 
         RubyHash convertMapToRubyHashWithSymbols = RubyHashUtil.convertMapToRubyHashWithSymbolsIfNecessary(rubyRuntime,
-                options);
+                optionsCopy);
 
         RubyArray rubyText = rubyRuntime.newArray();
         rubyText.addAll(text);
@@ -200,9 +203,10 @@ public class JRubyProcessor implements Processor {
 
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
 
-        options.put(Options.ATTRIBUTES, RubyHashUtil.convertMapToRubyHashWithStrings(rubyRuntime, attributes));
+        Map<String, Object> optionsCopy = new HashMap<>(options);
+        optionsCopy.put(Options.ATTRIBUTES, RubyHashUtil.convertMapToRubyHashWithStrings(rubyRuntime, attributes));
 
-        RubyHash convertedOptions = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, options);
+        RubyHash convertedOptions = RubyHashUtil.convertMapToRubyHashWithSymbols(rubyRuntime, optionsCopy);
 
         IRubyObject[] parameters = {
                 ((ContentNodeImpl) parent).getRubyObject(),
@@ -306,8 +310,9 @@ public class JRubyProcessor implements Processor {
                                                Map<String, Object> attributes,
                                                Map<Object, Object> options) {
 
-        options.put(Options.ATTRIBUTES, new HashMap<>(attributes));
-        return createList(parent, context, options);
+        HashMap<Object, Object> optionsCopy = new HashMap<>(options);
+        optionsCopy.put(Options.ATTRIBUTES, new HashMap<>(attributes));
+        return createList(parent, context, optionsCopy);
     }
 
     @Override
@@ -330,14 +335,14 @@ public class JRubyProcessor implements Processor {
     public ListItem createListItem(final org.asciidoctor.ast.List parent, final String text) {
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
 
-        return (ListItem) NodeConverter.createASTNode(rubyRuntime, NodeConverter.NodeType.LIST_ITEM_CLASS, ListImpl.class.cast(parent).getRubyObject(), rubyRuntime.newString(text));
+        return (ListItem) NodeConverter.createASTNode(rubyRuntime, NodeConverter.NodeType.LIST_ITEM_CLASS, ((ListImpl) parent).getRubyObject(), rubyRuntime.newString(text));
     }
 
     @Override
     public ListItem createListItem(final org.asciidoctor.ast.DescriptionList parent, final String text) {
         Ruby rubyRuntime = JRubyRuntimeContext.get(parent);
 
-        return (ListItem) NodeConverter.createASTNode(rubyRuntime, NodeConverter.NodeType.LIST_ITEM_CLASS, DescriptionListImpl.class.cast(parent).getRubyObject(), rubyRuntime.newString(text));
+        return (ListItem) NodeConverter.createASTNode(rubyRuntime, NodeConverter.NodeType.LIST_ITEM_CLASS, ((DescriptionListImpl) parent).getRubyObject(), rubyRuntime.newString(text));
     }
 
     /**

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyUtils.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyUtils.java
@@ -1,12 +1,10 @@
 package org.asciidoctor.jruby.internal;
 
-import java.io.InputStream;
-
 import org.jruby.Ruby;
-import org.jruby.RubyClass;
 import org.jruby.RubySymbol;
-import org.jruby.javasupport.JavaClass;
 import org.jruby.runtime.builtin.IRubyObject;
+
+import java.io.InputStream;
 
 public class RubyUtils {
 
@@ -15,12 +13,7 @@ public class RubyUtils {
     }
 
     public static RubySymbol toSymbol(Ruby rubyRuntime, String key) {
-        RubySymbol newSymbol = RubySymbol.newSymbol(rubyRuntime, key);
-        return newSymbol;
-    }
-
-    public static RubyClass toRubyClass(Ruby rubyRuntime, Class<?> rubyClass) {
-        return JavaClass.get(rubyRuntime, rubyClass).getProxyClass();
+        return RubySymbol.newSymbol(rubyRuntime, key);
     }
 
     public static void requireLibrary(Ruby rubyRuntime, String require) {
@@ -32,7 +25,7 @@ public class RubyUtils {
         rubyRuntime.evalScriptlet(script);
     }
 
-    public static final void setGlobalVariable(Ruby rubyRuntime, String variableName, Object variableValue) {
+    public static void setGlobalVariable(Ruby rubyRuntime, String variableName, Object variableValue) {
         String script = String.format("$%s = %s", variableName, variableValue);
         rubyRuntime.evalScriptlet(script);
     }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/ManpageMacro.java
@@ -3,7 +3,6 @@ package org.asciidoctor.extension;
 import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.ast.StructuralNode;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class ManpageMacro extends InlineMacroProcessor {
@@ -19,9 +18,9 @@ public class ManpageMacro extends InlineMacroProcessor {
     @Override
     public PhraseNode process(StructuralNode parent, String target,
                               Map<String, Object> attributes) {
-        Map<String, Object> options = new HashMap<String, Object>();
-        options.put("type", ":link");
-        options.put("target", target + ".html");
+        Map<String, Object> options = Map.of(
+                "type", ":link",
+                "target", target + ".html");
         return createPhraseNode(parent, "anchor", target, attributes, options);
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/TerminalCommandTreeprocessor.java
@@ -4,7 +4,7 @@ import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.StructuralNode;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -32,7 +32,7 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {
 
         for (int i = 0; i < blocks.size(); i++) {
             final StructuralNode currentBlock = blocks.get(i);
-            if (currentBlock instanceof StructuralNode) {
+            if (currentBlock != null) {
                 if ("paragraph".equals(currentBlock.getContext())) {
                     List<String> lines = ((Block) currentBlock).getLines();
                     if (lines.size() > 0 && lines.get(0).startsWith("$")) {
@@ -57,7 +57,7 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {
         for (String line : lines) {
             if (line.startsWith("$")) {
                 resultLines.append("<span class=\"command\">")
-                        .append(line.substring(2, line.length()))
+                        .append(line.substring(2))
                         .append("</span>");
             } else {
                 resultLines.append(line);
@@ -65,7 +65,7 @@ public class TerminalCommandTreeprocessor extends Treeprocessor {
         }
 
         return createBlock(this.document, "listing",
-                List.of(resultLines.toString()), attributes, new HashMap<>());
+                List.of(resultLines.toString()), attributes, Collections.emptyMap());
     }
 
 }


### PR DESCRIPTION
Create mutable copies of options passed to Processor.create...()

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Some methods of the Processor API to create nodes mutate the given attributes and options maps.
This is not only surprising, but apparently also fails with an exception if the given map is immutable.
This PR tries to fix this by creating a copy of the given map.

How does it achieve that?

Make a copy of the given map.

Are there any alternative ways to implement this?

I don't think so.

Are there any implications of this pull request? Anything a user must know?

Just in case, it should be impossible to mutate the given options after the Processor was called. This is likely made up, and makes assumptions of the internal behavior of AsciidoctorJ from the users perspective.

## Issue

Fixes #1221

