### PR TITLE
(v2.5.x) Ignore docs in ci

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -2,12 +2,14 @@ name: Build Main
 on:
   push:
     branches:
-      - main
       - v2.5.x
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
-      - main
       - v2.5.x
+    paths-ignore:
+      - 'docs/**'
   schedule:
     - cron: '0 0 * * *'
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,10 @@ Improvement::
 
 * Upgrade to JRuby 9.4.2.0 (#1215) (@abelsromero)
 
+Build / Infrastructure::
+
+* Ignore 'docs/**' changes in CI(#1226) (@abelsromero)
+
 == 2.5.9 (2023-06-01)
 
 Improvement::


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

*What is the goal of this pull request?*

Avoid unnecessary CI runs when modifying docs.
Docs are built from [docs.asciidoctor.](https://github.com/asciidoctor/docs.asciidoctor.org), we could have a job to build the docs and ensure they are correct, but right now this is using hardware resources for nothing :earth_africa: :leaves: .

*How does it achieve that?*
Use `paths-ignore` to ignore the 'docs/**' path.

*Are there any alternative ways to implement this?*
No

*Are there any implications of this pull request? Anything a user must know?*
No

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc