### PR TITLE
CLI should set :mkdirs option by default (#1241)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,10 @@ Improvement::
 
 * Upgrade to JRuby 9.4.3.0 (#1235) (@headius)
 
+Bug Fixes::
+
+* CLI should set :mkdirs option by default (#1241) (@mojavelinux)
+
 == 2.5.10 (2023-06-04)
 
 Improvement::

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/cli/AsciidoctorInvoker.java
@@ -160,6 +160,8 @@ public class AsciidoctorInvoker {
             return;
         }
 
+        options.setMkDirs(true);
+
         findInvalidInputFile(inputFiles)
                 .ifPresent(inputFile -> {
                     System.err.println("asciidoctor: FAILED: input file(s) '"

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -20,6 +20,8 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 public class WhenAsciidoctorIsCalledUsingCli {
@@ -274,6 +276,22 @@ public class WhenAsciidoctorIsCalledUsingCli {
         File expectedFile = new File(inputPath.replaceFirst("\\.asciidoc$", ".html"));
 
         assertThat(expectedFile.exists(), is(true));
+        expectedFile.delete();
+    }
+
+    @Test
+    public void should_convert_to_subdirectories() throws IOException {
+
+        File inputFile = classpath.getResource("relative/sub/test.adoc");
+        File srcDir = inputFile.getParentFile().getParentFile(); // points to relative/
+        File toDir = new File(temporaryFolder.getRoot(), getClass().getSimpleName());
+        File expectedFile = new File(toDir, "test.html");
+        assertFalse(toDir.exists());
+
+        new AsciidoctorInvoker().invoke("-R", srcDir.getPath(), "-D", toDir.getPath(), srcDir.getAbsolutePath() + "/**/*.adoc");
+        // Note that the subdirectory /sub is ignored, other than what asciidoctor does with it.
+
+        assertTrue(expectedFile.exists());
         expectedFile.delete();
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/cli/WhenAsciidoctorIsCalledUsingCli.java
@@ -280,7 +280,7 @@ public class WhenAsciidoctorIsCalledUsingCli {
     }
 
     @Test
-    public void should_convert_to_subdirectories() throws IOException {
+    public void should_create_targetdir() {
 
         File inputFile = classpath.getResource("relative/sub/test.adoc");
         File srcDir = inputFile.getParentFile().getParentFile(); // points to relative/
@@ -288,7 +288,7 @@ public class WhenAsciidoctorIsCalledUsingCli {
         File expectedFile = new File(toDir, "test.html");
         assertFalse(toDir.exists());
 
-        new AsciidoctorInvoker().invoke("-R", srcDir.getPath(), "-D", toDir.getPath(), srcDir.getAbsolutePath() + "/**/*.adoc");
+        new AsciidoctorInvoker().invoke("-R", srcDir.getPath(), "-D", toDir.getPath(), srcDir.getAbsolutePath() + "/sub/test.adoc");
         // Note that the subdirectory /sub is ignored, other than what asciidoctor does with it.
 
         assertTrue(expectedFile.exists());

--- a/asciidoctorj-core/src/test/resources/relative/sub/test.adoc
+++ b/asciidoctorj-core/src/test/resources/relative/sub/test.adoc
@@ -1,0 +1,5 @@
+= Test
+
+ == Test
+
+ Test


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Make the CLI set the :mkdirs option.

How does it achieve that?

Similar to the implementation of Asciidoctor it sets the option :mkdirs if the input is not read from stdin.

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

Fixes #1241 

