### PR TITLE
Fixes #1237. -s CLI option should be changed to -e to align with Asci…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 Bug Fixes::
 
 * 'UnsupportedOperationException' when passing immutable Map as options to 'createPhraseNode' (#1221) (@abelsromero)
+* -s CLI option should be changed to -e to align with Asciidoctor (#1237) (@mojavelinux)
 
 Improvement::
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,10 +13,28 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 == Unreleased
 
+=== Breaking changes
+
 Improvement::
 
-* BREAKING: Fix Macro APIs to take StructuralNodes and return Phrase- or StructuralNodes. (#1084)
-* BREAKING: Allow Preprocessor extensions to create new Readers and replace the original Reader. (#1081)
+* Fix Macro APIs to take StructuralNodes and return Phrase- or StructuralNodes. (#1084)
+* Allow Preprocessor extensions to create new Readers and replace the original Reader. (#1081)
+* Set Java 11 as the minimal version (#1151) (@abelsromero)
+* Remove deprecated methods in Options, OptionsBuilder, Attributes & AttributesBuilder (#1199) (@abelsromero)
+* Remove deprecated methods from Asciidoctor interface (#1201) (@abelsromero)
+* Remove deprecated methods from Document interface (#1202) (@abelsromero)
+* Remove deprecated methods and constants from extension package (#1203) (@abelsromero)
+* Remove deprecated methods from ast package (#1204) (@abelsromero)
+
+Bug Fixes::
+
+* Fix CLI target file location for source files relative to source dir (#1135) (@AlexCzar)
+* -s CLI option should be changed to -e to align with Asciidoctor (#1237) (@mojavelinux)
+
+=== Compatible changes
+
+Improvement::
+
 * Add command line option --failure-level to force non-zero exit code from AsciidoctorJ CLI if specified logging level is reached. (#1114)
 * Upgrade to asciidoctorj 2.0.20 (#1208)
 * Upgrade to asciidoctorj-pdf 2.3.7 (#1182)
@@ -28,7 +46,6 @@ Improvement::
 * Replace use of deprecated 'numbered' attribute by 'sectnums' (#1123) (@abelsromero)
 * Expose `source` and `source_lines` use of deprecated 'numbered' in Document interface (#1145) (@abelsromero)
 * Accept 'null' as valid input (same as empty string) for load and convert String methods (#1148) (@abelsromero)
-* Set Java 11 as the minimal version (#1151) (@abelsromero)
 * Create `asciidoctorj-cli` module to prevent unnecessary dependencies to asciidoctorj jar consumers (#1149)
 * Add required `--add-opens` to cli launch script to remove Jdk warnings (#1155) (@abelsromero)
 * Rename deprecated `headerFooter` option to the new `standalone` with same functionality (#1155) (@abelsromero)
@@ -36,21 +53,14 @@ Improvement::
 * Expose ImageReferences in the catalog (#1166) (@abelsromero)
 * Return Document AST when using convert or convertFile with appropriate options (#1171) (@abelsromero)
 * Expose Links in the catalog (#1183) (@abelsromero)
-* BREAKING: Remove deprecated methods in Options, OptionsBuilder, Attributes & AttributesBuilder (#1199) (@abelsromero)
-* BREAKING: Remove deprecated methods from Asciidoctor interface (#1201) (@abelsromero)
-* BREAKING: Remove deprecated methods from Document interface (#1202) (@abelsromero)
-* BREAKING: Remove deprecated methods and constants from extension package (#1203) (@abelsromero)
-* BREAKING: Remove deprecated methods from ast package (#1204) (@abelsromero)
 
 Bug Fixes::
 
-* BREAKING: Fix CLI target file location for source files relative to source dir (#1135) (@AlexCzar)
 * Cell nodes do not inherit from StructuralNode (#1086) (@rahmanusta)
 * Avoid throwing an exception when using AsciidoctorJ CLI and reading input from stdin (#1105) (@AlexCzar)
 * Remove destinationDir Option from API (use toDir instead) (#853, #941) (@abelsromero)
 * Fix ConcurrentModificationException when converting to stream concurrently (#1158) (@rocketraman)
 * 'UnsupportedOperationException' when passing immutable Map as options to 'createPhraseNode' (#1221) (@abelsromero)
-* -s CLI option should be changed to -e to align with Asciidoctor (#1237) (@mojavelinux)
 
 Build Improvement::
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,11 +13,6 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 == Unreleased
 
-Bug Fixes::
-
-* 'UnsupportedOperationException' when passing immutable Map as options to 'createPhraseNode' (#1221) (@abelsromero)
-* -s CLI option should be changed to -e to align with Asciidoctor (#1237) (@mojavelinux)
-
 Improvement::
 
 * BREAKING: Fix Macro APIs to take StructuralNodes and return Phrase- or StructuralNodes. (#1084)
@@ -54,6 +49,8 @@ Bug Fixes::
 * Avoid throwing an exception when using AsciidoctorJ CLI and reading input from stdin (#1105) (@AlexCzar)
 * Remove destinationDir Option from API (use toDir instead) (#853, #941) (@abelsromero)
 * Fix ConcurrentModificationException when converting to stream concurrently (#1158) (@rocketraman)
+* 'UnsupportedOperationException' when passing immutable Map as options to 'createPhraseNode' (#1221) (@abelsromero)
+* -s CLI option should be changed to -e to align with Asciidoctor (#1237) (@mojavelinux)
 
 Build Improvement::
 

--- a/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
@@ -24,9 +24,9 @@ public class AsciidoctorCliOptions {
     public static final String TEMPLATE_DIR = "-T";
     public static final String TEMPLATE_ENGINE = "-E";
     public static final String COMPACT = "-C";
-    public static final String ERUBY = "-e";
-    public static final String SECTION_NUMBERS = "-n";
+    public static final String EMBEDDED = "-e";
     public static final String NO_HEADER_FOOTER = "-s";
+    public static final String SECTION_NUMBERS = "-n";
     public static final String SAFE = "-S";
     public static final String OUTFILE = "-o";
     public static final String DOCTYPE = "-d";
@@ -37,16 +37,16 @@ public class AsciidoctorCliOptions {
     public static final char ATTRIBUTE_SEPARATOR = '=';
     public static final String TIMINGS_OPTION_NAME = "timings";
 
-    @Parameter(names = {VERBOSE, "--verbose"}, description = "enable verbose mode (default: false)")
+    @Parameter(names = {VERBOSE, "--verbose"}, description = "enable verbose mode")
     private boolean verbose = false;
 
-    @Parameter(names = {TIMINGS, "--timings"}, description = "enable timings mode (default: false)")
+    @Parameter(names = {TIMINGS, "--timings"}, description = "enable timings mode")
     private boolean timings = false;
 
     @Parameter(names = {VERSION, "--version"}, description = "display the version and runtime environment")
     private boolean version = false;
 
-    @Parameter(names = {BACKEND, "--backend"}, description = "set output format backend (default: html5)")
+    @Parameter(names = {BACKEND, "--backend"}, description = "set output format backend")
     private String backend = "html5";
 
     @Parameter(names = {DOCTYPE, "--doctype"}, description = "document type to use when rendering output: [article, book, inline] (default: article)")
@@ -61,16 +61,19 @@ public class AsciidoctorCliOptions {
     @Parameter(names = {SAFE, "--safe-mode"}, converter = SafeModeConverter.class, description = "set safe mode level explicitly: [unsafe, safe, server, secure] (default: unsafe)")
     private SafeMode safeMode = SafeMode.UNSAFE;
 
-    @Parameter(names = {NO_HEADER_FOOTER, "--no-header-footer"}, description = "suppress output of header and footer (default: false)")
+    @Parameter(names = {NO_HEADER_FOOTER, "--no-header-footer"}, description = "suppress output of header and footer")
     private boolean noHeaderFooter = false;
+
+    @Parameter(names = {EMBEDDED, "--embedded"}, description = "suppress enclosing document structure and output an embedded document")
+    private boolean embedded = false;
 
     @Parameter(names = {SECTION_NUMBERS, "--section-numbers"}, description = "auto-number section titles; disabled by default")
     private boolean sectionNumbers = false;
 
-    @Parameter(names = {ERUBY, "--eruby"}, description = "specify eRuby implementation to render built-in templates: [erb, erubis] (default: erb)")
+    @Parameter(names = {"--eruby"}, description = "specify eRuby implementation to render built-in templates: [erb, erubis]")
     private String eruby = "erb";
 
-    @Parameter(names = {COMPACT, "--compact"}, description = "compact the output by removing blank lines (default: false)")
+    @Parameter(names = {COMPACT, "--compact"}, description = "compact the output by removing blank lines")
     private boolean compact = false;
 
     @Parameter(names = {TEMPLATE_ENGINE, "--template-engine"}, description = "template engine to use for the custom render templates (loads gem on demand)")
@@ -88,7 +91,7 @@ public class AsciidoctorCliOptions {
     @Parameter(names = {SOURCE_DIR, "--source-dir"}, description = "source directory (requires destination directory)")
     private String sourceDir;
 
-    @Parameter(names = {"--trace"}, description = "include backtrace information on errors (default: false)")
+    @Parameter(names = {"--trace"}, description = "include backtrace information on errors")
     private boolean trace = false;
 
     @Parameter(names = {HELP, "--help"}, help = true, description = "show this message")
@@ -97,10 +100,10 @@ public class AsciidoctorCliOptions {
     @Parameter(names = {ATTRIBUTE, "--attribute"}, description = "a list of attributes, in the form key or key=value pair, to set on the document")
     private List<String> attributes = new ArrayList<>();
 
-    @Parameter(names = {QUIET, "--quiet"}, description = "suppress warnings (default: false)")
+    @Parameter(names = {QUIET, "--quiet"}, description = "suppress warnings")
     private boolean quiet = false;
 
-    @Parameter(names = {"--failure-level"}, converter = SeverityConverter.class, description = "set minimum log level that yields a non-zero exit code: [info, warning, error, fatal] (default: fatal) ")
+    @Parameter(names = {"--failure-level"}, converter = SeverityConverter.class, description = "set minimum log level that yields a non-zero exit code.")
     private Severity failureLevel = Severity.FATAL;
 
     @Parameter(names = {REQUIRE, "--require"}, description = "require the specified library before executing the processor (using require)")
@@ -293,6 +296,10 @@ public class AsciidoctorCliOptions {
             optionsBuilder.safe(SafeMode.SAFE);
         }
 
+        if (this.embedded) {
+            optionsBuilder.option(Options.STANDALONE, false);
+        }
+
         if (this.noHeaderFooter) {
             optionsBuilder.option(Options.STANDALONE, false);
         }
@@ -368,7 +375,7 @@ public class AsciidoctorCliOptions {
     }
 
     private static boolean isEmpty(String path) {
-        return path == null || path.trim().length() == 0;
+        return path == null || path.trim().isEmpty();
     }
 
 }


### PR DESCRIPTION
…idoctor

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Fix #1237 and change the command line option `-e` so that it creates an embedded document instead of selecting eRuby.

How does it achieve that?

Add a new cli option `--embedded` with the short key `-e`.
Change `--eruby` so that it doesn't have any short key.

Are there any alternative ways to implement this?

Likely not.

Are there any implications of this pull request? Anything a user must know?

I also removed the explicit mentionings of the defaults in the argument descriptions, since jcommander also shows the defaults, e.g.,:
```
    -e, --embedded
      suppress enclosing document structure and output an embedded document
      Default: false
    --eruby
      specify eRuby implementation to render built-in templates: [erb, erubis]
      Default: erb
```

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1237

