### PR TITLE
Fix #1294. Upgrade upload-artifact

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           gradlew.bat -i -S check
       - name: Upload asciidoctorj-core reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         env:
           os_name: ${{ matrix.os }}
           java_version: ${{ matrix.java }}
@@ -84,7 +84,7 @@ jobs:
           name: asciidoctorj-core-reports-${{ env.os_name }}-${{ env.java_version }}
           path: asciidoctorj-core/build/reports/*
       - name: Upload asciidoctorj-documentation reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         env:
           os_name: ${{ matrix.os }}
@@ -125,7 +125,7 @@ jobs:
           unset GEM_PATH GEM_HOME JRUBY_OPTS
           ./ci/test-asciidoctor-upstream.sh
       - name: Upload asciidoctorj-core reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         env:
           os_name: ${{ matrix.os }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ Build Improvement::
 
 * Move to new plugin suite org.ysb33r.jruby for installing ruby gems (#1293)
 * Upgrade build to Gradle 8.12 (#1293)
+* Upgrade gh action upload-artifact to v4 (#1294)
 
 
 == 3.0.0 (2024-08-25)


### PR DESCRIPTION
Thank you for opening a pull request and contributing to AsciidoctorJ!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

The CI build currently fails on Windows because it uses a deprecated version of the gh action upload-artifact.
This PR should fix the windows build again.

How does it achieve that?

Upgrade the version of the upload-artifact action.

Are there any alternative ways to implement this?

Yes, disable the windows build. But it's better to keep it.

Are there any implications of this pull request? Anything a user must know?

No.

## Issue

Fixes #1294.
