### PR TITLE
Try to fix CLI

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -6,12 +6,13 @@ import java.util.*;
 /**
  * AsciidoctorJ conversion options.
  * <p>
- * See https://docs.asciidoctor.org/asciidoctor/latest/api/options/ for further
+ * See <a href="https://docs.asciidoctor.org/asciidoctor/latest/api/options/">https://docs.asciidoctor.org/asciidoctor/latest/api/options/</a> for further
  * details.
  */
 public class Options {
 
     public static final String IN_PLACE = "in_place";
+    public static final String WARNINGS = "warnings";
     public static final String ATTRIBUTES = "attributes";
     public static final String TEMPLATE_DIRS = "template_dirs";
     public static final String TEMPLATE_ENGINE = "template_engine";
@@ -24,10 +25,10 @@ public class Options {
     public static final String ERUBY = "eruby";
     public static final String CATALOG_ASSETS = "catalog_assets";
     public static final String COMPACT = "compact";
-    public static final String SOURCE_DIR = "source_dir";
     public static final String BACKEND = "backend";
     public static final String DOCTYPE = "doctype";
     public static final String BASEDIR = "base_dir";
+    public static final String TRACE = "trace";
     public static final String TEMPLATE_CACHE = "template_cache";
     public static final String SOURCE = "source";
     public static final String PARSE = "parse";
@@ -158,10 +159,6 @@ public class Options {
 
     public void setCompact(boolean compact) {
         this.options.put(COMPACT, compact);
-    }
-
-    public void setSourceDir(String srcDir) {
-        this.options.put(SOURCE_DIR, srcDir);
     }
 
     public void setBackend(String backend) {

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
@@ -2,7 +2,6 @@ package org.asciidoctor;
 
 import java.io.File;
 import java.io.OutputStream;
-import java.util.Map;
 
 /**
  * Fluent Options API for AsciidoctorJ.
@@ -160,7 +159,7 @@ public class OptionsBuilder {
      * @return this instance.
      */
     public OptionsBuilder toDir(File directory) {
-        this.options.setToDir(directory.getAbsolutePath());
+        this.options.setToDir(directory.getPath());
         return this;
     }
 
@@ -266,20 +265,6 @@ public class OptionsBuilder {
     }
 
     /**
-     * Source directory.
-     *
-     * This must be used alongside {@link #toDir(File)}.
-     *
-     * @param srcDir
-     *            source directory.
-     * @return this instance.
-     */
-    public OptionsBuilder sourceDir(File srcDir) {
-        this.options.setSourceDir(srcDir.getAbsolutePath());
-        return this;
-    }
-
-    /**
      * Sets a custom or unlisted option.
      * 
      * @param option
@@ -301,7 +286,7 @@ public class OptionsBuilder {
      * @return this instance.
      */
     public OptionsBuilder baseDir(File baseDir) {
-        this.options.setBaseDir(baseDir.getAbsolutePath());
+        this.options.setBaseDir(baseDir.getPath());
         return this;
     }
 

--- a/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
@@ -1,7 +1,10 @@
 package org.asciidoctor.cli;
 
 import com.beust.jcommander.Parameter;
-import org.asciidoctor.*;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.Options;
+import org.asciidoctor.SafeMode;
 import org.asciidoctor.log.Severity;
 
 import java.io.File;
@@ -9,6 +12,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 public class AsciidoctorCliOptions {
@@ -16,6 +20,7 @@ public class AsciidoctorCliOptions {
     public static final String LOAD_PATHS = "-I";
     public static final String REQUIRE = "-r";
     public static final String QUIET = "-q";
+    public static final String WARNINGS = "-w";
     public static final String ATTRIBUTE = "-a";
     public static final String HELP = "-h";
     public static final String DESTINATION_DIR = "-D";
@@ -47,7 +52,7 @@ public class AsciidoctorCliOptions {
     private boolean version = false;
 
     @Parameter(names = {BACKEND, "--backend"}, description = "set output format backend")
-    private String backend = "html5";
+    private String backend;
 
     @Parameter(names = {DOCTYPE, "--doctype"}, description = "document type to use when rendering output: [article, book, inline] (default: article)")
     private String doctype;
@@ -70,8 +75,8 @@ public class AsciidoctorCliOptions {
     @Parameter(names = {SECTION_NUMBERS, "--section-numbers"}, description = "auto-number section titles; disabled by default")
     private boolean sectionNumbers = false;
 
-    @Parameter(names = {"--eruby"}, description = "specify eRuby implementation to render built-in templates: [erb, erubis]")
-    private String eruby = "erb";
+    @Parameter(names = {"--eruby"}, description = "specify eRuby implementation to render built-in templates: [erb, erubis]; default erb")
+    private String eruby;
 
     @Parameter(names = {COMPACT, "--compact"}, description = "compact the output by removing blank lines")
     private boolean compact = false;
@@ -102,6 +107,9 @@ public class AsciidoctorCliOptions {
 
     @Parameter(names = {QUIET, "--quiet"}, description = "suppress warnings")
     private boolean quiet = false;
+
+    @Parameter(names = {WARNINGS, "--warnings"}, description = "suppress warnings")
+    private boolean warnings = false;
 
     @Parameter(names = {"--failure-level"}, converter = SeverityConverter.class, description = "set minimum log level that yields a non-zero exit code.")
     private Severity failureLevel = Severity.FATAL;
@@ -266,80 +274,64 @@ public class AsciidoctorCliOptions {
         return !isOutFileOption() && !isDestinationDirOption() && !isOutputStdout();
     }
 
-    public Options parse() throws IOException {
-        OptionsBuilder optionsBuilder = Options.builder()
-                .backend(this.backend)
-                .safe(this.safeMode)
-                .eruby(this.eruby)
-                .option(Options.STANDALONE, true);
+    public Map<String, Object> parse() throws IOException {
 
-        if (isDoctypeOption()) {
-            optionsBuilder.docType(this.doctype);
+        Options opts = Options.builder().build();
+        Attributes attributes = buildAttributes();
+
+        opts.setOption(Options.STANDALONE, true);
+        opts.setOption(Options.WARNINGS, false);
+
+
+        if (this.backend != null) {
+            opts.setBackend(this.backend);
         }
-
-        if (isInputStdin()) {
-            optionsBuilder.toStream(System.out);
-            if (outFile == null) {
-                outFile = "-";
-            }
+        if (this.doctype != null) {
+            opts.setDocType(this.doctype);
         }
-
-        if (isOutFileOption() && !isOutputStdout()) {
-            optionsBuilder.toFile(new File(this.outFile));
-        }
-
-        if (isOutputStdout()) {
-            optionsBuilder.toStream(System.out);
-        }
-
-        if (this.safe) {
-            optionsBuilder.safe(SafeMode.SAFE);
-        }
-
         if (this.embedded) {
-            optionsBuilder.option(Options.STANDALONE, false);
+            opts.setOption(Options.STANDALONE, false);
         }
-
+        if (this.outFile != null) {
+            opts.setToFile(this.outFile);
+        }
+        if (this.safe) {
+            opts.setSafe(SafeMode.SAFE);
+        }
+        if (this.safeMode != null) {
+            opts.setSafe(this.safeMode);
+        }
         if (this.noHeaderFooter) {
-            optionsBuilder.option(Options.STANDALONE, false);
+            opts.setOption(Options.STANDALONE, false);
         }
-
-        if (this.compact) {
-            optionsBuilder.compact(this.compact);
-        }
-
-        if (isBaseDirOption()) {
-            optionsBuilder.baseDir(new File(this.baseDir).getCanonicalFile());
-        }
-
-        if (isTemplateEngineOption()) {
-            optionsBuilder.templateEngine(this.templateEngine);
-        }
-
-        if (isTemplateDirOption()) {
-            for (String templateDir : this.templateDir) {
-                optionsBuilder.templateDirs(new File(templateDir).getCanonicalFile());
-            }
-        }
-
-        if (isDestinationDirOption() && !isOutputStdout()) {
-            optionsBuilder.toDir(new File(this.destinationDir).getCanonicalFile());
-
-            if (isSourceDirOption()) {
-                optionsBuilder.sourceDir(new File(this.sourceDir).getCanonicalFile());
-            }
-        }
-
-        if (isInPlaceRequired()) {
-            optionsBuilder.inPlace(true);
-        }
-
-        Attributes attributesBuilder = buildAttributes();
         if (this.sectionNumbers) {
-            attributesBuilder.setSectionNumbers(this.sectionNumbers);
+            attributes.setAttribute("sectnums", "");
         }
-        optionsBuilder.attributes(attributesBuilder);
-        return optionsBuilder.build();
+        if (this.eruby != null) {
+            opts.setEruby(this.eruby);
+        }
+        if (isTemplateDirOption()) {
+            opts.setTemplateDirs(this.templateDir.toArray(new String[0]));
+        }
+        if (isTemplateEngineOption()) {
+            opts.setTemplateEngine(this.templateEngine);
+        }
+        if (this.baseDir != null) {
+            opts.setBaseDir(this.baseDir);
+        }
+        if (this.destinationDir != null) {
+            opts.setOption(Options.TO_DIR, this.destinationDir);
+        }
+        if (this.trace) {
+            opts.setOption(Options.TRACE, true);
+        }
+        if (this.warnings) {
+            opts.setOption(Options.WARNINGS, true);
+        }
+        if (!attributes.map().isEmpty()) {
+            opts.setAttributes(attributes);
+        }
+        return opts.map();
     }
 
     /**

--- a/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/jruby/AsciidoctorInvoker.java
+++ b/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/jruby/AsciidoctorInvoker.java
@@ -243,13 +243,6 @@ public class AsciidoctorInvoker {
         }
     }
 
-    private Optional<File> getAbsolutePathFromOption(Options options, String name) {
-        return Optional.ofNullable(options.map().get(name))
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .map(File::new);
-    }
-
     private Optional<File> findInvalidInputFile(List<File> inputFiles) {
         return inputFiles.stream()
                 .filter(inputFile -> !inputFile.canRead())

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/GlobDirectoryWalker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/GlobDirectoryWalker.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 
@@ -31,10 +32,10 @@ public class GlobDirectoryWalker implements DirectoryWalker {
 
         String unglobbedPart = globExpression.substring(0, indexOfUnglobbedPart + 1);
 
-        this.rootDirectory = new File(unglobbedPart).getAbsoluteFile();
+        this.rootDirectory = unglobbedPart.isEmpty() ? null : new File(unglobbedPart);
         this.globExpression = globExpression.substring(indexOfUnglobbedPart + 1);
         checkInput(rootDirectory);
-        this.canonicalRootDir = getCanonicalPath(rootDirectory);
+        this.canonicalRootDir = getCanonicalPath(Optional.ofNullable(rootDirectory).orElseGet(() -> new File(".")));
     }
 
     /**
@@ -88,6 +89,9 @@ public class GlobDirectoryWalker implements DirectoryWalker {
     }
 
     private void checkInput(File rootDir) {
+        if (rootDir == null) {
+            return;
+        }
         if (!rootDir.exists()) {
             throw new IllegalArgumentException("Directory does not exist: "
                     + rootDir);
@@ -137,7 +141,7 @@ public class GlobDirectoryWalker implements DirectoryWalker {
     private void findFilesThroughMatchingDirectories(File dir,
             List<Pattern> includes) {
         for (String fileName : dir.list()) {
-            List<Pattern> matchingIncludes = new ArrayList<Pattern>(
+            List<Pattern> matchingIncludes = new ArrayList<>(
                     includes.size());
             for (Pattern include : includes) {
                 if (include.matches(fileName)) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -39,7 +39,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     private RubyClass extensionGroupClass;
 
-    private List<LogHandler> logHandlers = new ArrayList<>();
+    private final List<LogHandler> logHandlers = new ArrayList<>();
 
     public JRubyAsciidoctor() {
         this(createRubyRuntime(Collections.singletonMap(GEM_PATH, null), new ArrayList<>(), null));
@@ -293,9 +293,6 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
         String currentDirectory = rubyRuntime.getCurrentDirectory();
 
-        if (options.containsKey(Options.BASEDIR)) {
-            rubyRuntime.setCurrentDirectory((String) options.get(Options.BASEDIR));
-        }
 
         final Object toFileOption = options.get(Options.TO_FILE);
         if (toFileOption instanceof OutputStream) {
@@ -306,7 +303,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
         try {
             IRubyObject object = getAsciidoctorModule().callMethod("convert_file",
-                    rubyRuntime.newString(file.getAbsolutePath()), rubyHash);
+                    rubyRuntime.newString(file.toString()), rubyHash);
             return adaptReturn(object, expectedResult);
         } catch (RaiseException e) {
             logger.severe(e.getMessage());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyGemsPreloader.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyGemsPreloader.java
@@ -25,7 +25,7 @@ public class RubyGemsPreloader {
             REVEALJS, "require 'asciidoctor-revealjs'"
     );
 
-    private Ruby rubyRuntime;
+    private final Ruby rubyRuntime;
 
     public RubyGemsPreloader(Ruby rubyRuntime) {
         this.rubyRuntime = rubyRuntime;
@@ -76,7 +76,7 @@ public class RubyGemsPreloader {
     }
 
     private boolean isOptionWithValue(Map<String, Object> attributes, String attribute, String value) {
-        return attributes.get(attribute).equals(value);
+        return value.equals(attributes.get(attribute));
     }
 
     private boolean isOptionSet(Map<String, Object> attributes, String attribute) {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
@@ -64,6 +64,7 @@ public class WhenGlobExpressionIsUsedForScanning {
         List<File> asciidocFiles = globDirectoryWalker.scan();
 
         assertThat(asciidocFiles)
+                .extracting(File::getAbsoluteFile)
                 .contains(new File(fileNameInRootDir).getAbsoluteFile());
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
@@ -76,6 +76,6 @@ public class WhenGlobExpressionIsUsedForScanning {
         List<File> asciidocFiles = globDirectoryWalker.scan();
 
         assertThat(asciidocFiles)
-                .containsExactly(new File(fileNameInCurrentWorkingDir).getAbsoluteFile());
+                .containsExactly(new File(fileNameInCurrentWorkingDir));
     }
 }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

As discovered in #1241 the AsciidoctorJ CLI works significantly different compared to Asciidoctor itself.
For example source file names are currently passed with their absolute path by AsciidoctorJ CLI to the Asciidoctor Ruby runtime, while the Asciidoctor Ruby CLI passes relative file names.
Also, AsciidoctorJ currently changes the current working directory to the baseDir atm, while Asciidoctor Ruby does not.
This PR tries to align the behavior of AsciidoctorJ with the behavior of Asciidoctor Ruby.

How does it achieve that?

I changed the AsciidoctorJ code to mimic the same behavior as Asciidoctor Ruby as much as possible.

Are there any alternative ways to implement this?

Yes, we could try to reuse the implementation of Asciidoctor::Cli itself.
We would likely need to create a subclass of Asciidoctor::Cli::Invoker where we pass our custom options, instead of the ones parsed in Asciidoctor::Cli::Options.

Are there any implications of this pull request? Anything a user must know?

The PR is pretty risky, I have made some tests, but I am not very confident that I was able to test all the different use cases.
Would be great to get some feedback.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc