### PR TITLE
Update asciidoctor 2.0.23

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -26,7 +26,7 @@ jobs:
           - '17'
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,12 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 == Unreleased
 
+Improvement::
+
+* Upgrade to asciidoctor 2.0.23 (#1272)
+* Upgrade to asciidoctorj-epub3 2.1.3 (#1272)
+* Upgrade to JRuby 9.4.7.0 (#1272)
+
 Bug Fixes::
 
 * Column#setWidth is ignored (#1265) (@Vampire)

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ ext {
   arquillianVersion = '1.6.0.Final'
   arquillianSpockVersion = '1.0.0.CR1'
   asciidoctorjPdfVersion = '2.3.14'
-  asciidoctorjEpub3Version = '2.1.0'
+  asciidoctorjEpub3Version = '2.1.3'
   asciidoctorjDiagramVersion = '2.3.0'
   asciidoctorjDiagramDitaaMiniVersion = '1.0.3'
   asciidoctorjDiagramPlantumlVersion = '1.2024.3'
@@ -69,7 +69,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '1.82'
-  jrubyVersion = '9.4.6.0'
+  jrubyVersion = '9.4.7.0'
   jsoupVersion = '1.14.3'
   junitVersion = '4.13.2'
   assertjVersion = '3.19.0'
@@ -79,7 +79,7 @@ ext {
   pdfboxVersion = '1.8.16'
 
   // gem versions
-  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.22'
+  asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.23'
   asciimathGemVersion = '2.0.4'
   coderayGemVersion = '1.1.3'
   rougeGemVersion = '3.30.0'


### PR DESCRIPTION
This PR updates the asciidoctor gem to the latest version 2.0.23.
It also updates JRuby and asciidoctorj-epub3 to the latest versions.