### PR TITLE
Add setContext function

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -49,6 +49,11 @@ Documentation::
 
 Improvement::
 
+* Add `setContext` function to ContentNode.
+
+* Add command line option --failure-level to force non-zero exit code from AsciidoctorJ CLI if specified logging level is reached. (#1114)
+* Upgrade to asciidoctorj 2.0.20 (#1208)
+* Upgrade to asciidoctorj-pdf 2.3.7 (#1182)
 * Add 'standalone' option, deprecates 'headerFooter' (#1160) (@abelsromero)
 * Upgrade to asciidoctorj-diagram 2.2.7
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentNode.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/ContentNode.java
@@ -32,6 +32,9 @@ public interface ContentNode {
     @Deprecated
     String context();
     String getContext();
+
+    void setContext(String context);
+
     /**
      * @deprecated Use {@linkplain #getDocument()}  instead.
      */

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ContentNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/ast/impl/ContentNodeImpl.java
@@ -47,6 +47,11 @@ public abstract class ContentNodeImpl extends RubyObjectWrapper implements Conte
     }
 
     @Override
+    public void setContext(String context) {
+        setString("context", context);
+
+    }
+    @Override
     @Deprecated
     public ContentNode parent() {
         return getParent();

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/ContextChangeTest.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/jruby/ast/impl/ContextChangeTest.java
@@ -1,0 +1,54 @@
+package org.asciidoctor.jruby.ast.impl;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.StructuralNode;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class ContextChangeTest  {
+
+    private final Asciidoctor asciiDoctor = Asciidoctor.Factory.create();
+
+    static String orderedListSample() {
+        return "= Document Title\n\n" +
+                "== Section A\n\n" +
+                ". This it item 1 in an ordered list\n\n" +
+                ". This is item 2 in an ordered list\n\n" +
+                ". This is item 3 in and ordered list\n\n";
+
+    }
+
+    @Test
+    public void get_context_of_ordered_list(){
+
+        Document document = loadDocument(orderedListSample());
+
+        assertThat(document, notNullValue());
+        assertThat(document.getBlocks().size(), equalTo(1));
+
+        StructuralNode orderedList = document.getBlocks().get(0).getBlocks().get(0);
+        assertThat(orderedList, notNullValue());
+
+        // Odd – I expected this to send back :'olist'
+        assertThat(orderedList.getContext(), equalTo("olist"));
+
+        // But can you change it?
+
+        orderedList.setContext("colist");
+
+        assertThat(orderedList.getContext(), equalTo("colist"));
+
+    }
+
+    private Document loadDocument(String source) {
+        Attributes attributes = Attributes.builder().sectionNumbers(false).build();
+        Options options = Options.builder().attributes(attributes).build();
+        return asciiDoctor.load(source, options);
+    }
+}


### PR DESCRIPTION
Added unit test for changing the context: ContextChangeTest.java (#1250) Reformatting the setContext function.
Added entry to CHANGELOG.adoc
(cherry picked from commit 43154994a316728363286bd42894536fa9af6b15)

Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?
Add setContext function to ContentNode

How does it achieve that?
By adding a new function and unit test

Are there any alternative ways to implement this?
Probably not

Are there any implications of this pull request? Anything a user must know?

Used a cherry-pick to bring the function over; there are a lot of @deprecated statements that have appeared too.
Worth checking before rebasing.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc