### PR TITLE
(v3.0.x) Update Antora metadata for v3.0.0-alpha.1 prerelease

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,18 +1,19 @@
 name: asciidoctorj
 title: AsciidoctorJ
-version: '2.5'
+version: '3.0'
+prerelease: '.0-alpha.1'
 asciidoc:
   attributes:
-    release-version: 2.5.7
-    artifact-version: 2.5.7
+    release-version: 3.0.0-alpha.1
+    artifact-version: 3.0.0-alpha.1
     asciidoctorj-epub3-version: 1.5.1
-    asciidoctorj-pdf-version: 1.6.0
-    jruby-version: 9.3.8.0
-    url-jruby: http://jruby.org
+    asciidoctorj-pdf-version: 2.3.6
+    jruby-version: 9.4.1.0
+    url-jruby: https://www.jruby.org/
     url-gradle: https://gradle.org
     url-repo: https://github.com/asciidoctor/asciidoctorj
     url-tilt: https://github.com/rtomayko/tilt
-    url-font-awesome: http://fortawesome.github.io/Font-Awesome
+    url-font-awesome: https://fontawesome.com
     url-highlightjs: https://highlightjs.org
     url-prismjs: https://prismjs.com
 nav:


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*
Prepare metadata to publish the docs as pre-release.
I tested building the docs from the playbook from https://github.com/asciidoctor/docs.asciidoctor.org and it worked well.
Both versions appear...btw, I will remove v2.4 from the published docs, last release was Feb 21, no point in keeping the docs since that version is no longer maintained.
![image](https://github.com/asciidoctor/asciidoctorj/assets/5781153/1d4bb777-082e-42d8-830e-7abce96acf10)
When clicking on the "AsciidoctorJ" title, 2.5 is loaded by default :ok_hand: 

*How does it achieve that?*
Update the metadata, after that, I'll create the PR to http://github.com/asciidoctor/docs.asciidoctor.org to remove v2.4 and publish v3.0.x as a pre-release according to https://asciidoctor.zulipchat.com/#narrow/stream/279644-users.2Fasciidoctorj/topic/Publish.203.2E0.2E0-alpha.2E1.20docs.

*Are there any alternative ways to implement this?*
Tested using `prerelease: true` and did not appreciate any difference. So I am going with the original proposal.

*Are there any implications of this pull request? Anything a user must know?*
No

## Issue

If this PR fixes an open issue, please add a line of the form:

No issue.

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc

Docs are published from `docs.asciidoctor.org` repo, it doesn't make sense to me to add anything to the changelog.