### PR TITLE
Bump JRuby to v9.4.5.0 (fixes #1035)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ Improvement::
 * Remove deprecated methods and constants from extension package (#1203) (@abelsromero)
 * Remove deprecated methods from ast package (#1204) (@abelsromero)
 * Add Automatic-Module-Name manifest entry to core, api, and cli for reserving stable JPMS module names (#1240) (@leadpony)
+* Remove Java 'requires open access' module warning in modern Java versions (#1246)
 
 Bug Fixes::
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.82'
-  jrubyVersion = '9.4.3.0'
+  jrubyVersion = '9.4.5.0'
   jsoupVersion = '1.14.3'
   junit4Version = '4.13.2'
   junit5Version = '5.9.2'


### PR DESCRIPTION
## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Fix issue #1035 as commented https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/553#issuecomment-1793240139

How does it achieve that?

Yes, validated in maven runs and also building a custom distribution of AsciidoctorJ.

Are there any alternative ways to implement this?

n/a

Are there any implications of this pull request? Anything a user must know?

The only thing is that there's still another warning for Java > 13. But we can treat it in a separated PR.

```
OpenJDK 64-Bit Client VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release
```

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1035

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc