### PR TITLE
Fix #1297. Create ServiceLoader for loggers per Asciidoctor instance

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,10 @@ Build Improvement::
 
 == 3.0.0 (2024-08-25)
 
+Bug Fixes::
+
+* Create new log handler for each instance of Asciidoctor (#1297) (@dhendriks)
+
 Build Improvement::
 
 * Upgrade JCommander version and coordinates to v2.0 (#1290)

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/LogHandlerRegistryExecutor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/LogHandlerRegistryExecutor.java
@@ -6,8 +6,6 @@ import org.asciidoctor.log.LogHandler;
 import java.util.ServiceLoader;
 
 public class LogHandlerRegistryExecutor {
-    private ServiceLoader<LogHandler> logHandlerServiceLoader = ServiceLoader
-        .load(LogHandler.class);
 
     private AsciidoctorJRuby asciidoctor;
 
@@ -16,6 +14,9 @@ public class LogHandlerRegistryExecutor {
     }
 
     public void registerAllLogHandlers() {
+        ServiceLoader<LogHandler> logHandlerServiceLoader = ServiceLoader
+                .load(LogHandler.class);
+
         for (LogHandler logHandler: logHandlerServiceLoader) {
             asciidoctor.registerLogHandler(logHandler);
         }

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/LogHandlerRegistryExecutor.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/jruby/log/internal/LogHandlerRegistryExecutor.java
@@ -6,7 +6,7 @@ import org.asciidoctor.log.LogHandler;
 import java.util.ServiceLoader;
 
 public class LogHandlerRegistryExecutor {
-    private static ServiceLoader<LogHandler> logHandlerServiceLoader = ServiceLoader
+    private ServiceLoader<LogHandler> logHandlerServiceLoader = ServiceLoader
         .load(LogHandler.class);
 
     private AsciidoctorJRuby asciidoctor;

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -257,8 +257,11 @@ public class WhenAsciidoctorLogsToConsole {
 
     @Test
     public void shouldCreateNewLogHandlersOnCreateAsciidoctor() {
+        TestLogHandlerService.instancesCount.set(0);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
         asciidoctor.convert("Test", Options.builder().build());
-        asciidoctor.convert("Test", Options.builder().build());
+        Asciidoctor asciidoctor2 = Asciidoctor.Factory.create();
+        asciidoctor2.convert("Test", Options.builder().build());
         assertEquals(2, TestLogHandlerService.instancesCount.get());
     }
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -255,6 +255,13 @@ public class WhenAsciidoctorLogsToConsole {
         }
     }
 
+    @Test
+    public void shouldCreateNewLogHandlersOnCreateAsciidoctor() {
+        asciidoctor.convert("Test", Options.builder().build());
+        asciidoctor.convert("Test", Options.builder().build());
+        assertEquals(2, TestLogHandlerService.instancesCount.get());
+    }
+
     @Name("big")
     public static class LoggingProcessor extends BlockProcessor {
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciidoctorLogsToConsole.java
@@ -255,16 +255,6 @@ public class WhenAsciidoctorLogsToConsole {
         }
     }
 
-    @Test
-    public void shouldCreateNewLogHandlersOnCreateAsciidoctor() {
-        TestLogHandlerService.instancesCount.set(0);
-        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
-        asciidoctor.convert("Test", Options.builder().build());
-        Asciidoctor asciidoctor2 = Asciidoctor.Factory.create();
-        asciidoctor2.convert("Test", Options.builder().build());
-        assertEquals(2, TestLogHandlerService.instancesCount.get());
-    }
-
     @Name("big")
     public static class LoggingProcessor extends BlockProcessor {
 

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenTwoAsciidoctorsLogToConsole.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenTwoAsciidoctorsLogToConsole.java
@@ -1,0 +1,26 @@
+package org.asciidoctor;
+
+import org.asciidoctor.log.TestLogHandlerService;
+import org.asciidoctor.test.extension.AsciidoctorExtension;
+import org.asciidoctor.test.extension.ClasspathExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.junit.Assert.assertEquals;
+
+@ExtendWith({AsciidoctorExtension.class, ClasspathExtension.class})
+public class WhenTwoAsciidoctorsLogToConsole {
+
+    @Execution(ExecutionMode.SAME_THREAD)
+    @Test
+    public void shouldCreateNewLogHandlersOnCreateAsciidoctor() {
+        TestLogHandlerService.instancesCount.set(0);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.convert("Test", Options.builder().build());
+        Asciidoctor asciidoctor2 = Asciidoctor.Factory.create();
+        asciidoctor2.convert("Test", Options.builder().build());
+        assertEquals(2, TestLogHandlerService.instancesCount.get());
+    }
+}

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/log/TestLogHandlerService.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/log/TestLogHandlerService.java
@@ -2,6 +2,7 @@ package org.asciidoctor.log;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestLogHandlerService implements LogHandler {
 
@@ -13,6 +14,12 @@ public class TestLogHandlerService implements LogHandler {
 
     public static void clear() {
         logRecords.clear();
+    }
+
+    public static AtomicInteger instancesCount = new AtomicInteger();
+
+    public TestLogHandlerService() {
+        instancesCount.incrementAndGet();
     }
 
     @Override


### PR DESCRIPTION
## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

Currently, if 2 Asciidoctor instances are created from the same ClassLoader, LogHandler services discovered from the ServiceLoader are reused.
This behavior differs from how extensions are created: For every new instance of Asciidoctor, a new ServiceLoader is created with `ServiceLoader.load()` so that no extension instances from a previous Asciidoctor instance are reused.

This PR updates the behavior so that it aligns with how extensions are created, and creates a new ServiceLoader for every new Asciidoctor instance.

Fixes #1297
