### PR TITLE
Reuse Asciidoctor Ruby invoker

### DIFF
--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Attributes.java
@@ -593,7 +593,7 @@ public class Attributes {
 
     private void extractAttributeNameAndValue(String attribute, int equalsIndex) {
         String attributeName = attribute.substring(0, equalsIndex);
-        String attributeValue = attribute.substring(equalsIndex + 1, attribute.length());
+        String attributeValue = attribute.substring(equalsIndex + 1);
 
         this.attributes.put(attributeName, attributeValue);
     }
@@ -618,6 +618,10 @@ public class Attributes {
 
     private static String toTime(Date time) {
         return TIME_FORMAT.format(time);
+    }
+
+    public boolean isEmpty() {
+        return this.attributes.isEmpty();
     }
 
     /**

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -13,6 +13,7 @@ public class Options {
 
     public static final String IN_PLACE = "in_place";
     public static final String WARNINGS = "warnings";
+    public static final String TIMINGS = "timings";
     public static final String ATTRIBUTES = "attributes";
     public static final String TEMPLATE_DIRS = "template_dirs";
     public static final String TEMPLATE_ENGINE = "template_engine";

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/Options.java
@@ -6,12 +6,13 @@ import java.util.*;
 /**
  * AsciidoctorJ conversion options.
  * <p>
- * See https://docs.asciidoctor.org/asciidoctor/latest/api/options/ for further
+ * See <a href="https://docs.asciidoctor.org/asciidoctor/latest/api/options/">https://docs.asciidoctor.org/asciidoctor/latest/api/options/</a> for further
  * details.
  */
 public class Options {
 
     public static final String IN_PLACE = "in_place";
+    public static final String WARNINGS = "warnings";
     public static final String ATTRIBUTES = "attributes";
     public static final String TEMPLATE_DIRS = "template_dirs";
     public static final String TEMPLATE_ENGINE = "template_engine";
@@ -24,10 +25,10 @@ public class Options {
     public static final String ERUBY = "eruby";
     public static final String CATALOG_ASSETS = "catalog_assets";
     public static final String COMPACT = "compact";
-    public static final String SOURCE_DIR = "source_dir";
     public static final String BACKEND = "backend";
     public static final String DOCTYPE = "doctype";
     public static final String BASEDIR = "base_dir";
+    public static final String TRACE = "trace";
     public static final String TEMPLATE_CACHE = "template_cache";
     public static final String SOURCE = "source";
     public static final String PARSE = "parse";
@@ -158,10 +159,6 @@ public class Options {
 
     public void setCompact(boolean compact) {
         this.options.put(COMPACT, compact);
-    }
-
-    public void setSourceDir(String srcDir) {
-        this.options.put(SOURCE_DIR, srcDir);
     }
 
     public void setBackend(String backend) {

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/OptionsBuilder.java
@@ -2,7 +2,6 @@ package org.asciidoctor;
 
 import java.io.File;
 import java.io.OutputStream;
-import java.util.Map;
 
 /**
  * Fluent Options API for AsciidoctorJ.
@@ -160,7 +159,7 @@ public class OptionsBuilder {
      * @return this instance.
      */
     public OptionsBuilder toDir(File directory) {
-        this.options.setToDir(directory.getAbsolutePath());
+        this.options.setToDir(directory.getPath());
         return this;
     }
 
@@ -266,20 +265,6 @@ public class OptionsBuilder {
     }
 
     /**
-     * Source directory.
-     *
-     * This must be used alongside {@link #toDir(File)}.
-     *
-     * @param srcDir
-     *            source directory.
-     * @return this instance.
-     */
-    public OptionsBuilder sourceDir(File srcDir) {
-        this.options.setSourceDir(srcDir.getAbsolutePath());
-        return this;
-    }
-
-    /**
      * Sets a custom or unlisted option.
      * 
      * @param option
@@ -301,7 +286,7 @@ public class OptionsBuilder {
      * @return this instance.
      */
     public OptionsBuilder baseDir(File baseDir) {
-        this.options.setBaseDir(baseDir.getAbsolutePath());
+        this.options.setBaseDir(baseDir.getPath());
         return this;
     }
 

--- a/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
@@ -10,7 +10,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyHash;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -42,7 +41,6 @@ public class AsciidoctorCliOptions {
     public static final String VERBOSE = "-v";
     public static final String TIMINGS = "-t";
     public static final char ATTRIBUTE_SEPARATOR = '=';
-    public static final String TIMINGS_OPTION_NAME = "timings";
 
     @Parameter(names = {VERBOSE, "--verbose"}, description = "enable verbose mode")
     private boolean verbose = false;
@@ -276,7 +274,7 @@ public class AsciidoctorCliOptions {
         return !isOutFileOption() && !isDestinationDirOption() && !isOutputStdout();
     }
 
-    public RubyHash parse(Ruby ruby) throws IOException {
+    public RubyHash parse(Ruby ruby) {
 
         RubyHash opts = new RubyHash(ruby);
         Map attributes = buildAttributes();
@@ -300,13 +298,13 @@ public class AsciidoctorCliOptions {
             opts.put(ruby.newSymbol(Options.SAFE), SafeMode.SAFE.getLevel());
         }
         if (this.safeMode != null) {
-            opts.put(ruby.newSymbol("safe"), this.safeMode.getLevel());
+            opts.put(ruby.newSymbol(Options.SAFE), this.safeMode.getLevel());
         }
         if (this.noHeaderFooter) {
             opts.put(ruby.newSymbol(Options.STANDALONE), false);
         }
         if (this.sectionNumbers) {
-            attributes.put("sectnums", "");
+            attributes.put(Attributes.SECTION_NUMBERS, "");
         }
         if (this.eruby != null) {
             opts.put(ruby.newSymbol(Options.ERUBY), this.eruby);
@@ -327,7 +325,7 @@ public class AsciidoctorCliOptions {
             opts.put(ruby.newSymbol(Options.TRACE), true);
         }
         if (this.timings) {
-            opts.put(ruby.newSymbol("timings"), true);
+            opts.put(ruby.newSymbol(Options.TIMINGS), true);
         }
         if (this.warnings) {
             opts.put(ruby.newSymbol(Options.WARNINGS), true);

--- a/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
+++ b/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/AsciidoctorCliOptions.java
@@ -13,7 +13,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.StringTokenizer;
 
 public class AsciidoctorCliOptions {
@@ -277,16 +276,16 @@ public class AsciidoctorCliOptions {
     public RubyHash parse(Ruby ruby) {
 
         RubyHash opts = new RubyHash(ruby);
-        Map attributes = buildAttributes();
+        Attributes attributes = buildAttributes();
 
         opts.put(ruby.newSymbol(Options.STANDALONE), true);
         opts.put(ruby.newSymbol(Options.WARNINGS), false);
 
         if (this.backend != null) {
-            attributes.put(Options.BACKEND, this.backend);
+            attributes.setAttribute(Options.BACKEND, this.backend);
         }
         if (this.doctype != null) {
-            attributes.put(Options.DOCTYPE, this.doctype);
+            attributes.setAttribute(Options.DOCTYPE, this.doctype);
         }
         if (this.embedded) {
             opts.put(ruby.newSymbol(Options.STANDALONE), false);
@@ -304,7 +303,7 @@ public class AsciidoctorCliOptions {
             opts.put(ruby.newSymbol(Options.STANDALONE), false);
         }
         if (this.sectionNumbers) {
-            attributes.put(Attributes.SECTION_NUMBERS, "");
+            attributes.setAttribute(Attributes.SECTION_NUMBERS, "");
         }
         if (this.eruby != null) {
             opts.put(ruby.newSymbol(Options.ERUBY), this.eruby);
@@ -331,7 +330,7 @@ public class AsciidoctorCliOptions {
             opts.put(ruby.newSymbol(Options.WARNINGS), true);
         }
         if (!attributes.isEmpty()) {
-            opts.put(ruby.newSymbol(Options.ATTRIBUTES), attributes);
+            opts.put(ruby.newSymbol(Options.ATTRIBUTES), attributes.map());
         }
         if (this.isSourceDirOption()) {
             opts.put(ruby.newSymbol("source_dir"), this.sourceDir);
@@ -344,7 +343,7 @@ public class AsciidoctorCliOptions {
      * {@link Attributes} instance.
      */
     // FIXME Should be private, made protected for testing.
-    Map buildAttributes() {
+    Attributes buildAttributes() {
         final AttributesBuilder attributesBuilder = Attributes.builder();
         for (String attribute : attributes) {
             int separatorIndex = attribute.indexOf(ATTRIBUTE_SEPARATOR);
@@ -356,7 +355,7 @@ public class AsciidoctorCliOptions {
                 attributesBuilder.attribute(attribute);
             }
         }
-        return attributesBuilder.build().map();
+        return attributesBuilder.build();
     }
 
     private List<String> splitByPathSeparator(String path) {

--- a/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/jruby/AsciidoctorRubyInvoker.java
+++ b/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/jruby/AsciidoctorRubyInvoker.java
@@ -33,7 +33,7 @@ public class AsciidoctorRubyInvoker {
     public void invoke(List<File> inputFiles, AsciidoctorCliOptions cliOptions) {
         RubyHash opts = cliOptions.parse(ruby);
 
-        new RubyGemsPreloader(asciidoctor.getRubyRuntime()).preloadRequiredLibrariesCommandLine(opts);
+        new RubyGemsPreloader(asciidoctor.getRubyRuntime()).preloadRequiredLibraries(opts);
 
         opts.put(ruby.newSymbol("input_files"), inputFiles.stream().map(f -> ruby.newString(f.getPath())).collect(Collectors.toList()));
 

--- a/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/jruby/AsciidoctorRubyInvoker.java
+++ b/asciidoctorj-cli/src/main/java/org/asciidoctor/cli/jruby/AsciidoctorRubyInvoker.java
@@ -1,0 +1,44 @@
+package org.asciidoctor.cli.jruby;
+
+import org.asciidoctor.cli.AsciidoctorCliOptions;
+import org.asciidoctor.jruby.internal.JRubyAsciidoctor;
+import org.asciidoctor.jruby.internal.RubyGemsPreloader;
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyHash;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Converts AsciiDoc files using the Asciidoctor Ruby API.
+ * Note that this bypasses the AsciidoctorJ API and is only used for the CLI.
+ */
+public class AsciidoctorRubyInvoker {
+
+    private final JRubyAsciidoctor asciidoctor;
+
+    private final Ruby ruby;
+
+    private final RubyClass invokerClass;
+
+    public AsciidoctorRubyInvoker(JRubyAsciidoctor asciidoctor) {
+        this.asciidoctor = asciidoctor;
+        this.ruby = asciidoctor.getRubyRuntime();
+        this.invokerClass = ruby.getModule("AsciidoctorJ").getModule("Cli").getClass("Invoker");
+    }
+
+    public void invoke(List<File> inputFiles, AsciidoctorCliOptions cliOptions) {
+        RubyHash opts = cliOptions.parse(ruby);
+
+        new RubyGemsPreloader(asciidoctor.getRubyRuntime()).preloadRequiredLibrariesCommandLine(opts);
+
+        opts.put(ruby.newSymbol("input_files"), inputFiles.stream().map(f -> ruby.newString(f.getPath())).collect(Collectors.toList()));
+
+        IRubyObject invoker = invokerClass.newInstance(ruby.getCurrentContext(), opts);
+        invoker.callMethod(ruby.getCurrentContext(), "invoke!");
+    }
+
+}

--- a/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorAPICallIsCalled.java
+++ b/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorAPICallIsCalled.java
@@ -33,7 +33,7 @@ public class WhenAsciidoctorAPICallIsCalled {
         assertThat(asciidoctorCliOptions.getSafeMode()).isEqualTo(SafeMode.UNSAFE);
         assertThat(asciidoctorCliOptions.getBackend()).isEqualTo("docbook");
         assertThat(asciidoctorCliOptions.getParameters()).containsExactly("file.adoc");
-        assertThat(asciidoctorCliOptions.buildAttributes())
+        assertThat(asciidoctorCliOptions.buildAttributes().map())
                 .containsEntry("myAttribute", "myValue")
                 .containsEntry("sectnums", "")
                 .containsEntry("copycss!", "");

--- a/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorAPICallIsCalled.java
+++ b/asciidoctorj-cli/src/test/java/org/asciidoctor/cli/WhenAsciidoctorAPICallIsCalled.java
@@ -33,7 +33,7 @@ public class WhenAsciidoctorAPICallIsCalled {
         assertThat(asciidoctorCliOptions.getSafeMode()).isEqualTo(SafeMode.UNSAFE);
         assertThat(asciidoctorCliOptions.getBackend()).isEqualTo("docbook");
         assertThat(asciidoctorCliOptions.getParameters()).containsExactly("file.adoc");
-        assertThat(asciidoctorCliOptions.buildAttributes().map())
+        assertThat(asciidoctorCliOptions.buildAttributes())
                 .containsEntry("myAttribute", "myValue")
                 .containsEntry("sectnums", "")
                 .containsEntry("copycss!", "");

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/GlobDirectoryWalker.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/GlobDirectoryWalker.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 
@@ -31,10 +32,10 @@ public class GlobDirectoryWalker implements DirectoryWalker {
 
         String unglobbedPart = globExpression.substring(0, indexOfUnglobbedPart + 1);
 
-        this.rootDirectory = new File(unglobbedPart).getAbsoluteFile();
+        this.rootDirectory = unglobbedPart.isEmpty() ? null : new File(unglobbedPart);
         this.globExpression = globExpression.substring(indexOfUnglobbedPart + 1);
         checkInput(rootDirectory);
-        this.canonicalRootDir = getCanonicalPath(rootDirectory);
+        this.canonicalRootDir = getCanonicalPath(Optional.ofNullable(rootDirectory).orElseGet(() -> new File(".")));
     }
 
     /**
@@ -88,6 +89,9 @@ public class GlobDirectoryWalker implements DirectoryWalker {
     }
 
     private void checkInput(File rootDir) {
+        if (rootDir == null) {
+            return;
+        }
         if (!rootDir.exists()) {
             throw new IllegalArgumentException("Directory does not exist: "
                     + rootDir);
@@ -137,7 +141,7 @@ public class GlobDirectoryWalker implements DirectoryWalker {
     private void findFilesThroughMatchingDirectories(File dir,
             List<Pattern> includes) {
         for (String fileName : dir.list()) {
-            List<Pattern> matchingIncludes = new ArrayList<Pattern>(
+            List<Pattern> matchingIncludes = new ArrayList<>(
                     includes.size());
             for (Pattern include : includes) {
                 if (include.matches(fileName)) {

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/JRubyAsciidoctor.java
@@ -39,7 +39,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
     private RubyClass extensionGroupClass;
 
-    private List<LogHandler> logHandlers = new ArrayList<>();
+    private final List<LogHandler> logHandlers = new ArrayList<>();
 
     public JRubyAsciidoctor() {
         this(createRubyRuntime(Collections.singletonMap(GEM_PATH, null), new ArrayList<>(), null));
@@ -293,9 +293,6 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
         String currentDirectory = rubyRuntime.getCurrentDirectory();
 
-        if (options.containsKey(Options.BASEDIR)) {
-            rubyRuntime.setCurrentDirectory((String) options.get(Options.BASEDIR));
-        }
 
         final Object toFileOption = options.get(Options.TO_FILE);
         if (toFileOption instanceof OutputStream) {
@@ -306,7 +303,7 @@ public class JRubyAsciidoctor implements AsciidoctorJRuby, LogHandler {
 
         try {
             IRubyObject object = getAsciidoctorModule().callMethod("convert_file",
-                    rubyRuntime.newString(file.getAbsolutePath()), rubyHash);
+                    rubyRuntime.newString(file.toString()), rubyHash);
             return adaptReturn(object, expectedResult);
         } catch (RaiseException e) {
             logger.severe(e.getMessage());

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyGemsPreloader.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyGemsPreloader.java
@@ -3,12 +3,9 @@ package org.asciidoctor.jruby.internal;
 import org.asciidoctor.Attributes;
 import org.asciidoctor.Options;
 import org.jruby.Ruby;
-import org.jruby.RubyHash;
 
 import java.util.Map;
-import java.util.Objects;
-
-import static java.util.Collections.emptyMap;
+import java.util.Optional;
 
 public class RubyGemsPreloader {
 
@@ -42,11 +39,11 @@ public class RubyGemsPreloader {
      *                This is usually obtained by calling Options.map() on an Options instance.
      *                The attributes are passed as a nested Map with String keys and String values.
      */
-    public void preloadRequiredLibraries(Map<String, Object> options) {
+    public void preloadRequiredLibraries(Map<? super String, Object> options) {
 
-        if (options.containsKey(Options.ATTRIBUTES)) {
-            Map<String, Object> attributes = (Map<String, Object>) options.get(Options.ATTRIBUTES);
-
+        Map<Object, Object> opts = RubyHashUtil.convertRubyHashMapToMap(options);
+        Map<String, Object> attributes = (Map<String, Object>) opts.get(Options.ATTRIBUTES);
+        if (attributes != null) {
             if (isOptionSet(attributes, Attributes.SOURCE_HIGHLIGHTER)
                     && isOptionWithValue(attributes, Attributes.SOURCE_HIGHLIGHTER, CODERAY)) {
                 preloadLibrary(Attributes.SOURCE_HIGHLIGHTER);
@@ -61,78 +58,37 @@ public class RubyGemsPreloader {
             }
         }
 
-        if (isOptionSet(options, Options.ERUBY) && isOptionWithValue(options, Options.ERUBY, ERUBIS)) {
+        if (isOptionSet(opts, Options.ERUBY) && isOptionWithValue(opts, Options.ERUBY, ERUBIS)) {
             preloadLibrary(Options.ERUBY);
         }
 
-        if (isOptionSet(options, Options.TEMPLATE_DIRS)) {
+        if (isOptionSet(opts, Options.TEMPLATE_DIRS)) {
             preloadLibrary(Options.TEMPLATE_DIRS);
         }
 
-        if (isOptionSet(options, Options.BACKEND)) {
-            if ("epub3".equalsIgnoreCase(Objects.toString(options.get(Options.BACKEND)))) {
-                preloadLibrary(EPUB3);
-            } else if ("pdf".equalsIgnoreCase(Objects.toString(options.get(Options.BACKEND)))) {
-                preloadLibrary(PDF);
-            } else if ("revealjs".equalsIgnoreCase(Objects.toString(options.get(Options.BACKEND)))) {
-                preloadLibrary(REVEALJS);
-            }
-        }
-    }
-
-    /**
-     * Preload required libraries based on the options passed in the command line.
-     * This method is only to be used from the CLI module, since it relies on how command line arguments map
-     * to attributes and options expected by the Asciidoctor::Cli::Invoker.
-     * @param opts The options that will be passed to the Asciidoctor::Cli::Invoker.
-     *             Should be a Hash with RubySymbol keys and arbitrary values.
-     *             The attributes are passed as a nested Hash with String keys and String values.
-     */
-    public void preloadRequiredLibrariesCommandLine(RubyHash opts) {
-        Ruby ruby = opts.getRuntime();
-        if (opts.containsKey(ruby.newSymbol(Options.ATTRIBUTES))) {
-            Map<String, Object> attributes = (Map<String, Object>) opts.getOrDefault(ruby.newSymbol(Options.ATTRIBUTES), emptyMap());
-
-            if (CODERAY.equals(attributes.get(Attributes.SOURCE_HIGHLIGHTER))) {
-                preloadLibrary(Attributes.SOURCE_HIGHLIGHTER);
-            }
-
-            if (attributes.containsKey(Attributes.CACHE_URI)) {
-                preloadLibrary(Attributes.CACHE_URI);
-            }
-
-            if (attributes.containsKey(Attributes.DATA_URI)) {
-                preloadLibrary(Attributes.DATA_URI);
-            }
-
-            if ("epub3".equals(attributes.get(Options.BACKEND))) {
-                preloadLibrary(EPUB3);
-            } else if ("pdf".equals(attributes.get(Options.BACKEND))) {
-                preloadLibrary(PDF);
-            } else if ("revealjs".equals(attributes.get(Options.BACKEND))) {
-                preloadLibrary(REVEALJS);
-            }
-        }
-
-        if (ERUBIS.equals(opts.get(ruby.newSymbol(Options.ERUBY)))) {
-            preloadLibrary(Options.ERUBY);
-        }
-
-        if (opts.containsKey(ruby.newSymbol(Options.TEMPLATE_DIRS))) {
-            preloadLibrary(Options.TEMPLATE_DIRS);
-        }
-
+        Optional.ofNullable(opts.get(Options.BACKEND))
+                .or(() -> Optional.ofNullable(attributes).map(a -> a.get(Attributes.BACKEND)))
+                .map(Object::toString)
+                .ifPresent(backend -> {
+                    if ("epub3".equalsIgnoreCase(backend)) {
+                        preloadLibrary(EPUB3);
+                    } else if ("pdf".equalsIgnoreCase(backend)) {
+                        preloadLibrary(PDF);
+                    } else if ("revealjs".equalsIgnoreCase(backend)) {
+                        preloadLibrary(REVEALJS);
+                    }
+                });
     }
 
     private void preloadLibrary(String option) {
         this.rubyRuntime.evalScriptlet(optionToRequiredGem.get(option));
     }
 
-    private boolean isOptionWithValue(Map<String, Object> attributes, String attribute, String value) {
+    private boolean isOptionWithValue(Map<? super String, Object> attributes, String attribute, String value) {
         return value.equals(attributes.get(attribute));
     }
 
-    private boolean isOptionSet(Map<String, Object> attributes, String attribute) {
+    private boolean isOptionSet(Map<? super String, Object> attributes, String attribute) {
         return attributes.containsKey(attribute);
     }
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyHashUtil.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/internal/RubyHashUtil.java
@@ -109,13 +109,11 @@ public class RubyHashUtil {
         return keyType instanceof CharSequence;
     }
 
-    public static Map<Object, Object> convertRubyHashMapToMap(Map<Object, Object> rubyHashMap) {
+    public static Map<Object, Object> convertRubyHashMapToMap(Map<? super String, Object> rubyHashMap) {
 
-        Map<Object, Object> map = new HashMap<Object, Object>();
+        Map<Object, Object> map = new HashMap<>();
 
-        Set<Entry<Object, Object>> elements = rubyHashMap.entrySet();
-
-        for (Entry<Object, Object> element : elements) {
+        for (Entry<? super String, Object> element : rubyHashMap.entrySet()) {
             if(element.getKey() instanceof RubySymbol) {
                 map.put(toJavaString((RubySymbol)element.getKey()), toJavaObject(element.getValue()));
             } else {
@@ -129,7 +127,7 @@ public class RubyHashUtil {
 
     public static Map<String, Object> convertRubyHashMapToStringObjectMap(RubyHash rubyHashMap) {
 
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
 
         Set<Entry<Object, Object>> elements = rubyHashMap.entrySet();
 

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/jruby/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/jruby/internal/asciidoctorclass.rb
@@ -1,3 +1,9 @@
+require 'java'
+require 'asciidoctor'
+require 'asciidoctor/cli'
+require 'asciidoctor/extensions'
+
+
 module AsciidoctorJ
     include_package 'org.asciidoctor'
     module Extensions
@@ -6,11 +12,19 @@ module AsciidoctorJ
         # This is necessary to run against both Asciidoctor 1.5.5 and 1.5.6
         TreeProcessor = Treeprocessor unless defined? TreeProcessor
     end
-end
 
-require 'java'
-require 'asciidoctor'
-require 'asciidoctor/extensions'
+    module Cli
+        class Invoker < Asciidoctor::Cli::Invoker
+            def initialize options
+                @documents = []
+                @out = nil
+                @err = nil
+                @code = 0
+                @options = options
+            end
+        end
+    end
+end
 
 module AsciidoctorModule
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenGlobExpressionIsUsedForScanning.java
@@ -64,6 +64,7 @@ public class WhenGlobExpressionIsUsedForScanning {
         List<File> asciidocFiles = globDirectoryWalker.scan();
 
         assertThat(asciidocFiles)
+                .extracting(File::getAbsoluteFile)
                 .contains(new File(fileNameInRootDir).getAbsoluteFile());
     }
 
@@ -76,6 +77,6 @@ public class WhenGlobExpressionIsUsedForScanning {
         List<File> asciidocFiles = globDirectoryWalker.scan();
 
         assertThat(asciidocFiles)
-                .containsExactly(new File(fileNameInCurrentWorkingDir).getAbsoluteFile());
+                .containsExactly(new File(fileNameInCurrentWorkingDir));
     }
 }

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionGroupIsRegistered.java
@@ -14,6 +14,7 @@ import org.asciidoctor.test.ClasspathResource;
 import org.asciidoctor.test.extension.AsciidoctorExtension;
 import org.asciidoctor.test.extension.ClasspathExtension;
 import org.asciidoctor.util.TestHttpServer;
+import org.assertj.core.api.Assertions;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -155,7 +156,7 @@ public class WhenJavaExtensionGroupIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -213,7 +214,7 @@ public class WhenJavaExtensionGroupIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -386,7 +387,7 @@ public class WhenJavaExtensionGroupIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -407,7 +408,7 @@ public class WhenJavaExtensionGroupIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -428,7 +429,7 @@ public class WhenJavaExtensionGroupIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/extension/WhenJavaExtensionIsRegistered.java
@@ -15,6 +15,7 @@ import org.asciidoctor.test.ClasspathResource;
 import org.asciidoctor.test.extension.AsciidoctorExtension;
 import org.asciidoctor.test.extension.ClasspathExtension;
 import org.asciidoctor.util.TestHttpServer;
+import org.assertj.core.api.Assertions;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -157,7 +158,7 @@ public class WhenJavaExtensionIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -215,7 +216,7 @@ public class WhenJavaExtensionIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -389,7 +390,7 @@ public class WhenJavaExtensionIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -410,7 +411,7 @@ public class WhenJavaExtensionIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -431,7 +432,7 @@ public class WhenJavaExtensionIsRegistered {
 
         Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-        assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+        Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
 
     }
 
@@ -925,7 +926,7 @@ public class WhenJavaExtensionIsRegistered {
 
             Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-            assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+            Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
         }
     }
 
@@ -947,7 +948,7 @@ public class WhenJavaExtensionIsRegistered {
 
             Element contentElement = doc.getElementsByAttributeValue("class", "language-ruby").first();
 
-            assertThat(contentElement.text(), startsWith(ASCIIDOCTORCLASS_PREFIX));
+            Assertions.assertThat(contentElement.text()).contains(ASCIIDOCTORCLASS_PREFIX);
         }
     }
 


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

This PR should do the same thing as #1248, that is better align the behavior of the AsciidoctorJ CLI with the behavior of the Asciidoctor Ruby CLI.
This PR however, reuses the original Asciidoctor::Cli::Invoker and feeds its own options into it instead of letting Asciidoctor Ruby parse them.

So chances are that this works a bit better than the other PR.

The code is still raw, but I'd like to get some feedback on what approach to pursue.

How does it achieve that?

Are there any alternative ways to implement this?

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc