### PR TITLE
Update to JRuby 9.4.3.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,7 +25,7 @@ Improvement::
 * Upgrade to asciidoctorj 2.0.20 (#1208)
 * Upgrade to asciidoctorj-pdf 2.3.7 (#1182)
 * Upgrade to asciidoctorj-diagram 2.2.7
-* Upgrade to JRuby 9.4.1.0 (#1141)
+* Upgrade to JRuby 9.4.3.0 (#1234)
 * Upgrade to tilt 2.0.11 (#1109)
 * Upgrade to asciimath 2.0.4 (#1109)
 * Expose `sectnum` property in Section interface (#1121)

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.82'
-  jrubyVersion = '9.4.1.0'
+  jrubyVersion = '9.4.3.0'
   jsoupVersion = '1.14.3'
   junit4Version = '4.13.2'
   junit5Version = '5.9.2'


### PR DESCRIPTION
JRuby 9.4.3.0 includes an updated Psych YAML library, which uses SnakeYAML-Engine and avoids several CVEs against the original SnakeYAML. By updating here, downstream users of asciidoctorj will not run into security audit issues.

See related issues and PRs:

* https://github.com/jruby/jruby/issues/7570
* https://github.com/jruby/jruby/pull/7600
* https://github.com/jruby/jruby/pull/7626
* https://github.com/jruby/jruby/issues/7935

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix (sorta, update JRuby to get away from false-ish CVEs in SnakeYAML)
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

* Update JRuby to get a version that does not use CVE-ridden SnakeYAML

How does it achieve that?

* Updates JRuby to 9.4.3.0

Are there any alternative ways to implement this?

* Not really

Are there any implications of this pull request? Anything a user must know?

* YAML compliance rises to 1.2, which may reject YAML that was valid in 1.0 or 1.1.

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc