### PR TITLE
Bump JRuby from v9.4.9.0 to v9.4.12.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,7 +18,7 @@ Improvements::
 * Upgrade to asciidoctorj-pdf 2.3.19 (#1300)
 * Upgrade to asciidoctorj-epub 2.2.0 (#1300)
 * Upgrade to asciidoctorj-revealjs 5.2.0 (#1300)
-* Upgrade to jruby 9.4.9.0 (#1300)
+* Upgrade to JRuby 9.4.12.1 (#1301)
 
 Bug Fixes::
 

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext {
   guavaVersion = '18.0'
   hamcrestVersion = '1.3'
   jcommanderVersion = '2.0'
-  jrubyVersion = '9.4.9.0'
+  jrubyVersion = '9.4.12.1'
   jsoupVersion = '1.20.1'
   junit4Version = '4.13.2'
   junit5Version = '5.13.1'


### PR DESCRIPTION

## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Fixes CVE-2025-46551
Closes #1301


How does it achieve that?

Simple bump

Are there any alternative ways to implement this?

n/a

Are there any implications of this pull request? Anything a user must know?

n/a

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #1301 

## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc