### PR TITLE
Fix version in docs: removed alpha references

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,11 +1,10 @@
 name: asciidoctorj
 title: AsciidoctorJ
 version: '3.0'
-prerelease: '.0-alpha.1'
 asciidoc:
   attributes:
-    release-version: 3.0.0-alpha.1
-    artifact-version: 3.0.0-alpha.1
+    release-version: 3.0.0
+    artifact-version: 3.0.0
     asciidoctorj-epub3-version: 1.5.1
     asciidoctorj-pdf-version: 2.3.6
     jruby-version: 9.4.1.0


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [x] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*

Fix version that appears in docs, Antora config still mentions `alpha` but the stable 3.0.0 is out.

*How does it achieve that?*

Update config files and wait for nighly docs rebuild.

*Are there any alternative ways to implement this?*
no

*Are there any implications of this pull request? Anything a user must know?*
no

No need to reference issue or changelog imo.