### PR TITLE
Incorporating Jamal macro into the documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@
 ////
 This is a generated file. DO NOT EDIT!!!!!
 To modify this file edit README.adoc.jam in the same directory
+
 ////
 Alex Soto <https://github.com/lordofthejars[@lordofthejars]>; Dan Allen <https://github.com/mojavelinux[@mojavelinux]>; Robert Panzer <https://github.com/robertpanzer[@robertpanzer]>
 // Settings:
@@ -33,11 +34,14 @@ endif::[]
 ifdef::awestruct[:uri-docs: link:/docs]
 ifndef::awestruct[:uri-docs: https://asciidoctor.org/docs]
 :uri-asciidoctor: {uri-docs}/what-is-asciidoctor
-:uri-repo: https://github.com/asciidoctor/asciidoctorj
+:github-url: https://github.com/
+:uri-repo: {github-url}asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-zulip: https://asciidoctor.zulipchat.com/
 :artifact-version: 3.0.0-alpha.1
+:artifact-dev-version: 3.0.0-alpha.2-SNAPSHOT
 :api-version: 3.0.0-alpha.1
+:api-dev-version: 3.0.0-alpha.2-SNAPSHOT
 :asciidoctorj-epub3-version: 1.5.1
 :asciidoctorj-pdf-version: 2.3.7
 :maven-search: http://search.maven.org/
@@ -49,7 +53,7 @@ ifndef::awestruct[:uri-docs: https://asciidoctor.org/docs]
 :uri-maven-artifact-api-file: {maven-search}remotecontent?filepath=org/asciidoctor/asciidoctorj-api/{artifact-version}/asciidoctorj-api-{artifact-version}
 :uri-maven-guide: {uri-docs}/install-and-use-asciidoctor-maven-plugin
 :uri-gradle-guide: {uri-docs}/install-and-use-asciidoctor-gradle-plugin
-:uri-tilt: https://github.com/rtomayko/tilt
+:uri-tilt: {github-url}rtomayko/tilt
 :uri-font-awesome: http://fortawesome.github.io/Font-Awesome
 :uri-gradle: https://gradle.org
 :uri-chocolatey: https://chocolatey.org
@@ -60,7 +64,7 @@ Using AsciidoctorJ, you can convert AsciiDoc content or analyze the structure of
 You can find the documentation for integrating Asciidoctor in your JVM based language of choice at the https://docs.asciidoctor.org/asciidoctorj/latest/[Asciidoctor Docs site].
 
 ifdef::badges[]
-image:https://github.com/asciidoctor/asciidoctorj/workflows/Build%20Main/badge.svg?event=push[Build Status (Github Actions)]
+image:{github-url}asciidoctor/asciidoctorj/workflows/Build%20Main/badge.svg?event=push[Build Status (Github Actions)]
 image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg[project chat,link=https://asciidoctor.zulipchat.com/]
 endif::[]
 
@@ -100,6 +104,9 @@ The artifact information can be found in the tables below.
 |===
 
 CAUTION: The artifactId changed to `asciidoctorj` starting in 1.5.0.
+The latest version released in the repository may be an alpha version.
+You may consider using the latest stable version instead.
+The document you are currently reading describes the version {api-dev-version}.
 
 == Quick win: using the command line interface
 
@@ -342,7 +349,7 @@ TIP: We strongly recommend that you use Gradle via the https://www.timroes.de/20
 
 To clone the project, compile the source and build the artifacts (i.e., jars) locally, run:
 
- $ git clone https://github.com/asciidoctor/asciidoctorj
+ $ git clone {github-url}asciidoctor/asciidoctorj
    cd asciidoctorj
    ./gradlew assemble
 
@@ -390,7 +397,7 @@ Then, import the project into Eclipse using menu:File[Import,General,Existing Pr
 === Continuous integration
 
 Continuous integration for the AsciidoctorJ project is performed by GitHub Actions.
-You can find recent build results, including the build status of pull requests, on the https://github.com/asciidoctor/asciidoctorj/actions[asciidoctor/asciidoctorj] page.
+You can find recent build results, including the build status of pull requests, on the {github-url}asciidoctor/asciidoctorj/actions[asciidoctor/asciidoctorj] page.
 
 === Release and publish the artifacts
 

--- a/README.adoc.jam
+++ b/README.adoc.jam
@@ -3,11 +3,14 @@
 ////
 {%@rot13 Guvf vf n trarengrq svyr. QB ABG RQVG!!!!!
 Gb zbqvsl guvf svyr rqvg ERNQZR.nqbp.wnz va gur fnzr qverpgbel%}\
+{%@snip:properties gradle.properties%}
 {%@define VERSION_XPATH=//metadata/versioning/release%}\
+{%#define ASCIIDOCTORJ_VERSION={%@snip version%}%}\
+{%#define ASCIIDOCTORJ_API_VERSION={%@snip version%}%}\
 {%@snip:xml MVN_ASCIIDOCTORJ=https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctorj/maven-metadata.xml%}\
-{%#define ASCIIDOCTORJ_VERSION={%MVN_ASCIIDOCTORJ {%VERSION_XPATH%}%}%}\
+{%#define ASCIIDOCTORJ_LAST_RELEASE={%MVN_ASCIIDOCTORJ {%VERSION_XPATH%}%}%}\
 {%@snip:xml MVN_ASCIIDOCTORJ_API=https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctorj-api/maven-metadata.xml%}\
-{%#define ASCIIDOCTORJ_API_VERSION={%MVN_ASCIIDOCTORJ_API {%VERSION_XPATH%}%}%}\
+{%#define ASCIIDOCTORJ_API_LAST_RELEASE={%MVN_ASCIIDOCTORJ_API {%VERSION_XPATH%}%}%}\
 {%@snip:xml MVN_ASCIIDOCTORJ_EPUB3=https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctorj-epub3/maven-metadata.xml%}\
 {%#define ASCIIDOCTORJ_EPUB3_VERSION={%MVN_ASCIIDOCTORJ_EPUB3 {%VERSION_XPATH%}%}%}\
 {%@snip:xml MVN_ASCIIDOCTORJ_PDF=https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctorj-pdf/maven-metadata.xml%}\
@@ -43,11 +46,14 @@ endif::[]
 ifdef::awestruct[:uri-docs: link:/docs]
 ifndef::awestruct[:uri-docs: https://asciidoctor.org/docs]
 :uri-asciidoctor: {uri-docs}/what-is-asciidoctor
-:uri-repo: https://github.com/asciidoctor/asciidoctorj
+:github-url: https://github.com/
+:uri-repo: {github-url}asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-zulip: https://asciidoctor.zulipchat.com/
-:artifact-version: {%ASCIIDOCTORJ_VERSION%}
-:api-version: {%ASCIIDOCTORJ_API_VERSION%}
+:artifact-version: {%ASCIIDOCTORJ_LAST_RELEASE%}
+:artifact-dev-version: {%ASCIIDOCTORJ_VERSION%}
+:api-version: {%ASCIIDOCTORJ_API_LAST_RELEASE%}
+:api-dev-version: {%ASCIIDOCTORJ_API_VERSION%}
 :asciidoctorj-epub3-version: {%ASCIIDOCTORJ_EPUB3_VERSION%}
 :asciidoctorj-pdf-version: {%ASCIIDOCTORJ_PDF_VERSION%}
 :maven-search: http://search.maven.org/
@@ -59,7 +65,7 @@ ifndef::awestruct[:uri-docs: https://asciidoctor.org/docs]
 :uri-maven-artifact-api-file: {maven-search}remotecontent?filepath=org/asciidoctor/asciidoctorj-api/{artifact-version}/asciidoctorj-api-{artifact-version}
 :uri-maven-guide: {uri-docs}/install-and-use-asciidoctor-maven-plugin
 :uri-gradle-guide: {uri-docs}/install-and-use-asciidoctor-gradle-plugin
-:uri-tilt: https://github.com/rtomayko/tilt
+:uri-tilt: {github-url}rtomayko/tilt
 :uri-font-awesome: http://fortawesome.github.io/Font-Awesome
 :uri-gradle: https://gradle.org
 :uri-chocolatey: https://chocolatey.org
@@ -70,7 +76,7 @@ Using AsciidoctorJ, you can convert AsciiDoc content or analyze the structure of
 You can find the documentation for integrating Asciidoctor in your JVM based language of choice at the https://docs.asciidoctor.org/asciidoctorj/latest/[Asciidoctor Docs site].
 
 ifdef::badges[]
-image:https://github.com/asciidoctor/asciidoctorj/workflows/Build%20Main/badge.svg?event=push[Build Status (Github Actions)]
+image:{github-url}asciidoctor/asciidoctorj/workflows/Build%20Main/badge.svg?event=push[Build Status (Github Actions)]
 image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg[project chat,link=https://asciidoctor.zulipchat.com/]
 endif::[]
 
@@ -110,6 +116,9 @@ The artifact information can be found in the tables below.
 |===
 
 CAUTION: The artifactId changed to `asciidoctorj` starting in 1.5.0.
+The latest version released in the repository may be an alpha version.
+You may consider using the latest stable version instead.
+The document you are currently reading describes the version {api-dev-version}.
 
 == Quick win: using the command line interface
 
@@ -352,7 +361,7 @@ TIP: We strongly recommend that you use Gradle via the https://www.timroes.de/20
 
 To clone the project, compile the source and build the artifacts (i.e., jars) locally, run:
 
- $ git clone https://github.com/asciidoctor/asciidoctorj
+ $ git clone {github-url}asciidoctor/asciidoctorj
    cd asciidoctorj
    ./gradlew assemble
 
@@ -400,7 +409,7 @@ Then, import the project into Eclipse using menu:File[Import,General,Existing Pr
 === Continuous integration
 
 Continuous integration for the AsciidoctorJ project is performed by GitHub Actions.
-You can find recent build results, including the build status of pull requests, on the https://github.com/asciidoctor/asciidoctorj/actions[asciidoctor/asciidoctorj] page.
+You can find recent build results, including the build status of pull requests, on the {github-url}asciidoctor/asciidoctorj/actions[asciidoctor/asciidoctorj] page.
 
 === Release and publish the artifacts
 

--- a/README.adoc.jam
+++ b/README.adoc.jam
@@ -1,8 +1,18 @@
-
+{%@comment dual%}
 = AsciidoctorJ: Java bindings for Asciidoctor
 ////
-This is a generated file. DO NOT EDIT!!!!!
-To modify this file edit README.adoc.jam in the same directory
+{%@rot13 Guvf vf n trarengrq svyr. QB ABG RQVG!!!!!
+Gb zbqvsl guvf svyr rqvg ERNQZR.nqbp.wnz va gur fnzr qverpgbel%}\
+{%@define VERSION_XPATH=//metadata/versioning/release%}\
+{%@snip:xml MVN_ASCIIDOCTORJ=https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctorj/maven-metadata.xml%}\
+{%#define ASCIIDOCTORJ_VERSION={%MVN_ASCIIDOCTORJ {%VERSION_XPATH%}%}%}\
+{%@snip:xml MVN_ASCIIDOCTORJ_API=https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctorj-api/maven-metadata.xml%}\
+{%#define ASCIIDOCTORJ_API_VERSION={%MVN_ASCIIDOCTORJ_API {%VERSION_XPATH%}%}%}\
+{%@snip:xml MVN_ASCIIDOCTORJ_EPUB3=https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctorj-epub3/maven-metadata.xml%}\
+{%#define ASCIIDOCTORJ_EPUB3_VERSION={%MVN_ASCIIDOCTORJ_EPUB3 {%VERSION_XPATH%}%}%}\
+{%@snip:xml MVN_ASCIIDOCTORJ_PDF=https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctorj-pdf/maven-metadata.xml%}\
+{%#define ASCIIDOCTORJ_PDF_VERSION={%MVN_ASCIIDOCTORJ_PDF {%VERSION_XPATH%}%}%}\
+{%@define artifactQuery($X)={maven-search}#{%@urlencode search|ga|1|g:"org.asciidoctor" AND a:"asciidoctorj-api" AND v:"%}{artifact-version}{%@urlencode "%}%}
 ////
 Alex Soto <https://github.com/lordofthejars[@lordofthejars]>; Dan Allen <https://github.com/mojavelinux[@mojavelinux]>; Robert Panzer <https://github.com/robertpanzer[@robertpanzer]>
 // Settings:
@@ -36,16 +46,16 @@ ifndef::awestruct[:uri-docs: https://asciidoctor.org/docs]
 :uri-repo: https://github.com/asciidoctor/asciidoctorj
 :uri-issues: {uri-repo}/issues
 :uri-zulip: https://asciidoctor.zulipchat.com/
-:artifact-version: 3.0.0-alpha.1
-:api-version: 3.0.0-alpha.1
-:asciidoctorj-epub3-version: 1.5.1
-:asciidoctorj-pdf-version: 2.3.7
+:artifact-version: {%ASCIIDOCTORJ_VERSION%}
+:api-version: {%ASCIIDOCTORJ_API_VERSION%}
+:asciidoctorj-epub3-version: {%ASCIIDOCTORJ_EPUB3_VERSION%}
+:asciidoctorj-pdf-version: {%ASCIIDOCTORJ_PDF_VERSION%}
 :maven-search: http://search.maven.org/
-:uri-maven-artifact-query: {maven-search}#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22+AND+a%3A%22asciidoctorj-api%22+AND+v%3A%22{artifact-version}%22
+:uri-maven-artifact-query: {%artifactQuery /asciidoctorj%}
 :uri-maven-artifact-file: {maven-search}remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}
-:uri-maven-artifact-api-query: {maven-search}#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22+AND+a%3A%22asciidoctorj-api%22+AND+v%3A%22{artifact-version}%22
-:uri-maven-artifact-detail: {maven-search}%23artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
-:uri-maven-artifact-api-detail: {maven-search}%23artifactdetails%7Corg.asciidoctor%7Casciidoctorj-api%7C{artifact-version}%7Cjar
+:uri-maven-artifact-api-query: {%artifactQuery /asciidoctorj-api%}
+:uri-maven-artifact-detail: {maven-search}{%@urlencode #artifactdetails|org.asciidoctor|asciidoctorj|%}{artifact-version}{%@urlencode |jar%}
+:uri-maven-artifact-api-detail: {maven-search}{%@urlencode #artifactdetails|org.asciidoctor|asciidoctorj-api|%}{artifact-version}{%@urlencode |jar%}
 :uri-maven-artifact-api-file: {maven-search}remotecontent?filepath=org/asciidoctor/asciidoctorj-api/{artifact-version}/asciidoctorj-api-{artifact-version}
 :uri-maven-guide: {uri-docs}/install-and-use-asciidoctor-maven-plugin
 :uri-gradle-guide: {uri-docs}/install-and-use-asciidoctor-gradle-plugin

--- a/asciidoctorj-documentation/build.gradle
+++ b/asciidoctorj-documentation/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     testImplementation("org.asciidoctor:asciidoctorj-pdf:$asciidoctorjPdfVersion") {
         transitive = false
     }
+    testImplementation "com.javax0.jamal:jamal-all:$jamalVersion"
 }
 
 compileTestJava {

--- a/asciidoctorj-documentation/src/test/java/org/asciidoctor/ReadmeJamalConversionTest.java
+++ b/asciidoctorj-documentation/src/test/java/org/asciidoctor/ReadmeJamalConversionTest.java
@@ -1,0 +1,16 @@
+package org.asciidoctor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import javax0.jamal.DocumentConverter;
+
+public class ReadmeJamalConversionTest {
+
+    @Test
+    @DisplayName("Convert README.adoc.jam to README.adoc")
+    void generateDoc() throws Exception {
+
+        DocumentConverter.convert("../README.adoc.jam");
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ ext {
   saxonVersion = '9.9.0-2'
   xmlMatchersVersion = '1.0-RC1'
   pdfboxVersion = '1.8.16'
+  jamalVersion = '2.3.0-SNAPSHOT'
 
   // gem versions
   asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.20'

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
   saxonVersion = '9.9.0-2'
   xmlMatchersVersion = '1.0-RC1'
   pdfboxVersion = '1.8.16'
-  jamalVersion = '2.3.0-SNAPSHOT'
+  jamalVersion = '2.3.0'
 
   // gem versions
   asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.20'


### PR DESCRIPTION
## Documentation maintenance enhancement adding Jamal to the documentation toolset

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [X] Documentation update
- [X] Build improvement

## Description

### Goal

Adding this change to the build process, the documentation will automatically fetch and use the latest release.
Later the tool use can be gradually extended to reduce documentation and code redundancy, automatically pulling information from the documented source code into the documentation.

The pull request 

* adds Jamal as a test dependency to the toolset and 
* contains a test that converts the new `README.adoc.jam` file into `README.adoc`.
* It also moved the content of the `README.adoc` to `README.adoc.jam` and extended it with macros to fetch the versions automatically when the documentation is processed while editing in IntelliJ/AsciidocFX or during the build.

An alternative way could be to write some specific test that updates the documentation, but Jamal does it, and it is a powerful framework for the very purpose. I do not know any professional alternative. It is also possible to keep editing the pure Asciidoc without macros and invest the manual effort to keep the version numbers and other features in the documentation up to date, which was unsuccessful.

Adding this pull request will require document editors to know a bit of Jamal, which complicates the markup being a hyper markup above the Asciidoc markup.

## Release notes

Documentation processing is extended using Jamal.