### PR TITLE
Fixes #1275. Fix unresolved dependency grolifant and okhttp-digest

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,7 @@ Bug Fixes::
 
 * -s CLI option should be changed to -e to align with Asciidoctor (#1237) (@mojavelinux)
 * Column#setWidth is ignored (#1265) (@Vampire)
+* Fix unresolvable dependency of JRuby Gradle plugin. (#1275)
 
 === Compatible changes
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ buildscript {
     }
     dependencies {
         classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0"
+        classpath("com.github.jruby-gradle:jruby-gradle-plugin:2.0.1") {
+          exclude module: 'grolifant'
+          exclude module: 'okhttp-digest'
+        }
+        classpath 'org.ysb33r.gradle:grolifant:0.17.0'
     }
 }
 
@@ -26,7 +31,8 @@ plugins {
   id "io.sdkman.vendors" version "3.0.0"
   id "signing"
   id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
-  id 'com.github.jruby-gradle.base' version '2.0.1'
+  // Moved to dependency in buildscript. See https://github.com/asciidoctor/asciidoctorj/issues/1275
+  // id 'com.github.jruby-gradle.base' version '2.0.1'
   id 'codenarc'
 }
 


### PR DESCRIPTION
## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

The build does not work anymore since a few weeks because a couple of dependencies cannot be resolved anymore, namely grolifant and okhttp-digest.
This PR tries to fix the build again.

How does it achieve that?

Move the dependency on the plugin to an old style plugin dependency, and specify an explicit dependency on grolifant.

Are there any alternative ways to implement this?

Probably.
For example getting rid of Gradle altogether, or installing gems with some other mechanism, like Maven.

Are there any implications of this pull request? Anything a user must know?

## Issue

Fixes #1275 
