### PR TITLE
Add methods Reader.getSource and Reader.getSourceLines

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Improvement::
 * Remove deprecated methods from ast package (#1204) (@abelsromero)
 * Add Automatic-Module-Name manifest entry to core, api, and cli for reserving stable JPMS module names (#1240) (@leadpony)
 * Remove Java 'requires open access' module warning in modern Java versions (#1246)
+* Add Reader.getSource() and Reader.getSourceLines() (#1262)
 
 Bug Fixes::
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Reader.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Reader.java
@@ -73,6 +73,18 @@ public interface Reader {
     List<String> getLines();
 
     /**
+     * Returns the source lines for this Reader joined as a String
+     * @return The source lines for this Reader joined as a String
+     */
+    String getSource();
+
+    /**
+     * Get the document source as a String Array of lines.
+     * @return the document source as a String Array of lines.
+     */
+    List<String> getSourceLines();
+
+    /**
      * Push the String line onto the beginning of the Array of source data.
      * <p>
      * Since this line was (assumed to be) previously retrieved through the

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Reader.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/extension/Reader.java
@@ -79,8 +79,8 @@ public interface Reader {
     String getSource();
 
     /**
-     * Get the document source as a String Array of lines.
-     * @return the document source as a String Array of lines.
+     * Get the document source as a List of Strings.
+     * @return the document source as a List of Strings.
      */
     List<String> getSourceLines();
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/internal/ReaderImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/extension/internal/ReaderImpl.java
@@ -71,6 +71,16 @@ public class ReaderImpl extends RubyObjectWrapper implements Reader {
     }
 
     @Override
+    public String getSource() {
+        return getString("source");
+    }
+
+    @Override
+    public List<String> getSourceLines() {
+        return getList("source_lines", String.class);
+    }
+
+    @Override
     public void restoreLine(String line) {
         getRubyProperty("unshift_line", line);
     }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
@@ -178,7 +178,7 @@ $secondLine"""
     def 'should be able to get source and source lines'() {
         given:
 
-        String source = ""
+        String source = ''
         List<String> sourceLines = []
 
         asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenAPreprocessorIsRegistered.groovy
@@ -175,4 +175,27 @@ $secondLine"""
         preprocessorCalled.get()
     }
 
+    def 'should be able to get source and source lines'() {
+        given:
+
+        String source = ""
+        List<String> sourceLines = []
+
+        asciidoctor.javaExtensionRegistry().preprocessor(new Preprocessor() {
+            @Override
+            Reader process(Document doc, PreprocessorReader reader) {
+                source = reader.source
+                sourceLines = reader.sourceLines
+                reader
+            }
+        })
+
+        when:
+        asciidoctor.convert(document, emptyOptions())
+
+        then:
+        source == document
+        sourceLines == [firstLine, secondLine]
+    }
+
 }


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

https://github.com/asciidoctor/asciidoctorj/issues/1262#issuecomment-1960031235 mentioned that AsciidoctorJ is currently missing the methods Reader.getSource() and Reader.getSourceLines().
This PR adds the missing methods.

How does it achieve that?

Add the methods.

Are there any alternative ways to implement this?

No.

Are there any implications of this pull request? Anything a user must know?

No, it just adds new methods to the API.

## Issue

It is related to #1262, but doesn't fix it, since the issue complains about the docs.

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc