### PR TITLE
Bump test dependencies

### DIFF
--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAttributesAreUsedInAsciidoctor.java
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
 import static org.junit.Assert.assertEquals;
 import static org.xmlmatchers.xpath.HasXPath.hasXPath;
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,7 @@ ext {
   statusIsRelease = (status == 'release')
 
   // jar versions
-  arquillianVersion = '1.6.0.Final'
-  arquillianSpockVersion = '1.0.0.CR1'
+  arquillianVersion = '1.9.2.Final'
   asciidoctorjPdfVersion = '2.3.19'
   asciidoctorjEpub3Version = '2.2.0'
   asciidoctorjDiagramVersion = '2.3.2'
@@ -73,20 +72,19 @@ ext {
   asciidoctorjDiagramBatikVersion = '1.17'
   asciidoctorjDiagramPlantumlVersion = '1.2025.2'
   asciidoctorjRevealJsVersion = '5.2.0'
-  commonsioVersion = '2.15.1'
-  guavaVersion = '18.0'
-  hamcrestVersion = '1.3'
+  commonsioVersion = '2.19.0'
+  hamcrestVersion = '2.2'
   jcommanderVersion = '2.0'
   jrubyVersion = '9.4.9.0'
   jsoupVersion = '1.20.1'
   junit4Version = '4.13.2'
   junit5Version = '5.13.1'
-  junitPioneerVersion = '2.2.0'
-  assertjVersion = '3.24.2'
-  nettyVersion = '4.1.58.Final'
-  saxonVersion = '9.9.0-2'
+  junitPioneerVersion = '2.3.0'
+  assertjVersion = '3.27.3'
+  nettyVersion = '4.2.2.Final'
+  saxonVersion = '9.9.1-8'
   xmlMatchersVersion = '1.0-RC1'
-  pdfboxVersion = '3.0.0'
+  pdfboxVersion = '3.0.5'
 
   // gem versions
   asciidoctorGemVersion = project.hasProperty('asciidoctorGemVersion') ? project.asciidoctorGemVersion : '2.0.23'
@@ -95,7 +93,7 @@ ext {
   rougeGemVersion = '3.30.0'
 
   codenarcVersion = '3.2.0'
-  groovyVersion = '3.0.17'
+  groovyVersion = '3.0.25'
   erubisGemVersion = '2.7.0'
   hamlGemVersion = '5.2.2'
   openUriCachedGemVersion = '0.0.5'


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

What is the goal of this pull request?

Bump test dependencies:

- arquillian from 1.6.0.Final to 1.9.2.Final
- commons-io from 2.15.1 to 2.19.0
- hamcrest from 1.3 to 2.2
- junit-pioneer from 2.2.0 to 2.3.0
- Assertj from 3.24.2 to 3.27.3
- Netty from 4.1.58.Final to 4.2.2.Final
- saxon-HE 9.9.0-2 from 9.9.1-8
- PDF-box from 3.0.0 to 3.0.5
- Groovy from 3.0.17 to 3.0.25

Also, remove a couple of unused configs.
 
How does it achieve that?

Are there any alternative ways to implement this?

n/a

Are there any implications of this pull request? Anything a user must know?

no


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc