### PR TITLE
Update JCommander coordinates for v2.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,10 @@ For a detailed view of what has changed, refer to the {url-repo}/commits/main[co
 
 == 3.0.0 (2024-08-25)
 
+Build Improvement::
+
+* Upgrade JCommander version and coordinates to v2.0 (#1290)
+
 === Breaking changes
 
 Improvement::

--- a/asciidoctorj-cli/build.gradle
+++ b/asciidoctorj-cli/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'biz.aQute.bnd.builder'
 dependencies {
   api project(':asciidoctorj-api')
   api project(':asciidoctorj')
-  implementation "com.beust:jcommander:$jcommanderVersion"
+  implementation "org.jcommander:jcommander:$jcommanderVersion"
 
   testImplementation (project(':asciidoctorj-test-support')) {
     exclude group: 'junit', module: 'junit'

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ ext {
   commonsioVersion = '2.15.1'
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
-  jcommanderVersion = '1.82'
+  jcommanderVersion = '2.0'
   jrubyVersion = '9.4.8.0'
   jsoupVersion = '1.17.1'
   junit4Version = '4.13.2'


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [x] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

*What is the goal of this pull request?*

Bump JCommander to the latest v2.0.

*How does it achieve that?*

Update the version and the coordinates.

*Are there any alternative ways to implement this?*

No.

*Are there any implications of this pull request? Anything a user must know?*

Only artifact coordinates changed, not the packages.

## Issue

~If this PR fixes an open issue, please add a line of the form:~

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc