### PR TITLE
(v2.5.x) Update distributions dependencies

### DIFF
--- a/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenDocumentContainsDitaaDiagram.java
+++ b/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenDocumentContainsDitaaDiagram.java
@@ -1,0 +1,34 @@
+package org.asciidoctor;
+
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+public class WhenDocumentContainsDitaaDiagram {
+
+    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+    @Test
+    public void png_should_be_rendered_for_diagram() {
+        File sourceDir = new File("build/resources/test");
+        File inputFile = new File(sourceDir, "sample-with-diagram.adoc");
+
+        File outputDiagram = new File(sourceDir, "asciidoctor-diagram-process.png");
+        File outputDiagramCache = new File(sourceDir, ".asciidoctor/diagram/asciidoctor-diagram-process.png.cache");
+
+        asciidoctor.requireLibrary("asciidoctor-diagram");
+        asciidoctor.convertFile(inputFile,
+                Options.builder()
+                        .backend("html5")
+                        .toFile(new File(sourceDir, "sample.html"))
+                        .build());
+
+        assertThat(outputDiagram.exists(), is(true));
+        assertThat(outputDiagramCache.exists(), is(true));
+    }
+}

--- a/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenEpub3BackendIsUsed.java
+++ b/asciidoctorj-distribution/src/test/java/org/asciidoctor/WhenEpub3BackendIsUsed.java
@@ -1,0 +1,27 @@
+package org.asciidoctor;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.asciidoctor.OptionsBuilder.options;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class WhenEpub3BackendIsUsed {
+
+    private Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+    @Test
+    public void epub3_should_be_rendered_for_epub3_backend() {
+        File inputFile = new File("src/test/resources/epub/epub-index.adoc");
+        File outputDir = new File("build/test-output");
+        outputDir.mkdirs();
+        File outputFile = new File(outputDir, "epub-index.epub");
+        asciidoctor.convertFile(inputFile, options().safe(SafeMode.SAFE)
+                .backend("epub3")
+                .toDir(outputDir)
+                .get());
+        assertThat(outputFile.exists(), is(true));
+    }
+}

--- a/asciidoctorj-distribution/src/test/resources/epub/content-document.adoc
+++ b/asciidoctorj-distribution/src/test/resources/epub/content-document.adoc
@@ -1,0 +1,9 @@
+= Content Title
+Author Name
+
+[abstract]
+This is the actual content.
+
+== First Section
+
+And off we go.

--- a/asciidoctorj-distribution/src/test/resources/epub/epub-index.adoc
+++ b/asciidoctorj-distribution/src/test/resources/epub/epub-index.adoc
@@ -1,0 +1,5 @@
+= Book Title
+Author Name
+:imagesdir: images
+
+include::content-document.adoc[]

--- a/asciidoctorj-distribution/src/test/resources/sample-with-diagram.adoc
+++ b/asciidoctorj-distribution/src/test/resources/sample-with-diagram.adoc
@@ -1,0 +1,22 @@
+= Document Title
+
+[ditaa,asciidoctor-diagram-process]
+....
+                   +-------------+
+                   | Asciidoctor |-------+
+                   |   diagram   |       |
+                   +-------------+       | PNG out
+                       ^                 |
+                       | ditaa in        |
+                       |                 v
+ +--------+   +--------+----+    /---------------\
+ |        |---+ Asciidoctor +--->|               |
+ |  Text  |   +-------------+    |   Beautiful   |
+ |Document|   |   !magic!   |    |    Output     |
+ |     {d}|   |             |    |               |
+ +---+----+   +-------------+    \---------------/
+     :                                   ^
+     |          Lots of work             |
+     +-----------------------------------+
+....
+

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,9 @@ ext {
   // jar versions
   arquillianVersion = '1.6.0.Final'
   arquillianSpockVersion = '1.0.0.CR1'
-  asciidoctorjPdfVersion = '1.6.2'
+  asciidoctorjPdfVersion = '2.3.7'
   asciidoctorjEpub3Version = '1.5.1'
-  asciidoctorjDiagramVersion = '2.2.7'
+  asciidoctorjDiagramVersion = '2.2.7' // 2.2.8+ requires Java 11
   asciidoctorjDiagramDitaaMiniVersion = '1.0.3'
   asciidoctorjDiagramPlantumlVersion = '1.2023.5'
   asciidoctorjRevealJsVersion = '4.1.0'


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [X] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*

- Update distribution dependencies according to https://github.com/asciidoctor/asciidoctorj/issues/1227.
`asciidoctorj-diagram` is excluded since v2.2.8 is not compatible with Java 8 and this branch still is.
- Ported a tests from asciidoctorj-diagram to detect issues with it diagram and epub.

*How does it achieve that?*

Simply bumps the dependencies.

*Are there any alternative ways to implement this?*

no, that I know off :shrug: 

*Are there any implications of this pull request? Anything a user must know?*

## Issue

Does not close any issue directly

## Release notes

