### PR TITLE
(2.5.x) Bump java 19 to 21

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -24,6 +24,7 @@ jobs:
           - '8'
           - '11'
           - '17'
+          - '21'
         os:
           - ubuntu-latest
           - macos-latest
@@ -51,6 +52,7 @@ jobs:
         java:
           - '11'
           - '17'
+          - '21'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -79,6 +81,7 @@ jobs:
         java:
           - '11'
           - '17'
+          - '21'
         os:
           - ubuntu-latest
         maven:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,10 @@ Bug Fixes::
 
 * CLI should set :mkdirs option by default (#1241) (@mojavelinux)
 
+Build improvement::
+
+* Run tests on Java 21 (#1245) (@abelsromero)
+
 == 2.5.10 (2023-06-04)
 
 Improvement::


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Ensure v2.5.x is tested on Java 21.

How does it achieve that?

Add Java 21 to CI.

Are there any alternative ways to implement this?

No. I went with absolute minimal changes here. No Gradle, SpringBoot (test) neither.
On Boot, v2.7 is out of support already, but we already test newer version in main branch.

Are there any implications of this pull request? Anything a user must know?

no

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc