### PR TITLE
Upgrade jsyntrax to 1.38.2

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,6 +46,7 @@ Improvement::
 * Upgrade to asciidoctorj-pdf 2.3.18 (#1280)
 * Upgrade to asciidoctorj-revealjs 5.1.0 (#1256)
 * Upgrade to asciidoctorj-diagram 2.3.1 (#1280)
+* Upgrade to asciidoctorj-diagram-jsyntrax 1.38.2 (#1282)
 * Upgrade to JRuby 9.4.8.0 (#1280)
 * Upgrade to tilt 2.0.11 (#1109)
 * Upgrade to asciimath 2.0.4 (#1109)

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
   asciidoctorjEpub3Version = '2.1.3'
   asciidoctorjDiagramVersion = '2.3.1'
   asciidoctorjDiagramDitaaMiniVersion = '1.0.3'
-  asciidoctorjDiagramJsyntraxVersion = '1.38.1'
+  asciidoctorjDiagramJsyntraxVersion = '1.38.2'
   asciidoctorjDiagramBatikVersion = '1.17'
   asciidoctorjDiagramPlantumlVersion = '1.2024.5'
   asciidoctorjRevealJsVersion = '5.1.0'


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

Upgrade asciidoctorj-diagram-jsyntrax to the latest version 1.38.2.
1.38.1 did not work with Java 21.

