### PR TITLE
Reserve stable module names for future JPMS modularization

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ Improvement::
 * Remove deprecated methods from Document interface (#1202) (@abelsromero)
 * Remove deprecated methods and constants from extension package (#1203) (@abelsromero)
 * Remove deprecated methods from ast package (#1204) (@abelsromero)
+* Add Automatic-Module-Name manifest entry to core, api, and cli for reserving stable JPMS module names (#1240) (@leadpony)
 
 Bug Fixes::
 

--- a/asciidoctorj-api/build.gradle
+++ b/asciidoctorj-api/build.gradle
@@ -11,6 +11,11 @@ jar {
     ('Bundle-Name'): 'asciidoctorj-api',
     ('Bundle-SymbolicName'): 'org.asciidoctor.asciidoctorj-api',
   )
+  manifest {
+    attributes(
+      'Automatic-Module-Name': 'org.asciidoctor.asciidoctorj.api'
+    )
+  }
 }
 
 ext.publicationName = "mavenAsciidoctorJApi"

--- a/asciidoctorj-cli/build.gradle
+++ b/asciidoctorj-cli/build.gradle
@@ -23,5 +23,10 @@ jar {
     ('Bundle-SymbolicName'): 'org.asciidoctor.asciidoctorj-cli',
     ('Import-Package'): 'com.beust.jcommander;resolution:=optional, *'
   )
+  manifest {
+    attributes(
+      'Automatic-Module-Name': 'org.asciidoctor.asciidoctorj.cli'
+    )
+  }
   metaInf { from "$buildDir/version-info/" }
 }

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -91,6 +91,11 @@ jar {
     ('Bundle-Name'): 'asciidoctorj',
     ('Bundle-SymbolicName'): 'org.asciidoctor.asciidoctorj'
   )
+  manifest {
+    attributes(
+      'Automatic-Module-Name': 'org.asciidoctor.asciidoctorj'
+    )
+  }
   metaInf { from "$buildDir/version-info/" }
 }
 


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [x] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

The module names I picked are in accordance with those of OSGi bundles.
If you don't like the names, I will change them.

## Issue

Fixes #1239 

## Release notes

I added a line to CHANGELOG.adoc.
