### PR TITLE
Moved context functions to ContentNode

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,8 @@ Bug Fixes::
 
 Improvement::
 
+* Add `setContext` function to StructuralNode.
+
 * Add command line option --failure-level to force non-zero exit code from AsciidoctorJ CLI if specified logging level is reached. (#1114)
 * Upgrade to asciidoctorj 2.0.20 (#1208)
 * Upgrade to asciidoctorj-pdf 2.3.7 (#1182)

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentNode.java
@@ -18,6 +18,8 @@ public interface ContentNode {
 
     String getContext();
 
+    void setContext(String context);
+
     Document getDocument();
 
     boolean isInline();

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ContentNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ContentNodeImpl.java
@@ -34,6 +34,11 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
         return getString("context");
     }
 
+    @Override
+    public void setContext(String context) {
+        setString("context", context);
+
+    }
 
     @Override
     public ContentNode getParent() {

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/ContextChangeTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/ContextChangeTest.java
@@ -1,0 +1,53 @@
+package org.asciidoctor.jruby.ast.impl;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.StructuralNode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class ContextChangeTest  {
+
+    private final Asciidoctor asciiDoctor = Asciidoctor.Factory.create();
+
+    static String orderedListSample() {
+        return "= Document Title\n\n" +
+                "== Section A\n\n" +
+                ". This it item 1 in an ordered list\n\n" +
+                ". This is item 2 in an ordered list\n\n" +
+                ". This is item 3 in and ordered list\n\n";
+
+    }
+
+    @Test
+    public void get_context_of_ordered_list(){
+
+        Document document = loadDocument(orderedListSample());
+
+        assertThat(document).isNotNull();
+        assertThat(document.getBlocks().size()).isEqualTo(1);
+
+        StructuralNode orderedList = document.getBlocks().get(0).getBlocks().get(0);
+        assertThat(orderedList).isNotNull();
+
+        // Odd – I expected this to send back :'olist'
+        assertThat(orderedList.getContext()).isEqualTo("olist");
+
+        // But can you change it?
+
+        orderedList.setContext("colist");
+
+        assertThat(orderedList.getContext()).isEqualTo("colist");
+
+    }
+
+    private Document loadDocument(String source) {
+        Attributes attributes = Attributes.builder().sectionNumbers(false).build();
+        Options options = Options.builder().attributes(attributes).build();
+        return asciiDoctor.load(source, options);
+    }
+}


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Adding a function to set the Context of a node.

How does it achieve that?
Added a setContext function to the ContentNode

Are there any alternative ways to implement this?
Possibly.

Are there any implications of this pull request? Anything a user must know?
Not that I know of.


## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc