### PR TITLE
Fixes #1230. Add test to make sure Asciidoctor version is returned wh…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,7 +29,6 @@ Improvement::
 
 Bug Fixes::
 
-* Fix CLI target file location for source files relative to source dir (#1135) (@AlexCzar)
 * -s CLI option should be changed to -e to align with Asciidoctor (#1237) (@mojavelinux)
 
 === Compatible changes
@@ -60,6 +59,7 @@ Bug Fixes::
 * Cell nodes do not inherit from StructuralNode (#1086) (@rahmanusta)
 * Avoid throwing an exception when using AsciidoctorJ CLI and reading input from stdin (#1105) (@AlexCzar)
 * Remove destinationDir Option from API (use toDir instead) (#853, #941) (@abelsromero)
+* Fix CLI target file location for source files relative to source dir (#1135) (@AlexCzar)
 * Fix ConcurrentModificationException when converting to stream concurrently (#1158) (@rocketraman)
 * 'UnsupportedOperationException' when passing immutable Map as options to 'createPhraseNode' (#1221) (@abelsromero)
 
@@ -73,6 +73,7 @@ Build Improvement::
 * Set JUnit5 as default test engine (#1186) (@abelsromero)
 * Removed pollutedTest Gradle task using junit-pioneer (#1193) (@abelsromero)
 * Ignore 'docs/**' changes in CI (#1225) (@abelsromero)
+* Add test for ensuring that asciidoctor version is available in CLI (#1230) (@abelsromero)
 
 Documentation::
 

--- a/asciidoctorj-cli/build.gradle
+++ b/asciidoctorj-cli/build.gradle
@@ -28,5 +28,4 @@ jar {
       'Automatic-Module-Name': 'org.asciidoctor.asciidoctorj.cli'
     )
   }
-  metaInf { from "$buildDir/version-info/" }
 }

--- a/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/jruby/AsciidoctorInvoker.java
+++ b/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/jruby/AsciidoctorInvoker.java
@@ -90,9 +90,6 @@ public class AsciidoctorInvoker {
 
     private String getAsciidoctorJVersion() {
         InputStream in = getClass().getResourceAsStream("/META-INF/asciidoctorj-version.properties");
-        if (in == null) {
-            return "N/A";
-        }
         Properties versionProps = new Properties();
         try {
             versionProps.load(in);

--- a/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -283,9 +283,14 @@ public class WhenAsciidoctorIsCalledUsingCli {
             System.setOut(sysout);
             new AsciidoctorInvoker().invoke("--version");
             String result = out.toString(StandardCharsets.UTF_8);
+            String expected = System.getProperty("org.asciidoctor.asciidoctorj-test.version.asciidoctorj");
+            Assertions.assertThat(expected)
+                    .as("Bad test setup, could not determine expected Asciidoctor version")
+                    .isNotEmpty();
+            expected = expected.replace("-SNAPSHOT", "");
             Assertions.assertThat(result)
                     // Needs to be updated when version changes
-                    .contains("2.0.20");
+                    .contains(expected);
         } finally {
             System.setOut(previousSystemOut);
         }

--- a/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -279,7 +279,7 @@ public class WhenAsciidoctorIsCalledUsingCli {
     void should_print_version() throws IOException {
         PrintStream previousSystemOut = System.out;
         try (ByteArrayOutputStream out = new ByteArrayOutputStream();
-            PrintStream sysout = new PrintStream(out)){
+             PrintStream sysout = new PrintStream(out)) {
             System.setOut(sysout);
             new AsciidoctorInvoker().invoke("--version");
             String result = out.toString(StandardCharsets.UTF_8);
@@ -289,7 +289,6 @@ public class WhenAsciidoctorIsCalledUsingCli {
                     .isNotEmpty();
             expected = expected.replace("-SNAPSHOT", "");
             Assertions.assertThat(result)
-                    // Needs to be updated when version changes
                     .contains(expected);
         } finally {
             System.setOut(previousSystemOut);

--- a/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.hamcrest.CoreMatchers.is;
@@ -273,6 +274,23 @@ public class WhenAsciidoctorIsCalledUsingCli {
         assertThat(expectedFile.exists(), is(true));
         expectedFile.delete();
     }
+
+    @Test
+    void should_print_version() throws IOException {
+        PrintStream previousSystemOut = System.out;
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+            PrintStream sysout = new PrintStream(out)){
+            System.setOut(sysout);
+            new AsciidoctorInvoker().invoke("--version");
+            String result = out.toString(StandardCharsets.UTF_8);
+            Assertions.assertThat(result)
+                    // Needs to be updated when version changes
+                    .contains("2.0.20");
+        } finally {
+            System.setOut(previousSystemOut);
+        }
+    }
+
 
     private ByteArrayOutputStream redirectStdout() {
         ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/asciidoctorj-core/build.gradle
+++ b/asciidoctorj-core/build.gradle
@@ -86,6 +86,20 @@ javadoc {
   source(project(':asciidoctorj-api').sourceSets.main.allJava)
 }
 
+task createVersionFile {
+  inputs.property('version.asciidoctor', asciidoctorGemVersion)
+  inputs.property('version.asciidoctorj', project.version)
+  outputs.dir("${buildDir}/version-info")
+
+  doLast {
+    file("${buildDir}/version-info/asciidoctorj-version.properties", ).text = """
+version.asciidoctorj: ${project.version}
+version.asciidoctor: $asciidoctorGemVersion
+"""
+  }
+}
+
+
 jar {
   bnd(
     ('Bundle-Name'): 'asciidoctorj',
@@ -96,24 +110,12 @@ jar {
       'Automatic-Module-Name': 'org.asciidoctor.asciidoctorj'
     )
   }
-  metaInf { from "$buildDir/version-info/" }
+  metaInf {
+    from createVersionFile
+  }
 }
 
 test {
   useJUnitPlatform()
 }
 
-task createVersionFile {
-  inputs.property('version.asciidoctor', asciidoctorGemVersion)
-  inputs.property('version.asciidoctorj', project.version)
-  outputs.dir("$buildDir/version-info")
-
-  doLast {
-    file("$buildDir/version-info/asciidoctorj-version.properties").text = """
-version.asciidoctorj: ${project.version}
-version.asciidoctor: $asciidoctorGemVersion
-"""
-  }
-}
-
-jar.dependsOn createVersionFile

--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,7 @@ subprojects {
       // Allow junit-pioneer environment manipulation on Windows + Java17+
       jvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED']
     }
+    systemProperty 'org.asciidoctor.asciidoctorj-test.version.asciidoctorj', asciidoctorGemVersion
   }
 
 }


### PR DESCRIPTION
…en using --version

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

This PR fixes #1230.
#1230 mentioned that we have a fallback when returning the version of the packaged Asciidoctor version.
This PR removes that fallback and would fail hard with a NullPointerException if the generated file containing the version numbers is not available.
Additionally a test makes sure that the generated file is available.

How does it achieve that?

Remove the fallback, and enhance the tests.

Are there any alternative ways to implement this?

We could search the class path for the asciidoctor gemspec and parse that, or maybe call some API exposed by JRuby to query the gems (or a Ruby-native API).

Are there any implications of this pull request? Anything a user must know?

No, everything should work as before.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1230 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc