### PR TITLE
Upgrade to JRuby 9.4.14.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,7 +18,7 @@ Improvements::
 * Upgrade to asciidoctorj-pdf 2.3.19 (#1300)
 * Upgrade to asciidoctorj-epub 2.2.0 (#1300)
 * Upgrade to asciidoctorj-revealjs 5.2.0 (#1300)
-* Upgrade to JRuby 9.4.12.1 (#1301)
+* Upgrade to JRuby 9.4.14.0 (#1313)
 
 Bug Fixes::
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ ext {
   commonsioVersion = '2.19.0'
   hamcrestVersion = '2.2'
   jcommanderVersion = '2.0'
-  jrubyVersion = '9.4.12.1'
+  jrubyVersion = '9.4.14.0'
   jsoupVersion = '1.20.1'
   junit4Version = '4.13.2'
   junit5Version = '5.13.1'
@@ -188,8 +188,8 @@ subprojects {
     useJUnitPlatform()
 
     forkEvery = 10
-    minHeapSize = '128m'
-    maxHeapSize = '1024m'
+    minHeapSize = '256m'
+    maxHeapSize = '2048m'
 
     testLogging {
       // events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'


### PR DESCRIPTION
## Kind of change

- [ ] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [x] Build improvement

## Description

This PR upgrades JRuby to the latest version of the 9.x release train.

10.x is not possible yet, because of a regression in the Ruby method Pathname::glob which will only be fixed with the next version of JRuby 10.x, and some other incompatibilities that make the tests fail.
