### PR TITLE
Fixes #1265. Support setting column widths

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,7 @@ Improvement::
 Bug Fixes::
 
 * -s CLI option should be changed to -e to align with Asciidoctor (#1237) (@mojavelinux)
+* Column#setWidth is ignored (#1265) (@Vampire)
 
 === Compatible changes
 

--- a/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Table.java
+++ b/asciidoctorj-api/src/main/java/org/asciidoctor/ast/Table.java
@@ -57,4 +57,5 @@ public interface Table extends StructuralNode {
      */
     void setGrid(String grid);
 
+    void assignColumnWidths();
 }

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
@@ -31,10 +31,16 @@ class GithubContributorsBlockMacro extends BlockMacroProcessor {
 
         // Create the columns 'Login' and 'Contributions'
         Column avatarColumn = createTableColumn(table, 0)
+        avatarColumn.width = 1
         Column loginColumn = createTableColumn(table, 1)
+        loginColumn.width = 2
         Column contributionsColumn = createTableColumn(table, 2)
+        contributionsColumn.width = 2
         contributionsColumn.horizontalAlignment = Table.HorizontalAlignment.CENTER
-
+        table.columns << avatarColumn
+        table.columns << loginColumn
+        table.columns << contributionsColumn
+        table.assignColumnWidths()
         // Create the single header row with the column titles
         Row headerRow = createTableRow(table)
         headerRow.cells << createTableCell(avatarColumn, 'Avatar')

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/GithubContributorsBlockMacro.groovy
@@ -12,6 +12,7 @@ import org.asciidoctor.util.TestHttpServer
 class GithubContributorsBlockMacro extends BlockMacroProcessor {
 
     private static final String IMAGE = 'image'
+    private static final String WIDTHS = 'widths'
 
     GithubContributorsBlockMacro(String macroName) {
         super(macroName)
@@ -29,13 +30,17 @@ class GithubContributorsBlockMacro extends BlockMacroProcessor {
         table.grid = 'rows'
         table.title = "Github contributors of $target"
 
+        List<Integer> widths = [1,2,2]
+        if (attributes.containsKey(WIDTHS)) {
+            widths = (attributes[WIDTHS] as String).split(',').collect {Integer.parseInt(it) }
+        }
         // Create the columns 'Login' and 'Contributions'
         Column avatarColumn = createTableColumn(table, 0)
-        avatarColumn.width = 1
+        avatarColumn.width = widths[0]
         Column loginColumn = createTableColumn(table, 1)
-        loginColumn.width = 2
+        loginColumn.width = widths[1]
         Column contributionsColumn = createTableColumn(table, 2)
-        contributionsColumn.width = 2
+        contributionsColumn.width = widths[2]
         contributionsColumn.horizontalAlignment = Table.HorizontalAlignment.CENTER
         table.columns << avatarColumn
         table.columns << loginColumn

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesATable.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesATable.groovy
@@ -19,8 +19,9 @@ class WhenABlockMacroProcessorCreatesATable extends Specification {
     public static final String IMG_ELEMENT = 'img'
     public static final String COL  = 'col'
     public static final String STYLE  = 'style'
-    public static final String WIDTH_20  = 'width: 20%'
-    public static final String WIDTH_40  = 'width: 40%'
+    public static final String WIDTH  = 'width'
+    public static final String WIDTH_20  = '20%'
+    public static final String WIDTH_40  = '40%'
     public static final String CONTRIBUTOR = 'bob'
     public static final String BLOCKMACRO_NAME = 'githubcontributors'
 
@@ -69,9 +70,9 @@ githubcontributors::asciidoctor/asciidoctorj[]
 
         Elements cols = htmlDocument.select(COL)
         cols.size() == 3
-        cols.get(0).attr(STYLE).contains(WIDTH_20)
-        cols.get(1).attr(STYLE).contains(WIDTH_40)
-        cols.get(2).attr(STYLE).contains(WIDTH_40)
+        cols.get(0).attr(STYLE).contains(WIDTH_20) || cols.get(0).attr(WIDTH).equals(WIDTH_20)
+        cols.get(1).attr(STYLE).contains(WIDTH_40) || cols.get(1).attr(WIDTH).equals(WIDTH_40)
+        cols.get(2).attr(STYLE).contains(WIDTH_40) || cols.get(2).attr(WIDTH).equals(WIDTH_40)
 
         htmlDocument.select('table').hasClass('grid-rows')
 

--- a/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesATable.groovy
+++ b/asciidoctorj-core/src/test/groovy/org/asciidoctor/extension/WhenABlockMacroProcessorCreatesATable.groovy
@@ -7,6 +7,7 @@ import org.asciidoctor.test.extension.ClasspathHelper
 import org.asciidoctor.util.TestHttpServer
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -16,6 +17,10 @@ class WhenABlockMacroProcessorCreatesATable extends Specification {
     public static final String SECOND_TD = 'td:nth-child(2)'
     public static final String THIRD_TD = 'td:nth-child(3)'
     public static final String IMG_ELEMENT = 'img'
+    public static final String COL  = 'col'
+    public static final String STYLE  = 'style'
+    public static final String WIDTH_20  = 'width: 20%'
+    public static final String WIDTH_40  = 'width: 40%'
     public static final String CONTRIBUTOR = 'bob'
     public static final String BLOCKMACRO_NAME = 'githubcontributors'
 
@@ -61,6 +66,12 @@ githubcontributors::asciidoctor/asciidoctorj[]
 
         then:
         Document htmlDocument = Jsoup.parse(resultFile, 'UTF-8')
+
+        Elements cols = htmlDocument.select(COL)
+        cols.size() == 3
+        cols.get(0).attr(STYLE).contains(WIDTH_20)
+        cols.get(1).attr(STYLE).contains(WIDTH_40)
+        cols.get(2).attr(STYLE).contains(WIDTH_40)
 
         htmlDocument.select('table').hasClass('grid-rows')
 

--- a/config/codenarc/codenarc.groovy
+++ b/config/codenarc/codenarc.groovy
@@ -43,7 +43,9 @@ ruleset {
     ruleset('rulesets/braces.xml') {
         exclude 'IfStatementBraces'
     }
-    ruleset('rulesets/size.xml')
+    ruleset('rulesets/size.xml') {
+        exclude 'AbcMetric'
+    }
     ruleset('rulesets/junit.xml') {
         // Does not play well with Spock tests
         exclude 'JUnitPublicNonTestMethod'


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Add support for setting the width of table columns.
While columns have a method `setWidth()` that sets the attribute `width` of a column, this does not become effective.
In addition it is required to set the attribute `colpcwidth`, which Asciidoctor core only sets internally when calling Table#assign_column_widths.

How does it achieve that?

This PR adds a method Table.assignColumnWidths which calls the Ruby method mentioned above.

Are there any alternative ways to implement this?

Very likely.

Are there any implications of this pull request? Anything a user must know?

There should be no change of existing behavior.

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1265

This PR is a draft until more tests, in particular for the auto width_cols are added.


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc