### PR TITLE
(v3.0.x) Ignore docs folder in CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   schedule:
     - cron: '0 0 * * *'
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -59,6 +59,7 @@ Build Improvement::
 * Fix upstream build removing the explicit plugin repository (#1131)
 * Set JUnit5 as default test engine (#1186) (@abelsromero)
 * Removed pollutedTest Gradle task using junit-pioneer (#1193) (@abelsromero)
+* Ignore 'docs/**' changes in CI (#1225) (@abelsromero)
 
 Documentation::
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

*What is the goal of this pull request?*

Avoid unnecessary CI runs when modifying docs.
Docs are built from [docs.asciidoctor.](https://github.com/asciidoctor/docs.asciidoctor.org), we could have a job to build the docs and ensure they are correct, but right now this is using hardware resources for nothing :earth_africa: :leaves: .

*How does it achieve that?*
Use `paths-ignore` to ignore the 'docs/**' path.

*Are there any alternative ways to implement this?*
No

*Are there any implications of this pull request? Anything a user must know?*
No

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc